### PR TITLE
Harden repository setup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,7 +32,7 @@ This runs Ruff lint + format check, **ty static type analysis**, and pytest with
 ## Key conventions
 
 - **Packaging**: `uv` + `pyproject.toml` + `uv.lock`. Never use `pip install` directly.
-- **Bootstrap**: use `make bootstrap` in local worktrees, CI, and agent environments.
+- **Bootstrap**: use `make bootstrap` in local worktrees and agent environments; CI uses `make ci-bootstrap`.
 - **Linting**: Ruff with `select = ["E", "F", "W", "I", "UP"]` (UP031 ignored).
 - **Type checking**: `ty check .` — Django dynamic attributes are downgraded to warnings; new code should pass clean.
 - **Tests**: pytest-django in `tests/`. Requires PostgreSQL.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,13 +17,14 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       UV_NO_ENV_FILE: "1"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: "3.12"
 
@@ -39,6 +40,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     services:
       postgres:
         image: postgres:16
@@ -61,15 +63,15 @@ jobs:
       UV_NO_ENV_FILE: "1"
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: make bootstrap
+        run: make ci-bootstrap
 
       - name: Check migration drift
         run: make migrations-check

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -36,10 +36,10 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -32,20 +32,22 @@ jobs:
       - name: Health check (with retries)
         run: |
           echo "Testing health endpoint: $BASE_URL/health/"
+          health_ok=false
           for i in 1 2 3; do
             response=$(curl --silent --max-time 20 --write-out "\n%{http_code}" "$BASE_URL/health/" || true)
-            http_code=$(echo "$response" | tail -1)
-            body=$(echo "$response" | head -1)
+            http_code=$(printf '%s\n' "$response" | tail -1)
+            body=$(printf '%s\n' "$response" | sed '$d')
             echo "Attempt $i — HTTP $http_code — $body"
             if [ "$http_code" = "200" ]; then
-              if echo "$body" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['status']=='ok'; assert d['db'] is True" 2>/dev/null; then
+              if printf '%s' "$body" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['status']=='ok'; assert d['db'] is True" 2>/dev/null; then
                 echo "✅ Health check passed"
+                health_ok=true
                 break
               fi
             fi
             if [ "$i" -lt 3 ]; then sleep 30; fi
           done
-          if [ "$http_code" != "200" ]; then
+          if [ "$health_ok" != "true" ]; then
             echo "❌ Health check failed after retries (last HTTP $http_code)"
             exit 1
           fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-toml
       - id: check-yaml
       - id: check-added-large-files
-        args: [--maxkb=99000]
+        args: [--maxkb=5000]
       - id: check-json
       - id: forbid-submodules
       - id: end-of-file-fixer

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,14 @@
 
 export UV_NO_ENV_FILE = 1
 
-.PHONY: help bootstrap install serve check test lint typecheck django-check migrations-check fmt migrate
+.PHONY: help bootstrap ci-bootstrap install hooks database serve check test lint typecheck django-check migrations-check fmt migrate
 
 help:
 	@echo "Available targets:"
 	@echo "  bootstrap  Prepare dependencies, database, migrations, and hooks"
-	@echo "  install    Install all dependencies (requires uv)"
+	@echo "  ci-bootstrap  Prepare dependencies, database, and migrations for CI"
+	@echo "  install    Install all dependencies without changing Git hooks"
+	@echo "  hooks      Install pre-commit hooks"
 	@echo "  serve      Start the development server"
 	@echo "  check      Run the same lint, type, Django, migration, and test checks as CI"
 	@echo "  test       Run tests only"
@@ -18,11 +20,17 @@ help:
 
 install:
 	uv sync --locked --group dev
+
+hooks:
 	uv run pre-commit install
 
-bootstrap: install
+database:
 	uv run python -m scripts.worktree create-database
 	uv run python manage.py migrate
+
+bootstrap: install hooks database
+
+ci-bootstrap: install database
 
 serve:
 	uv run python -m scripts.worktree serve


### PR DESCRIPTION
## Summary

- make production smoke tests fail when the health payload is invalid
- add CI job timeouts and a hook-free CI bootstrap target
- pin GitHub Actions to verified commit SHAs
- lower the pre-commit large-file limit from 99 MB to 5 MB
- keep local bootstrap behavior and documentation aligned

## Checks

- `make check`
- `pre-commit run check-yaml --all-files`
- `pre-commit run check-toml --all-files`
- `pre-commit run check-added-large-files --all-files`
- focused valid/invalid health-payload shell checks