### PR TITLE
Fix Cloudflare-to-Heroku HTTPS redirect loop

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,7 +47,10 @@ This runs Ruff lint + format check, **ty static type analysis**, and pytest with
 - `Procfile` runs `python manage.py migrate --noinput` as the release step.
 - `/health/` endpoint verifies DB connectivity.
 - Rollback: `heroku releases --app palewire` then `heroku rollback vN --app palewire`.
-- Stack: heroku-24 (Cedar). Buildpacks: `heroku/python` + `heroku-buildpack-django-sass`.
+- Stack: heroku-24 (Cedar). Buildpack: `heroku/python`.
+- Production sets `SECURE_SSL_REDIRECT=false` because Cloudflare terminates TLS
+  before connecting to the Heroku origin; Cloudflare remains responsible for
+  redirecting public HTTP traffic to HTTPS.
 
 ## Review Apps
 

--- a/app.json
+++ b/app.json
@@ -25,9 +25,6 @@
   "buildpacks": [
     {
       "url": "heroku/python"
-    },
-    {
-      "url": "https://github.com/drpancake/heroku-buildpack-django-sass.git"
     }
   ],
   "formation": {

--- a/project/settings.py
+++ b/project/settings.py
@@ -200,7 +200,9 @@ TWITTER_REMOVE_LINKS = False
 #
 
 if PRODUCTION:
-    SECURE_SSL_REDIRECT = True
+    # Cloudflare may connect to the Heroku origin over HTTP after terminating
+    # TLS. Allow that deployment to disable Django's redirect and avoid a loop.
+    SECURE_SSL_REDIRECT = os.environ.get("SECURE_SSL_REDIRECT", "true").lower() == "true"
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
     SECURE_HSTS_SECONDS = 31536000


### PR DESCRIPTION
## Summary

- make Django's `SECURE_SSL_REDIRECT` configurable for proxy deployments
- document why production disables Django's redirect when Cloudflare terminates TLS
- remove the obsolete Django Sass buildpack from `app.json`; the Python buildpack already compiles static assets successfully

## Production safety

Production was rolled back to the previous healthy release after the redirect loop was detected. The database was not changed: the release phase reported no migrations to apply.

The non-secret Heroku setting `SECURE_SSL_REDIRECT=false` is already configured and will take effect when this fix deploys.