### PR TITLE
Improve the 404 page

### DIFF
--- a/coltrane/static/_errors.scss
+++ b/coltrane/static/_errors.scss
@@ -1,0 +1,69 @@
+.error-page {
+  padding-top: clamp(1.5rem, 8vw, 4.5rem);
+  padding-bottom: clamp(2rem, 10vw, 6rem);
+
+  h1 {
+    max-width: 12ch;
+    font-size: clamp(2.5rem, 9vw, 5.5rem);
+    line-height: 0.95;
+    letter-spacing: -0.04em;
+    text-wrap: balance;
+  }
+}
+
+.error-page__message {
+  max-width: 33rem;
+  margin-top: 1.25rem;
+  font-size: 1.15em;
+}
+
+.error-page__home {
+  margin-top: 2rem;
+
+  a {
+    color: $black;
+    font-weight: 800;
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 0.2em;
+  }
+
+  a:hover {
+    color: $dark-gray;
+  }
+
+  a:focus-visible {
+    outline: 3px solid $black;
+    outline-offset: 4px;
+  }
+}
+
+.error-page__nav {
+  margin-top: 3.5rem;
+  padding-top: 1rem;
+  border-top: solid 2px #e5e5e5;
+
+  p {
+    margin: 0;
+    font-size: 0.8em;
+    font-weight: 700;
+  }
+
+  ul {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem 1.25rem;
+    margin-top: 0.5rem;
+    list-style: none;
+  }
+
+  a {
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+  }
+
+  a:focus-visible {
+    outline: 3px solid $black;
+    outline-offset: 3px;
+  }
+}

--- a/coltrane/static/styles.scss
+++ b/coltrane/static/styles.scss
@@ -13,3 +13,4 @@
 @import "comments";
 @import "footer";
 @import "pygments";
+@import "errors";

--- a/coltrane/templates/404.html
+++ b/coltrane/templates/404.html
@@ -1,11 +1,26 @@
 {% extends "coltrane/base.html" %}
 
-{% block title %}404 Error (Page Not Found) . {{ block.super }}{% endblock %}
+{% block title %}Page not found · {{ block.super }}{% endblock %}
+{% block robots %}noindex{% endblock %}
 
 {% block content %}
-
-    <div class="twelvecol last">
-        <h1 style="text-align:center;">Sorry, the page you're looking for could not be found.</h1>
-    </div>
-
+<section class="twelvecol last error-page" aria-labelledby="error-heading">
+    <h1 id="error-heading">Page not found.</h1>
+    <p class="error-page__message">
+        The page may have moved, or the address might be wrong.
+    </p>
+    <p class="error-page__home">
+        <a href="/">Go to the homepage <span aria-hidden="true">→</span></a>
+    </p>
+    <nav class="error-page__nav" aria-label="More places to visit">
+        <p>Or keep looking:</p>
+        <ul>
+            <li><a href="{% url 'coltrane_post_list' %}">Posts</a></li>
+            <li><a href="{% url 'coltrane_work_list' %}">Work</a></li>
+            <li><a href="{% url 'coltrane_talk_list' %}">Talks</a></li>
+            <li><a href="{% url 'coltrane_doc_list' %}">Docs</a></li>
+            <li><a href="{% url 'coltrane_bio' %}">About</a></li>
+        </ul>
+    </nav>
+</section>
 {% endblock %}

--- a/coltrane/templates/coltrane/base.html
+++ b/coltrane/templates/coltrane/base.html
@@ -9,7 +9,7 @@
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="referrer" content="strict-origin-when-cross-origin" />
-        <meta name="robots" content="index,follow" />
+        <meta name="robots" content="{% block robots %}index,follow{% endblock %}" />
         <meta name="theme-color" content="#ffffff" />
         <meta name="color-scheme" content="light" />
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 from django.db import DatabaseError
 from django.test import Client
+from django.test.utils import override_settings
 
 
 @pytest.fixture
@@ -53,6 +54,19 @@ def test_docs_list_ok(client):
 def test_bots_list_ok(client):
     response = client.get("/bots/")
     assert response.status_code == 200
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=False)
+def test_not_found_page_offers_navigation(client):
+    response = client.get("/this-page-does-not-exist/")
+
+    assert response.status_code == 404
+    content = response.content.decode()
+    assert "<title>Page not found · palewire</title>" in content
+    assert '<meta name="robots" content="noindex" />' in content
+    assert 'href="/">Go to the homepage' in content
+    assert 'href="/posts/">Posts</a>' in content
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

- replace the bare 404 message with a clear, responsive recovery page
- link visitors back home and to the site’s main sections
- keep 404 responses out of search indexes
- add coverage for the production 404 response

Closes #221

## Testing

- [ ] `make check` passes locally
- `ruff check .` and `ruff format --check .`
- `ty check --exit-zero-on-warning .`
- `pytest tests/`
- Django system and migration checks
- Sass compilation

`make check` could not run directly because `uv` is unavailable on this machine; each component passed through the existing virtual environment.

## Deployment notes

No migrations, configuration changes, or manual steps.