### PR TITLE
Disable commit signing in agent worktrees

### DIFF
--- a/.github/github-app.yml
+++ b/.github/github-app.yml
@@ -4,6 +4,10 @@ instructions: |
   Never edit files in another worktree or the project's main checkout.
 
 scripts:
+  - name: Disable commit signing
+    command: git config --local commit.gpgsign false
+    triggers:
+      - session.create
   - name: Setup
     command: make bootstrap
     triggers:


### PR DESCRIPTION
## Summary

- disable inherited commit signing locally when Copilot creates a worktree
- preserve the user's global signing configuration and normal checkouts
- prevent agent commits from failing when `smimesign` or a signing identity is unavailable

## Testing

- [x] Agent configuration YAML validates
- [x] Pre-commit hooks pass

## Changelog

- [ ] `feature`
- [ ] `improvement`
- [ ] `fix`
- [x] `maintenance`
- [ ] `skip-changelog`

## Deployment notes

No application deployment changes. The setup step takes effect for newly created Copilot sessions after this PR merges.