### PR TITLE
Fix legacy tagging migration cleanup

### DIFF
--- a/coltrane/migrations/0008_delete_beer_delete_book_delete_commit_delete_link_and_more.py
+++ b/coltrane/migrations/0008_delete_beer_delete_book_delete_commit_delete_link_and_more.py
@@ -27,6 +27,13 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunSQL(
+            sql=[
+                'DROP TABLE IF EXISTS "tagging_taggeditem";',
+                'DROP TABLE IF EXISTS "tagging_tag";',
+            ],
+            reverse_sql=migrations.RunSQL.noop,
+        ),
         migrations.DeleteModel(
             name="Beer",
         ),

--- a/coltrane/migrations/0009_remove_legacy_comments_categories_sites.py
+++ b/coltrane/migrations/0009_remove_legacy_comments_categories_sites.py
@@ -8,40 +8,20 @@ LEGACY_CONTENT_TYPES = [
 
 
 def delete_legacy_content_types_and_permissions(apps, schema_editor):
-    try:
-        ContentType = apps.get_model("contenttypes", "ContentType")
-    except Exception:
-        return
-
-    permission_model = None
-    try:
-        permission_model = apps.get_model("auth", "Permission")
-    except Exception:
-        pass
-
+    ContentType = apps.get_model("contenttypes", "ContentType")
+    Permission = apps.get_model("auth", "Permission")
     content_type_ids = set()
     for app_label, model_name in LEGACY_CONTENT_TYPES:
-        try:
-            queryset = ContentType.objects.filter(app_label=app_label)
-            if model_name is not None:
-                queryset = queryset.filter(model=model_name)
-            content_type_ids.update(queryset.values_list("id", flat=True))
-        except Exception:
-            continue
+        queryset = ContentType.objects.filter(app_label=app_label)
+        if model_name is not None:
+            queryset = queryset.filter(model=model_name)
+        content_type_ids.update(queryset.values_list("id", flat=True))
 
     if not content_type_ids:
         return
 
-    if permission_model is not None:
-        try:
-            permission_model.objects.filter(content_type_id__in=content_type_ids).delete()
-        except Exception:
-            pass
-
-    try:
-        ContentType.objects.filter(id__in=content_type_ids).delete()
-    except Exception:
-        pass
+    Permission.objects.filter(content_type_id__in=content_type_ids).delete()
+    ContentType.objects.filter(id__in=content_type_ids).delete()
 
 
 class Migration(migrations.Migration):
@@ -50,6 +30,13 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunSQL(
+            sql=[
+                'DROP TABLE IF EXISTS "tagging_taggeditem";',
+                'DROP TABLE IF EXISTS "tagging_tag";',
+            ],
+            reverse_sql=migrations.RunSQL.noop,
+        ),
         migrations.RemoveField(
             model_name="post",
             name="enable_comments",

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,136 @@
+"""Regression tests for production-shaped migration paths."""
+
+import pytest
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+
+MIGRATION_0007 = ("coltrane", "0007_remove_slogan_state")
+MIGRATION_0008 = ("coltrane", "0008_delete_beer_delete_book_delete_commit_delete_link_and_more")
+MIGRATION_0009 = ("coltrane", "0009_remove_legacy_comments_categories_sites")
+
+REMOVED_CONTENT_TYPES = {
+    ("coltrane", "category"),
+    ("coltrane", "track"),
+    ("django_comments", "comment"),
+    ("django_comments", "commentflag"),
+    ("sites", "site"),
+}
+PRESERVED_CONTENT_TYPES = {
+    ("coltrane", "post"),
+    ("other", "site"),
+}
+
+
+def _migrate_to(target):
+    executor = MigrationExecutor(connection)
+    targets = [
+        target,
+        *executor.loader.graph.leaf_nodes("auth"),
+        *executor.loader.graph.leaf_nodes("contenttypes"),
+    ]
+    executor.migrate(targets)
+    return executor.loader.project_state(targets).apps
+
+
+def _seed_content_types(apps, *, include_track=True):
+    ContentType = apps.get_model("contenttypes", "ContentType")
+    Permission = apps.get_model("auth", "Permission")
+
+    content_types = {}
+    content_type_keys = REMOVED_CONTENT_TYPES | PRESERVED_CONTENT_TYPES
+    if not include_track:
+        content_type_keys = content_type_keys - {("coltrane", "track")}
+
+    for app_label, model in content_type_keys:
+        content_type, _ = ContentType.objects.get_or_create(app_label=app_label, model=model)
+        Permission.objects.get_or_create(
+            content_type_id=content_type.id,
+            codename=f"view_{app_label}_{model}",
+            defaults={"name": f"Can view {app_label}.{model}"},
+        )
+        content_types[(app_label, model)] = content_type
+    return content_types
+
+
+def _create_legacy_tagging_tables(content_types):
+    tagged_content_type = content_types.get(("coltrane", "track"), content_types[("coltrane", "post")])
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            CREATE TABLE tagging_tag (
+                id integer PRIMARY KEY,
+                name varchar(50) NOT NULL UNIQUE
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE tagging_taggeditem (
+                id integer PRIMARY KEY,
+                tag_id integer NOT NULL REFERENCES tagging_tag(id),
+                content_type_id integer NOT NULL REFERENCES django_content_type(id),
+                object_id integer NOT NULL
+            )
+            """
+        )
+        cursor.execute("INSERT INTO tagging_tag (id, name) VALUES (1, 'legacy')")
+        cursor.execute(
+            """
+            INSERT INTO tagging_taggeditem (id, tag_id, content_type_id, object_id)
+            VALUES (1, 1, %s, 101), (2, 1, %s, 102)
+            """,
+            [
+                tagged_content_type.id,
+                content_types[("coltrane", "post")].id,
+            ],
+        )
+
+
+def _assert_cleanup(apps):
+    ContentType = apps.get_model("contenttypes", "ContentType")
+    Permission = apps.get_model("auth", "Permission")
+    existing_content_types = set(ContentType.objects.values_list("app_label", "model"))
+
+    assert REMOVED_CONTENT_TYPES.isdisjoint(existing_content_types)
+    assert PRESERVED_CONTENT_TYPES <= existing_content_types
+
+    removed_permissions = Permission.objects.filter(
+        codename__in={f"view_{app_label}_{model}" for app_label, model in REMOVED_CONTENT_TYPES}
+    )
+    preserved_permissions = Permission.objects.filter(
+        codename__in={f"view_{app_label}_{model}" for app_label, model in PRESERVED_CONTENT_TYPES}
+    )
+    assert not removed_permissions.exists()
+    assert preserved_permissions.count() == len(PRESERVED_CONTENT_TYPES)
+
+    tables = set(connection.introspection.table_names())
+    assert "tagging_taggeditem" not in tables
+    assert "tagging_tag" not in tables
+
+
+@pytest.mark.django_db(transaction=True)
+def test_migrations_remove_production_legacy_tagging_tables():
+    apps = _migrate_to(MIGRATION_0007)
+    try:
+        content_types = _seed_content_types(apps)
+        _create_legacy_tagging_tables(content_types)
+
+        apps = _migrate_to(MIGRATION_0009)
+
+        _assert_cleanup(apps)
+    finally:
+        _migrate_to(MIGRATION_0009)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_migration_0009_cleans_tagging_tables_left_after_0008():
+    apps = _migrate_to(MIGRATION_0008)
+    try:
+        content_types = _seed_content_types(apps, include_track=False)
+        _create_legacy_tagging_tables(content_types)
+
+        apps = _migrate_to(MIGRATION_0009)
+
+        _assert_cleanup(apps)
+    finally:
+        _migrate_to(MIGRATION_0009)


### PR DESCRIPTION
## Summary

- drop the retired `tagging_taggeditem` and `tagging_tag` tables, in dependency order, before legacy content-type deletion in migrations `0008` and `0009`
- make `0009` clean permissions and content types with explicit historical models and visible database errors
- add PostgreSQL migration regressions for both `0007 → 0009` and databases already at `0008`

## Production incident

Heroku releases `v291` (`0f315592`) and `v292` (`1adb353d`, current `main`) failed safely while applying `coltrane.0008`: `tagging_taggeditem` still referenced legacy content type ID 18. PostgreSQL rolled each migration transaction back fully, and production remains on successful release `v290` at `b17f2cee`.

The hotfix supports both relevant upgrade paths: production still at `0007` can run the corrected `0008`, while any database where `0008` was previously recorded can remove the same dead tables in `0009`.

## Data archive

Before this change, every column and row from both production tagging tables was exported read-only, checked against independent SQL counts, checksummed, zipped, uploaded to the private archive repository, downloaded again, and verified:

https://github.com/palewire/palewi.re-archive/releases/tag/tagging-data-archive-20260824T005357Z

- `tagging_tag`: 21,047 rows
- `tagging_taggeditem`: 665,391 rows
- archive SHA-256: `d96fe29b6ef547c7c65c4ac44e85eed5ac068dce13f72c5bac9cf9107dbdcf8b`

## Deployment requirement

**Capture a fresh Heroku Postgres backup immediately before deploying the merged commit.** Deploy the new current `main`; do not retry either old failed release.

## Checks

- full `make check`
- generated SQL inspection for migrations `0008` and `0009`
- independent code review: no findings