### PR TITLE
Simplify the 500 error page

### DIFF
--- a/coltrane/templates/500.html
+++ b/coltrane/templates/500.html
@@ -1,11 +1,13 @@
 {% extends "coltrane/base.html" %}
 
-{% block title %}500 Error (Server Error) . {{ block.super }}{% endblock %}
+{% block title %}Server error · {{ block.super }}{% endblock %}
+{% block robots %}noindex{% endblock %}
 
 {% block content %}
-
-    <div class="twelvecol last">
-        <h1 style="text-align:center;">Sorry, something is wrong. Please try back later.</h1>
-    </div>
-
+<section class="twelvecol last error-page" aria-labelledby="error-heading">
+    <h1 id="error-heading">500</h1>
+    <p class="error-page__message">
+        Something went wrong. Please try again later.
+    </p>
+</section>
 {% endblock %}

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -7,6 +7,8 @@ from django.db import DatabaseError
 from django.test import Client
 from django.test.utils import override_settings
 
+from coltrane.views import server_error
+
 
 @pytest.fixture
 def client():
@@ -71,6 +73,18 @@ def test_not_found_page_offers_navigation(client):
     assert '<meta name="robots" content="noindex" />' in content
     assert 'href="/">Go to the homepage' in content
     assert 'href="/posts/">Posts</a>' in content
+
+
+@override_settings(DEBUG=False)
+def test_server_error_page_uses_simplified_message(rf):
+    response = server_error(rf.get("/"))
+
+    assert response.status_code == 500
+    content = response.content.decode()
+    assert "<title>Server error · palewire</title>" in content
+    assert '<meta name="robots" content="noindex" />' in content
+    assert '<h1 id="error-heading">500</h1>' in content
+    assert "Something went wrong. Please try again later." in content
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- restyle the 500 page with the shared error-page layout
- show a concise message without extra navigation
- mark the error response as `noindex`
- test the custom 500 handler with production error settings

This mirrors the simplified error-page design proposed in #348 without modifying that pull request.

## Checks
- `make check`