### PR TITLE
Prevent overlong Django test database names

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import dj_database_url
 
-from project.worktree import default_database_url
+from project.worktree import default_database_url, django_test_database_name
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SETTINGS_DIR = os.path.join(BASE_DIR, "project")
@@ -69,6 +69,7 @@ DATABASES = {
         ssl_require=PRODUCTION,
     )
 }
+DATABASES["default"]["TEST"] = {"NAME": django_test_database_name(DATABASES["default"]["NAME"])}
 
 # Honor the 'X-Forwarded-Proto' header for request.is_secure()
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")

--- a/project/worktree.py
+++ b/project/worktree.py
@@ -8,6 +8,7 @@ DEFAULT_DATABASE_NAME = "palewire"
 DEFAULT_PORT = 8000
 PORT_RANGE = 1000
 POSTGRES_IDENTIFIER_LIMIT = 63
+TEST_DATABASE_PREFIX = "test_"
 
 
 def is_linked_worktree(root: Path) -> bool:
@@ -23,6 +24,25 @@ def database_name(root: Path) -> str:
     suffix = f"_{digest}"
     available = POSTGRES_IDENTIFIER_LIMIT - len(DEFAULT_DATABASE_NAME) - len(suffix) - 1
     return f"{DEFAULT_DATABASE_NAME}_{slug[:available]}{suffix}"
+
+
+def django_test_database_name(base_name: str | None) -> str:
+    """Return a safe PostgreSQL name for Django's test database.
+
+    The name is ``test_<base name>`` when it fits PostgreSQL's 63-character
+    limit. Longer names are shortened and end with a deterministic hash so
+    similarly named worktrees remain isolated.
+    """
+    raw_name = base_name or ""
+    safe_base_name = re.sub(r"[^a-z0-9]+", "_", raw_name.lower()).strip("_") or "database"
+    candidate = f"{TEST_DATABASE_PREFIX}{safe_base_name}"
+    if len(candidate) <= POSTGRES_IDENTIFIER_LIMIT:
+        return candidate
+
+    digest = hashlib.sha256(raw_name.encode()).hexdigest()[:8]
+    suffix = f"_{digest}"
+    available = POSTGRES_IDENTIFIER_LIMIT - len(TEST_DATABASE_PREFIX) - len(suffix)
+    return f"{TEST_DATABASE_PREFIX}{safe_base_name[:available]}{suffix}"
 
 
 def default_database_url(root: Path) -> str:

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -1,9 +1,21 @@
+import os
+import re
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 from project import worktree
-from project.worktree import DEFAULT_DATABASE_NAME, available_port, candidate_ports, database_name, default_database_url
+from project.worktree import (
+    DEFAULT_DATABASE_NAME,
+    POSTGRES_IDENTIFIER_LIMIT,
+    available_port,
+    candidate_ports,
+    database_name,
+    default_database_url,
+    django_test_database_name,
+)
 
 
 def test_main_checkout_uses_default_database(tmp_path: Path) -> None:
@@ -33,6 +45,86 @@ def test_long_worktree_names_produce_valid_database_names(tmp_path: Path) -> Non
 
     assert len(name) <= 63
     assert name.replace("_", "").isalnum()
+
+
+@pytest.mark.parametrize(
+    ("base_name", "expected"),
+    [
+        ("palewire", "test_palewire"),
+        ("a" * 58, f"test_{'a' * 58}"),
+        ("", "test_database"),
+        ("Odd database name! 🐘", "test_odd_database_name"),
+    ],
+)
+def test_test_database_name_handles_names_that_fit(base_name: str, expected: str) -> None:
+    name = django_test_database_name(base_name)
+
+    assert name == expected
+    assert len(name) <= POSTGRES_IDENTIFIER_LIMIT
+    assert re.fullmatch(r"[a-z0-9_]+", name)
+
+
+def test_test_database_name_hashes_name_one_character_over_limit() -> None:
+    name = django_test_database_name("a" * 59)
+
+    assert len(name) == POSTGRES_IDENTIFIER_LIMIT
+    assert name.startswith(f"test_{'a' * 49}_")
+    assert re.fullmatch(r"[a-z0-9_]+", name)
+
+
+def test_long_test_database_names_with_shared_prefix_remain_distinct() -> None:
+    prefix = "palewire_" + "same_prefix_" * 10
+    first = django_test_database_name(f"{prefix}first")
+    second = django_test_database_name(f"{prefix}second")
+
+    assert first != second
+    assert len(first) == len(second) == POSTGRES_IDENTIFIER_LIMIT
+    assert re.fullmatch(r"[a-z0-9_]+", first)
+    assert re.fullmatch(r"[a-z0-9_]+", second)
+
+
+def test_test_database_name_is_deterministic() -> None:
+    base_name = "palewire_" + "long_worktree_" * 10
+
+    assert django_test_database_name(base_name) == django_test_database_name(base_name)
+
+
+def test_long_linked_worktree_has_safe_test_database_name(tmp_path: Path) -> None:
+    root = tmp_path / "palewire-retire-legacy-scraper-models-and-database-tables"
+    root.mkdir()
+    (root / ".git").write_text("gitdir: /tmp/example\n")
+
+    development_name = database_name(root)
+    test_name = django_test_database_name(development_name)
+
+    assert len(development_name) == POSTGRES_IDENTIFIER_LIMIT
+    assert len(test_name) == POSTGRES_IDENTIFIER_LIMIT
+    assert re.fullmatch(r"[a-z0-9_]+", test_name)
+
+
+def test_database_url_override_configures_safe_django_test_name() -> None:
+    base_name = "palewire_" + "issue_357_worktree_" * 5
+    env = os.environ.copy()
+    env["DATABASE_URL"] = f"postgres://postgres@localhost/{base_name}"
+    command = (
+        "from project.settings import DATABASES; "
+        "print(DATABASES['default']['NAME']); "
+        "print(DATABASES['default']['TEST']['NAME'])"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", command],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+    configured_name, configured_test_name = result.stdout.splitlines()
+
+    assert configured_name == base_name
+    assert configured_test_name == django_test_database_name(base_name)
+    assert len(configured_test_name) <= POSTGRES_IDENTIFIER_LIMIT
+    assert re.fullmatch(r"[a-z0-9_]+", configured_test_name)
 
 
 def test_available_port_skips_occupied_and_excluded_ports(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- derive Django test database names from the configured database name
- cap long names at PostgreSQL's 63-character limit with a deterministic hash suffix
- cover boundary cases, DATABASE_URL overrides, and the long linked-worktree failure mode

## Testing

- [x] `make check` passes locally
- [x] transaction-based migration test passes with a 63-character configured database name

## Changelog

- [ ] `feature`
- [ ] `improvement`
- [ ] `fix`
- [x] `maintenance`
- [ ] `skip-changelog`

## Deployment notes

None. Development tooling only; no migration, backup, configuration change, or deployment step is required.