### PR TITLE
Layer 1/3: Archive and validate Markdown posts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 # See https://pre-commit.com for more information
+exclude: ^coltrane/content/posts/
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ Tests require a running PostgreSQL database. Set `DATABASE_URL` or rely on the
 default: `postgres://postgres@localhost/palewire` in a normal clone, or an
 automatically named isolated database in a linked worktree.
 
+## Blog post Markdown
+
+Public posts in `coltrane/content/posts/` are one `.md` file each. Their YAML
+front matter requires `title`, `slug`, and `published_at`; the datetime must
+use the Los Angeles offset. `repr_image` and `wordpress_id` are optional.
+Keep the body as raw HTML, including any `<pre lang="...">` code blocks. Do
+not add drafts or a status field. The filename format is
+`YYYY-MM-DD--slug.md`, and `posts-manifest.json` is the checked-in public
+fingerprint generated during the production export.
+
 ## Deployment
 
 The app deploys to Heroku automatically when a pull request merges to `main` **after CI passes**.

--- a/coltrane/content/posts-manifest.json
+++ b/coltrane/content/posts-manifest.json
@@ -1,0 +1,518 @@
+{
+  "legacy_pre_lang_post_count": 25,
+  "post_count": 72,
+  "posts": [
+    {
+      "body_sha256": "7061b29a316090dd15bd99c72c176be91dc3436f634419295c0ff5e65c8e0ce0",
+      "path": "posts/2007-02-08--how-much-does-george-bush-read.md",
+      "permalink": "/posts/2007/02/08/how-much-does-george-bush-read/",
+      "published_at": "2007-02-08T16:54:10-08:00",
+      "sha256": "0becddbd19d8ee5a066ef8d0ac9508cb7a2226f6e29696f4160fb22cee2e9a7d"
+    },
+    {
+      "body_sha256": "b4d24d249b4a664bfcff8efc71018ed9d069e8d989397ef3fb4825201a5ae3c3",
+      "path": "posts/2007-02-14--sql-recipe-the-number-of-federal-government-working-days-between-two-dates.md",
+      "permalink": "/posts/2007/02/14/sql-recipe-the-number-of-federal-government-working-days-between-two-dates/",
+      "published_at": "2007-02-14T07:52:24-08:00",
+      "sha256": "ef64fce6ca61d73780e3ecff0ec81f7031e7704464422006df78c9f0c9010f1a"
+    },
+    {
+      "body_sha256": "e78f2c6012c77f847d619a66a37d55d7ad7780f27fb6496c7a1d013283558161",
+      "path": "posts/2008-03-24--go-snoop-yourself.md",
+      "permalink": "/posts/2008/03/24/go-snoop-yourself/",
+      "published_at": "2008-03-24T06:46:31-07:00",
+      "sha256": "c228ea20f419b7423e35acd91f1e89c7c80d0dd08855ad67794e6531d9bdf5d1"
+    },
+    {
+      "body_sha256": "412c50671a731e3d1092954275e553b78b38eb4ba45a04e3f68636ba1117b8df",
+      "path": "posts/2008-04-05--python-recipe-open-a-file-read-through-it-print-each-line-matching-a-search-term.md",
+      "permalink": "/posts/2008/04/05/python-recipe-open-a-file-read-through-it-print-each-line-matching-a-search-term/",
+      "published_at": "2008-04-05T08:49:58-07:00",
+      "sha256": "82200c19beda37afdb25dad608b0d92b0ba470a443bb1b4831b75e5c322f764b"
+    },
+    {
+      "body_sha256": "d6d66f3d1992c1419bbdc47cc5256a2eb640bdfdf6a35d04b7d75d3b55bc6c4a",
+      "path": "posts/2008-04-07--python-recipe-open-multiple-files-search-for-matches-count-your-hits-on-the-fly.md",
+      "permalink": "/posts/2008/04/07/python-recipe-open-multiple-files-search-for-matches-count-your-hits-on-the-fly/",
+      "published_at": "2008-04-07T01:06:45-07:00",
+      "sha256": "d9874713dddbc871b98426354c2a372198a8427d4b4ffdd65939c4c2396b12f9"
+    },
+    {
+      "body_sha256": "d36a0826f4f277d9db58eceaed4600843a8face8cafc6f3c21db243165e01c51",
+      "path": "posts/2008-04-14--python-recipe-read-a-file-search-for-a-pattern-print-your-matches.md",
+      "permalink": "/posts/2008/04/14/python-recipe-read-a-file-search-for-a-pattern-print-your-matches/",
+      "published_at": "2008-04-14T22:52:41-07:00",
+      "sha256": "beddf380b9a2c42bd7b51732eca3b676920aa2f2be31225c38a4040cc980b6cc"
+    },
+    {
+      "body_sha256": "ce9d2239b40d8d5f0c8b88d971a83821939760124de265e00ebdb28740984464",
+      "path": "posts/2008-04-20--python-recipe-grab-a-page-scrape-a-table-download-a-file.md",
+      "permalink": "/posts/2008/04/20/python-recipe-grab-a-page-scrape-a-table-download-a-file/",
+      "published_at": "2008-04-20T13:43:13-07:00",
+      "sha256": "04aec49c7377d4e1aee421efb9963869595f54f386ae10ff09d9a29fe25b9a33"
+    },
+    {
+      "body_sha256": "208d4f338bda7b4842b6a2949051161e3c29589738763b01f4cbeddda414872a",
+      "path": "posts/2008-04-21--python-recipe-print-a-future-date-in-the-format-you-want.md",
+      "permalink": "/posts/2008/04/21/python-recipe-print-a-future-date-in-the-format-you-want/",
+      "published_at": "2008-04-21T10:31:59-07:00",
+      "sha256": "12a5fb9c47228d6d3d031601cf2a83531bb90499c9134435325a2fa73b25d1e4"
+    },
+    {
+      "body_sha256": "67c3ecac1a15c713273b226d390694edd4ee5aec2ab027c97c9ec473d0cdc9ab",
+      "path": "posts/2008-04-26--python-recipe-connect-to-mysql-database-execute-a-query-print-the-results.md",
+      "permalink": "/posts/2008/04/26/python-recipe-connect-to-mysql-database-execute-a-query-print-the-results/",
+      "published_at": "2008-04-26T10:28:57-07:00",
+      "sha256": "2a28e868c2c9264bbb87caedb31b541fdfefe074e76c5593d86e7f39c6dd06c4"
+    },
+    {
+      "body_sha256": "c84e2761472dfc5063951b62f9399f9e8476eaf65b794000e133f318f4dd81f2",
+      "path": "posts/2008-04-27--ubuntu-recipe-how-to-automagically-post-you-lastfm-feed-to-twitter.md",
+      "permalink": "/posts/2008/04/27/ubuntu-recipe-how-to-automagically-post-you-lastfm-feed-to-twitter/",
+      "published_at": "2008-04-27T12:12:13-07:00",
+      "sha256": "86909acc11034e3e0ea1025b3a1f88e04191d1a700022bcb083551cb55aec42d"
+    },
+    {
+      "body_sha256": "81385d2540431b5bc6d0d8bc1826289eeaf5ba050b82fc0e75a0e736eb27d7d3",
+      "path": "posts/2008-05-18--bill-oreilly-flips-out-the-ringtone.md",
+      "permalink": "/posts/2008/05/18/bill-oreilly-flips-out-the-ringtone/",
+      "published_at": "2008-05-18T22:04:00-07:00",
+      "sha256": "a89e622fb50d76fcaf8f9dfd87eb19487ab65395686a42d312ba03e203b043f2"
+    },
+    {
+      "body_sha256": "e7a564d43685c5829610e4c587b49c93e51487dedd0afbcc66be2aee2f4abf91",
+      "path": "posts/2008-05-19--la-red-light-cameras-on-your-tomtom-or-garmin.md",
+      "permalink": "/posts/2008/05/19/la-red-light-cameras-on-your-tomtom-or-garmin/",
+      "published_at": "2008-05-19T07:53:02-07:00",
+      "sha256": "6cf345c91dd6140e4131aab545044f2e48a81f945a20f0e2a71816868059f25e"
+    },
+    {
+      "body_sha256": "02ca441e51ea93c1b3d315c0f689b34ee64dd703f96144f31826b077ec7fc502",
+      "path": "posts/2008-05-26--californias-war-dead.md",
+      "permalink": "/posts/2008/05/26/californias-war-dead/",
+      "published_at": "2008-05-26T15:08:59-07:00",
+      "sha256": "2643f706a49abcf371bb2aa9e5de0e29b21aa4effd7144c59eceebd27c490950"
+    },
+    {
+      "body_sha256": "4bea38930d737b61934baa71b2c004258246f6b87bf8618da9bede71724ce758",
+      "path": "posts/2008-06-01--bens-hip-hop-twitter-bot.md",
+      "permalink": "/posts/2008/06/01/bens-hip-hop-twitter-bot/",
+      "published_at": "2008-06-01T03:56:05-07:00",
+      "sha256": "d71d15012dba77383d01614e8704c7c9bdfa4bae24ab1e32bc87a48e8cf69cf1"
+    },
+    {
+      "body_sha256": "cf7a8b58ec6e075e1409bf91a45363f5009f75bc412cb1e02e0abe3c0ab3fd89",
+      "path": "posts/2008-06-15--terminal-recipe-how-to-download-an-entire-web-site-with-wget.md",
+      "permalink": "/posts/2008/06/15/terminal-recipe-how-to-download-an-entire-web-site-with-wget/",
+      "published_at": "2008-06-15T09:05:15-07:00",
+      "sha256": "1c4df5e52dc1a79a7c19c8dd391cb3bae722e80eaed639e1f8ae331b5ff34458"
+    },
+    {
+      "body_sha256": "39c69d244e3713cc1db953f2aa24b7c7c209248c555e9f182964eca2f2baa254",
+      "path": "posts/2008-06-23--tickertube-bens-first-stab-at-amazon-web-services.md",
+      "permalink": "/posts/2008/06/23/tickertube-bens-first-stab-at-amazon-web-services/",
+      "published_at": "2008-06-23T08:36:39-07:00",
+      "sha256": "1f959d8e2a81a96a1be50dd07c4f40b693da3fc9cd5b34e8e4d6d21fafe5feae"
+    },
+    {
+      "body_sha256": "d51591b306ada05ac979f289b586172bc06bfc5a11241c0ad57ca4f903bbebe1",
+      "path": "posts/2008-07-06--permalinks-low-rent-data-viz-and-other-stupid-caspio-tricks.md",
+      "permalink": "/posts/2008/07/06/permalinks-low-rent-data-viz-and-other-stupid-caspio-tricks/",
+      "published_at": "2008-07-06T20:20:33-07:00",
+      "sha256": "2cb9c959adbe8ea502320992c81dcc840f98677b2c49fcd893dc9c05bd6be334"
+    },
+    {
+      "body_sha256": "4f4ca05a12364ffd666951b3e6188dba798ed1b8ecfa0fddebcf6ee3a6bfd5b2",
+      "path": "posts/2008-07-20--how-we-got-here-or-which-past-are-we-prolouging-again.md",
+      "permalink": "/posts/2008/07/20/how-we-got-here-or-which-past-are-we-prolouging-again/",
+      "published_at": "2008-07-20T10:36:17-07:00",
+      "sha256": "632fbf5a8a8416dc72e43e756eb1afdffa811a814b897d679d8cf256b69fedbc"
+    },
+    {
+      "body_sha256": "25e523465ce3e964dd1fcfdd81c6bec6a74a89aca3499c82ec5f61b27e93520b",
+      "path": "posts/2008-09-18--five-ways-your-data-app-can-catch-the-big-news-hook.md",
+      "permalink": "/posts/2008/09/18/five-ways-your-data-app-can-catch-the-big-news-hook/",
+      "published_at": "2008-09-18T08:15:53-07:00",
+      "sha256": "a7038853897f56f3e94e5864be7cd8f808034511a7c7320372f086cdff826d29"
+    },
+    {
+      "body_sha256": "4f8e623e7f1d92078b4b572e191c368e6e5e14458483422d175cbe2738ef0768",
+      "path": "posts/2009-02-15--django-recipe-add-an-auto-count-field-to-your-foreignkey-model.md",
+      "permalink": "/posts/2009/02/15/django-recipe-add-an-auto-count-field-to-your-foreignkey-model/",
+      "published_at": "2009-02-15T22:30:00-08:00",
+      "sha256": "e426a68364805f48b6a033ec332aa9fc7f75ce1d48e9e482bbd75405a90efd77"
+    },
+    {
+      "body_sha256": "bd36a4821b412bc1604c5876e5241ac550add4cbc3d1809f77f59df120f2e753",
+      "path": "posts/2009-03-03--django-recipe-dump-your-queryset-out-as-a-csv-file.md",
+      "permalink": "/posts/2009/03/03/django-recipe-dump-your-queryset-out-as-a-csv-file/",
+      "published_at": "2009-03-03T13:53:00-08:00",
+      "sha256": "8ea75f9da288d898ebf5230fc740b59d014e70fc61459d9e78dd49df6e415820"
+    },
+    {
+      "body_sha256": "853b6ebe2bce023c24dedf3e18b85c10bf6db97358958d75412c67df1e52efc5",
+      "path": "posts/2009-03-04--openlayers-recipe-how-to-map-proportional-symbols.md",
+      "permalink": "/posts/2009/03/04/openlayers-recipe-how-to-map-proportional-symbols/",
+      "published_at": "2009-03-04T11:04:00-08:00",
+      "sha256": "8d448ed1cf515f9033083549f0c5a4faed791f01056eff94ac1726251c69e853"
+    },
+    {
+      "body_sha256": "28108187d4bf5ba2ce4902b2189454a819e8b41b418d98a502a54e7190433f70",
+      "path": "posts/2009-03-16--dc-police-cite-privacy-to-rollback-public-access-to-crime-data.md",
+      "permalink": "/posts/2009/03/16/dc-police-cite-privacy-to-rollback-public-access-to-crime-data/",
+      "published_at": "2009-03-16T07:23:00-07:00",
+      "sha256": "38e8025f1155a37aff6c803456023806fa3971efe2ab1e23b85eb5cf0194b075"
+    },
+    {
+      "body_sha256": "3dfe0c09e2c8ec615a7630e6d19cca2cf165438dcd8427b497bb8c34d29dc570",
+      "path": "posts/2009-07-25--palewire.md",
+      "permalink": "/posts/2009/07/25/palewire/",
+      "published_at": "2009-07-25T17:21:58-07:00",
+      "sha256": "cd8bd9fcba2d9a1faf63322c7ac28a6101c20d514aa9a3ecdf58eea656aceb36"
+    },
+    {
+      "body_sha256": "231cf8e23142e5904394744840b5d6116c0d93c0ee7b622846c4e34aa4825a3c",
+      "path": "posts/2009-07-29--new-improved-even-more-conspicuous-consumption.md",
+      "permalink": "/posts/2009/07/29/new-improved-even-more-conspicuous-consumption/",
+      "published_at": "2009-07-29T09:42:08-07:00",
+      "sha256": "94c99358ba507944b13b94d1dd30ddee1881daa0549f3805de23c3e83707420b"
+    },
+    {
+      "body_sha256": "cc0651b560934b10786ced792891959b1220b261bd471a40be4977f7eaefb63f",
+      "path": "posts/2009-08-01--django-recipe-make-django-tagging-cloud-all-models.md",
+      "permalink": "/posts/2009/08/01/django-recipe-make-django-tagging-cloud-all-models/",
+      "published_at": "2009-08-01T10:45:25-07:00",
+      "sha256": "5c539c31d62a9adeaa28c6eeefb1ab8718db66b934511e168a7aa3b04d56ba77"
+    },
+    {
+      "body_sha256": "68a38efb14c803e58d41593b1fe867547a2237e2b6dfd1c236f1dfa5b6dcfbcd",
+      "path": "posts/2009-08-05--google-voice-fails-obama-test.md",
+      "permalink": "/posts/2009/08/05/google-voice-fails-obama-test/",
+      "published_at": "2009-08-05T23:28:54-07:00",
+      "sha256": "63ad148ce364c806bf39e35dde6d180323c4045879e7b25692e86111f7ff77b9"
+    },
+    {
+      "body_sha256": "3630c1f377502c6cc172f3a42a8db0ff4b826c4b5e544cb850455872fccfa7eb",
+      "path": "posts/2009-08-07--python-recipe-calculate-adjusted-monthly-values.md",
+      "permalink": "/posts/2009/08/07/python-recipe-calculate-adjusted-monthly-values/",
+      "published_at": "2009-08-07T20:40:28-07:00",
+      "sha256": "8483259d5675858d6814e1fa36bffe1c535c463f7ceeff023bf33ae95991fe16"
+    },
+    {
+      "body_sha256": "6248110261742c61c96e5f1ef8b57711b77728100f02aa996d42fd05b44cb834",
+      "path": "posts/2009-08-13--django-recipe-use-extent-your-querset-set-map-zoom.md",
+      "permalink": "/posts/2009/08/13/django-recipe-use-extent-your-querset-set-map-zoom/",
+      "published_at": "2009-08-13T19:09:27-07:00",
+      "sha256": "e0c1f77360440ceba23c4b05ca52a7d6741b5256c04c31ad66da034305aa8dbd"
+    },
+    {
+      "body_sha256": "a1d8daa1e41d398fbcd3bbb3d35d7f271b7986f5d164578ddf58dfb3071142fa",
+      "path": "posts/2009-08-23--django-recipe-rss-feed-every-tag.md",
+      "permalink": "/posts/2009/08/23/django-recipe-rss-feed-every-tag/",
+      "published_at": "2009-08-23T17:09:49-07:00",
+      "sha256": "9555cf06b886c5a82ea40e38ee3b245172e7f49f2dfa28287a2066453eab61bc"
+    },
+    {
+      "body_sha256": "f70f24f8d64f9abd9e2c477bbfb19eae4c6109cd741a3b9613ae78091f11a191",
+      "path": "posts/2009-09-01--python-recipe-fetch-all-days-between-two-dates.md",
+      "permalink": "/posts/2009/09/01/python-recipe-fetch-all-days-between-two-dates/",
+      "published_at": "2009-09-01T10:32:05-07:00",
+      "sha256": "28e1dd8d55dbf1d6328a177cae3f5493a4782787d7dab2c079040f93c51d0287"
+    },
+    {
+      "body_sha256": "6521c33df064c00b05826f229d242967db3841e74a518d28ac558171ca716b4d",
+      "path": "posts/2009-09-01--django-recipe-remove-newlines-text-block.md",
+      "permalink": "/posts/2009/09/01/django-recipe-remove-newlines-text-block/",
+      "published_at": "2009-09-01T18:01:17-07:00",
+      "sha256": "ad8196e3149ce5fc3890e697714512e4c815c73b393facc2e145cfa5a3e81d6a"
+    },
+    {
+      "body_sha256": "480e9c44836e4c2e2faf2b0a2f959cf6e0934e922c594b758b12fb1d583f2aab",
+      "path": "posts/2009-09-04--django-recipe-pretty-print-objects-and-querysets.md",
+      "permalink": "/posts/2009/09/04/django-recipe-pretty-print-objects-and-querysets/",
+      "published_at": "2009-09-04T13:41:03-07:00",
+      "sha256": "305e2add2797fee30b122254892fd795f2042426843723db457a4e8c0a770d67"
+    },
+    {
+      "body_sha256": "2e8b7fb4f2fe99f75c6a23bfae0eff927489d7d8096be5d46589256eb4e29eac",
+      "path": "posts/2009-10-24--la-county-public-health-should-just-say-no-pdfs.md",
+      "permalink": "/posts/2009/10/24/la-county-public-health-should-just-say-no-pdfs/",
+      "published_at": "2009-10-24T10:05:31-07:00",
+      "sha256": "7537b306305d83ba3c462d762ebabd5ba7baa5191b76431737786dec4d0c08fd"
+    },
+    {
+      "body_sha256": "7ad43f84576fe33291a7b2352d2714205129efaadcf4dce714dbab141ba4f678",
+      "path": "posts/2009-10-29--django-recipe-dynamically-load-your-google-maps-api-key.md",
+      "permalink": "/posts/2009/10/29/django-recipe-dynamically-load-your-google-maps-api-key/",
+      "published_at": "2009-10-29T18:06:46-07:00",
+      "sha256": "d735f2674ebde1737eabdc62d5b5cf70719d5c5bdc7a576deea286e1b3b9a1f3"
+    },
+    {
+      "body_sha256": "04d91936944f4a3fcca004c07687653353f3eb072bfe2572a3166ec3db69b1a9",
+      "path": "posts/2010-03-10--google-charts-takes-tufte-challenge.md",
+      "permalink": "/posts/2010/03/10/google-charts-takes-tufte-challenge/",
+      "published_at": "2010-03-10T13:13:57-08:00",
+      "sha256": "64a85ebb2b369dbcea409adf9339f28f1a32cc08c0b272d6e1689dad1fb44b63"
+    },
+    {
+      "body_sha256": "a98b5c29b9bb02049a1e3cda5e5cfb286ec94e9ccd69ac08a88c20ce8b98e7d6",
+      "path": "posts/2010-03-24--fabric-recipe-delete-pyc-files-runserver-starts.md",
+      "permalink": "/posts/2010/03/24/fabric-recipe-delete-pyc-files-runserver-starts/",
+      "published_at": "2010-03-24T13:19:09-07:00",
+      "sha256": "e34cdfe20adbf1bc2aa3852d1cef0879916c4d68488adf2b5a8a324e6c408f44"
+    },
+    {
+      "body_sha256": "88a95f1119613c68a0cd5b0f974cbe85c0ac9062a7c666b2c72273cadd054c40",
+      "path": "posts/2010-11-07--django-recipe-twitter-style-infinite-scroll.md",
+      "permalink": "/posts/2010/11/07/django-recipe-twitter-style-infinite-scroll/",
+      "published_at": "2010-11-07T12:36:59-08:00",
+      "sha256": "02e683fe48664768b7c6a696816ecb2654bebde4b1c801936c5ac6e7ea54ef6d"
+    },
+    {
+      "body_sha256": "760d01831d6424c008c34ed75ebe44e3e6d3e23ed86300f7bd31143738aeff60",
+      "path": "posts/2010-11-10--zain-memon-tells-how-tendermaps-works.md",
+      "permalink": "/posts/2010/11/10/zain-memon-tells-how-tendermaps-works/",
+      "published_at": "2010-11-10T07:53:40-08:00",
+      "sha256": "be9d4fdda3ac1ff5fa1c0aef4c50e4ca7d8cf6d4cfe4dee87b63d2007d4bf7a4"
+    },
+    {
+      "body_sha256": "e8195f2fa54d365fa29c2d432cfcc6de6ece75d61546bd7b0a672d1a329dad29",
+      "path": "posts/2010-12-16--introducing-pluggable-maps-geodjango.md",
+      "permalink": "/posts/2010/12/16/introducing-pluggable-maps-geodjango/",
+      "published_at": "2010-12-16T15:59:50-08:00",
+      "sha256": "d127ffb889bdd7921fa2de2c00385cc20c5f8228578906e5f7a3f32bf72620ed"
+    },
+    {
+      "body_sha256": "c25a302cd0662cec994c77771e28f2e635212a01b5cb1474a91400663c857f55",
+      "path": "posts/2011-02-24--postgis-is-your-new-bicycle.md",
+      "permalink": "/posts/2011/02/24/postgis-is-your-new-bicycle/",
+      "published_at": "2011-02-24T14:36:19-08:00",
+      "sha256": "c38f53a82e318b406e96f319a2bc5e2bde8f991ff502b8cef2ef1bd7fd0e1f9b"
+    },
+    {
+      "body_sha256": "3353c67641062b421ceb5b10dd5b0b8204db611b8f3afdcfe1346fff6cf37e67",
+      "path": "posts/2011-02-26--break-news-on-google-app-engine.md",
+      "permalink": "/posts/2011/02/26/break-news-on-google-app-engine/",
+      "published_at": "2011-02-26T05:08:47-08:00",
+      "sha256": "b6469597fa1910a71bef8cf39246308f93abcb999c8715e0a613984df9d88b9d"
+    },
+    {
+      "body_sha256": "28d5c0e759804d9131879340ac0fb67e06520f0c9c47c986bd9a3c9faa59a5d1",
+      "path": "posts/2011-08-14--brian-boyer-on-panda.md",
+      "permalink": "/posts/2011/08/14/brian-boyer-on-panda/",
+      "published_at": "2011-08-14T22:51:05-07:00",
+      "sha256": "774364d0340b8108454d9402b35f9a7e80f20dce7d413a15781a8405c28bcd8f"
+    },
+    {
+      "body_sha256": "3895a9b3289d3172f6d697085eb571279b37cd4af4539876c268889365823c11",
+      "path": "posts/2011-09-26--miranda-mulligan-responsive-design.md",
+      "permalink": "/posts/2011/09/26/miranda-mulligan-responsive-design/",
+      "published_at": "2011-09-26T18:37:55-07:00",
+      "sha256": "b82ba35dd4582efab0bf16ce496f81cd280b3b764e721220387f6993a6657fb8"
+    },
+    {
+      "body_sha256": "ce33d1a5e35b33261b66b5875cd69e57b6325e958d87936a0d082bd9039cbe29",
+      "path": "posts/2011-12-05--q-matt-waite-founding-drone-journalism-lab.md",
+      "permalink": "/posts/2011/12/05/q-matt-waite-founding-drone-journalism-lab/",
+      "published_at": "2011-12-05T08:35:49-08:00",
+      "sha256": "f03173d05c0b20438e6c449adbd48b814f228c279da6785d0addfb0dd0e09d83"
+    },
+    {
+      "body_sha256": "60191af3adad58af13d2d7ef571aaf9fde1af33bf2d94dba43ba169ce3e50764",
+      "path": "posts/2012-02-25--nicar-2012-things-i-said.md",
+      "permalink": "/posts/2012/02/25/nicar-2012-things-i-said/",
+      "published_at": "2012-02-25T00:01:17-08:00",
+      "sha256": "431479aff5e2cfe1be89a730d2db600ca3f3d3c1812a25fcb379d5d78a3bd1b3"
+    },
+    {
+      "body_sha256": "90d1522bbc6f257435153577c9dc3bfc9779bc9c1e94385d6414624398fc6e99",
+      "path": "posts/2012-03-26--leaflet-recipe-hover-events-features-and-polygons.md",
+      "permalink": "/posts/2012/03/26/leaflet-recipe-hover-events-features-and-polygons/",
+      "published_at": "2012-03-26T13:47:10-07:00",
+      "sha256": "000b865aa1ec67ebee075a1ef07588ea357d91d8230afafe9319cdf62b69df39"
+    },
+    {
+      "body_sha256": "05ee69dc86f29d47279e98f31d8fd363ea49f564f0fa96c668d262017776bae7",
+      "path": "posts/2013-07-08--where-will-downtown-la-regional-connector-run.md",
+      "permalink": "/posts/2013/07/08/where-will-downtown-la-regional-connector-run/",
+      "published_at": "2013-07-08T22:08:43-07:00",
+      "sha256": "eeac62c782589800b1e6f5cad6eecdff6765c23c111e2c11cc7d2a0d381f92ba"
+    },
+    {
+      "body_sha256": "608e74b5aa766fa18502dcf9622f0f28b439245c3f07abfd84ec4fbb98bd850f",
+      "path": "posts/2013-07-18--why-develop-in-the-newsroom.md",
+      "permalink": "/posts/2013/07/18/why-develop-in-the-newsroom/",
+      "published_at": "2013-07-18T23:53:54-07:00",
+      "sha256": "33d792cfbbd5eb9d8d4d2ced1a9bab129093fc0c2cb842eb0e4c5f195620fa90"
+    },
+    {
+      "body_sha256": "1b817110a93809fc2b291079c78218ee2ba3def51aedd4fcdc1322a1463c66e3",
+      "path": "posts/2014-07-25--django-recipe-base-management-command-running-custom-sql.md",
+      "permalink": "/posts/2014/07/25/django-recipe-base-management-command-running-custom-sql/",
+      "published_at": "2014-07-25T12:02:15-07:00",
+      "sha256": "62e1ac18f189647eed7209d227ff9e1124cfc886eed2734fa17e16f600c87fe9"
+    },
+    {
+      "body_sha256": "3fd914b5385f2e0a2dec7f268d7edf27da0b6846bb69fafb12156274b6b475bd",
+      "path": "posts/2015-02-11--first-news-app-second-time-around.md",
+      "permalink": "/posts/2015/02/11/first-news-app-second-time-around/",
+      "published_at": "2015-02-11T12:00:00-08:00",
+      "sha256": "33b2e7db9747db68b1f75c32cba6973771af2efd545863578e7d4d8eb8a43706"
+    },
+    {
+      "body_sha256": "969e7b2a483431b691c655354a36a64cb7847eb7bbb7980b840c8e7e2a407d0c",
+      "path": "posts/2015-04-14--california-civic-data-coalition-advances-knight-news-challenge.md",
+      "permalink": "/posts/2015/04/14/california-civic-data-coalition-advances-knight-news-challenge/",
+      "published_at": "2015-04-14T12:00:00-07:00",
+      "sha256": "db8c821fb950f0821fa05474f0d4d3a4d5a47f6d58367c8fea46d07c4fa8c959"
+    },
+    {
+      "body_sha256": "fb7a5ea1eaa440de47816a393a4552e447c45504bd45baf0c9d913f29b88de88",
+      "path": "posts/2015-04-16--join-2015-cal-access-challenge.md",
+      "permalink": "/posts/2015/04/16/join-2015-cal-access-challenge/",
+      "published_at": "2015-04-16T12:00:00-07:00",
+      "sha256": "98070ceab6940b47cedbe471581198f9c20bd72ea3b9e23e2c94e3e7a7f2b6ab"
+    },
+    {
+      "body_sha256": "83c68ddf6c2f333e3d3977b4826477bf7f06aedf9c57fbe88672bda66635c803",
+      "path": "posts/2015-05-12--introducing-django-memento-framework.md",
+      "permalink": "/posts/2015/05/12/introducing-django-memento-framework/",
+      "published_at": "2015-05-12T12:00:00-07:00",
+      "sha256": "989af228d960af09c381a94655278ad3487762838e8dd9644379778ea1019299"
+    },
+    {
+      "body_sha256": "da28d680d635a4a62d042cc3634a848576a14f66418563f4b0426a50ba3f0467",
+      "path": "posts/2015-07-22--california-civic-data-coalition-named-winner-knight-news-challenge.md",
+      "permalink": "/posts/2015/07/22/california-civic-data-coalition-named-winner-knight-news-challenge/",
+      "published_at": "2015-07-22T12:00:00-07:00",
+      "sha256": "633c579d7813dd46691dcebb8ebc08f14cd01047f9b2fccd3e79c57d2e8ab04f"
+    },
+    {
+      "body_sha256": "77886064a14ccd1b3c9c04dd89a475855073d1ec496519f026b143e771d28553",
+      "path": "posts/2015-09-28--introducing-memento-wordpress.md",
+      "permalink": "/posts/2015/09/28/introducing-memento-wordpress/",
+      "published_at": "2015-09-28T12:00:00-07:00",
+      "sha256": "517eb9cf41d86e09aca68df2e92d7901c1106590e8ba27056aec505c641062a2"
+    },
+    {
+      "body_sha256": "6f7cd16ff13c519456eed7787bf21179e00c1d7aeea2ac798ed684083c02d991",
+      "path": "posts/2015-09-29--l-times-liveblog-now-nationwide.md",
+      "permalink": "/posts/2015/09/29/l-times-liveblog-now-nationwide/",
+      "published_at": "2015-09-29T12:00:00-07:00",
+      "sha256": "93c0efead366def03e9a586205be81e360b202ab33227a67624d2d0ccf9c1fd1"
+    },
+    {
+      "body_sha256": "9043d8aae09e1b5200fd2d88c60aa294a629dea402bd63655803ba07964c2252",
+      "path": "posts/2015-10-15--unexpected-award.md",
+      "permalink": "/posts/2015/10/15/unexpected-award/",
+      "published_at": "2015-10-15T12:00:00-07:00",
+      "sha256": "31ad301df125d934fb198e66c900c2adb7620bcad76443634e490a21b23fa126"
+    },
+    {
+      "body_sha256": "ee739bda07fcd06c257cfeed4473d6c178ab934752aa9acdc3f608bd8783052f",
+      "path": "posts/2015-11-12--estado-de-las-artes.md",
+      "permalink": "/posts/2015/11/12/estado-de-las-artes/",
+      "published_at": "2015-11-12T12:00:00-08:00",
+      "sha256": "2effddf4e004f7a9c43bc2a505c46887d77f09fca810a64b5d3cf0974280437f"
+    },
+    {
+      "body_sha256": "4c8a09ac0bee3ca350a4c9c50be51ac6b598ebf7480099856b148a811b649e80",
+      "path": "posts/2015-12-03--who-they-were.md",
+      "permalink": "/posts/2015/12/03/who-they-were/",
+      "published_at": "2015-12-03T12:00:00-08:00",
+      "sha256": "08b42dd4b0923536c04ee192aef5e44dad84ffae440071bf137d3c8ab6b40b8a"
+    },
+    {
+      "body_sha256": "13b971c45a9c3947a254fb64d2f30ecfcd2c667dbf7a20493198ad47536d3aa9",
+      "path": "posts/2016-03-06--first-news-app-ride-again-nicar-2016.md",
+      "permalink": "/posts/2016/03/06/first-news-app-ride-again-nicar-2016/",
+      "published_at": "2016-03-06T12:00:00-08:00",
+      "sha256": "25669e39ed8cf480c6930ea337475fdd97f7a5928ea977fa0e17d615e5c2c4d1"
+    },
+    {
+      "body_sha256": "5873a20fe1c88bfea80ed8aeff52d899ba1f3bed4ba417043de19f93b1c02839",
+      "path": "posts/2016-04-18--pulitzer-pride.md",
+      "permalink": "/posts/2016/04/18/pulitzer-pride/",
+      "published_at": "2016-04-18T12:00:00-07:00",
+      "sha256": "1490706fa9ee71652a4ffd9bd386c1087401af83c86dcdb514665c1f82f2ccf8"
+    },
+    {
+      "body_sha256": "c2ece326da49860bf80a1c175f0f9ff65b216fca507722faca042f7828bcf1ec",
+      "path": "posts/2017-09-09--what-i-learned.md",
+      "permalink": "/posts/2017/09/09/what-i-learned/",
+      "published_at": "2017-09-09T20:00:00-07:00",
+      "sha256": "9791af73b8675c3a1291265955f31cb57b0e4ddabd541b829e306bb5c192c4f5"
+    },
+    {
+      "body_sha256": "efdb0c9cffbcf3c23ae9a9eb1a7c5e58ee581f45e94b9c9cc88d1c0df57879f8",
+      "path": "posts/2018-04-14--my-times.md",
+      "permalink": "/posts/2018/04/14/my-times/",
+      "published_at": "2018-04-14T10:00:00-07:00",
+      "sha256": "cbc98fd1aa7a71ab186a841b9792558884679915dfbdf36874dde78d45470db0"
+    },
+    {
+      "body_sha256": "0f1fb56cb208e21b634ee2ac7b57ffc02b13c1884640002f1b810e9229fcf872",
+      "path": "posts/2020-03-21--flash-mooc-first-python-notebook.md",
+      "permalink": "/posts/2020/03/21/flash-mooc-first-python-notebook/",
+      "published_at": "2020-03-21T18:09:31-07:00",
+      "sha256": "bbfcb1b6ba2eecb6ebe4371df56e50845c5a1b689bba146e1e8c88136cf859a2"
+    },
+    {
+      "body_sha256": "87d630f515304fc1fd310a6ba2d79d11c06584ba5088a2f4de24723479341d1d",
+      "path": "posts/2021-02-23--nicar21-after-party-first-python-notebook.md",
+      "permalink": "/posts/2021/02/23/nicar21-after-party-first-python-notebook/",
+      "published_at": "2021-02-23T19:20:22-08:00",
+      "sha256": "a86998f57bb584af92712623cf519e7c0f97fc08280faaca059db0f6ed40b692"
+    },
+    {
+      "body_sha256": "f64014ab1f24011e7239d8a29eb6046d87c82c6da02ea34bdf0a40b797e231c9",
+      "path": "posts/2021-05-02--ee-cummings-archive.md",
+      "permalink": "/posts/2021/05/02/ee-cummings-archive/",
+      "published_at": "2021-05-02T18:46:06-07:00",
+      "sha256": "336e06c05e5954a8369f09475f009d6615ed14e7e634f3045200a400e20c802c"
+    },
+    {
+      "body_sha256": "9c0215dbd98dc7e720c17bedb7751bfc38aa0253b59bc5a989b4b3c8347668e7",
+      "path": "posts/2021-05-09--public-art-on-la-light-rail-line.md",
+      "permalink": "/posts/2021/05/09/public-art-on-la-light-rail-line/",
+      "published_at": "2021-05-09T16:52:30-07:00",
+      "sha256": "773816d7f1b47ba19f8c994cdfe93361facbf226b6dac8ffaedf5578511fc685"
+    },
+    {
+      "body_sha256": "1050cb8925fec52a8bfa7b4c96868becbdd5f264b4efed9e0ea92d1542e96ce0",
+      "path": "posts/2024-10-30--data-journalism-delivery.md",
+      "permalink": "/posts/2024/10/30/data-journalism-delivery/",
+      "published_at": "2024-10-30T12:00:00-07:00",
+      "sha256": "a1f236aa4c8abdc94b9d87709fc51b3a1cc532a4d54d5e7040d751d73706e98c"
+    },
+    {
+      "body_sha256": "b52217f827a47b58b301d743fc7266f54b22b9a80a4070a19b5233aa4d2d26d8",
+      "path": "posts/2024-11-19--reuters-cuny-internship-2025.md",
+      "permalink": "/posts/2024/11/19/reuters-cuny-internship-2025/",
+      "published_at": "2024-11-19T06:00:00-08:00",
+      "sha256": "520f9b8a08c3330ad3988b3ea7105ca827c0a0195b9a8f1a5c9487a10e665d01"
+    },
+    {
+      "body_sha256": "9fc7c1b00b50601be75c6a7ccdda688d18fd5a43f13eb87ac62364bdd9bc483b",
+      "path": "posts/2025-03-11--new-at-nicar25.md",
+      "permalink": "/posts/2025/03/11/new-at-nicar25/",
+      "published_at": "2025-03-11T00:00:00-07:00",
+      "sha256": "cdd2209a8795fea56b6b1779e04c6130f7d14cbbe86faa92399a1bd862f379e7"
+    },
+    {
+      "body_sha256": "9c77ef984150e1a781e297265caa7a39cbde82d49400176db3c1c5e837e63420",
+      "path": "posts/2025-05-21--ire-podcast-transcript.md",
+      "permalink": "/posts/2025/05/21/ire-podcast-transcript/",
+      "published_at": "2025-05-21T09:30:00-07:00",
+      "sha256": "7280f0a460e1ab8d754172177f8c50aee3cbaf88cc0a22e1dc58ef8f03f0b586"
+    }
+  ],
+  "posts_fingerprint_sha256": "f76e4f53b42f15418862885da32516b822045953d80192a3eae4d0e88fafdcb5",
+  "production_inventory": {
+    "draft": 94,
+    "hidden": 0,
+    "live": 72,
+    "total": 166
+  },
+  "schema_version": 1
+}

--- a/coltrane/content/posts/2007-02-08--how-much-does-george-bush-read.md
+++ b/coltrane/content/posts/2007-02-08--how-much-does-george-bush-read.md
@@ -1,0 +1,617 @@
+---
+title: How much does George Bush read?
+slug: how-much-does-george-bush-read
+published_at: '2007-02-08T16:54:10-08:00'
+wordpress_id: 43
+---
+<p>Here's the story:</p>
+
+
+
+<blockquote>[President George W. Bush] has entered a book-reading competition with Karl Rove, his political adviser. White House aides say the president has read 60 books so far this year (while the brainy Rove, to Bush's competitive delight, has racked up only 50).</blockquote>
+
+
+
+<p>- Walsh, Kenneth. Humbled Presidency, U.S. News & World Report. August 20, 2006. <a href="http://www.usnews.com/usnews/news/articles/060820/28presidency.htm">Hyperlink</a>.</p>
+
+
+
+<p>So how much reading is that, really? It doesn't sound too "humble" to me.</p>
+
+<p>My brief survey of media articles on the subject turned up only 31 titles, published below.</p>
+
+
+
+<table>
+
+<tr>
+
+<td style="width: 474px; height: 23px"><font size="2"><strong>Title</strong></font></td>
+
+<td style="width: 222px; height: 23px" align="left"><font size="2"><strong>Author(s)</strong></font></td>
+
+<td style="width: 42px; height: 23px" align="center"><font size="2"><strong>Pages</strong></font></td>
+
+<td style="width: 65px; height: 23px" align="center"><font size="2"><strong>Source</strong></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/After-Fidel-Inside-Castros-Regime/dp/1403969434/sr=1-5/qid=1169401794/ref=sr_1_5/002-6979142-2096055?ie=UTF8&amp;s=books">After Fidel: The Inside Story of Castro's Regime and Cuba's Next Leader</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Latell, Brian</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">288</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/American-Prometheus-Triumph-Tragedy-Oppenheimer/dp/0375412026/sr=1-2/qid=1169402106/ref=pd_bbs_2/002-6979142-2096055?ie=UTF8&amp;s=books">American Prometheus: The Triumph and Tragedy of J. Robert Oppenheimer</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Bird, Kai &amp; Sherwin, Martin J.</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">736</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Beach-Road-James-Patterson/dp/B000KRMWIG/sr=1-1/qid=1169402173/ref=pd_bbs_sr_1/002-6979142-2096055?ie=UTF8&amp;s=books">Beach Road</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Patterson, James &amp; de Jonge, Peter</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">400</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Big-Bam-Life-Times-Babe/dp/0385514379/sr=1-1/qid=1169402066/ref=pd_bbs_sr_1/002-6979142-2096055?ie=UTF8&amp;s=books">Big Bam, The: The Life and Times of Babe Ruth</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Montville, Leigh</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">400</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Bridge-at-Andau-James-Michener/dp/0449210502/sr=1-1/qid=1169401917/ref=pd_bbs_sr_1/002-6979142-2096055?ie=UTF8&amp;s=books">Bridge at Andau, The</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Michener, James</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">288</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Challenger-Park-Stephen-Harrigan/dp/0375412050/sr=1-1/qid=1169401821/ref=pd_bbs_sr_1/002-6979142-2096055?ie=UTF8&amp;s=books">Challenger Park</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Harrigan, Stephen</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">416</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Cinnamon-Skin-Travis-McGee-Mysteries/dp/0449224848/sr=1-1/qid=1169403456/ref=sr_1_1/002-6979142-2096055?ie=UTF8&amp;s=books">Cinnamon Skin: Travis McGee Mysteries</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">MacDonald, John D.</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">336</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Clemente-Passion-Grace-Baseballs-Last/dp/0743217810/sr=1-1/qid=1169402086/ref=pd_bbs_1/002-6979142-2096055?ie=UTF8&amp;s=books">Clemente: The Passion and Grace of Baseball's Last Hero</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Maraniss, David</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">416</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Decision-Sea-Battles-American-History/dp/0195171454/ref=ed_oe_h/002-6979142-2096055">Decision at Sea: Five Naval Battles that Shaped American History</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Symonds, Craig</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">400</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Dreadful-Lemon-Travis-McGee-Mysteries/dp/0449224791/sr=8-1/qid=1169401767/ref=sr_1_1/002-6979142-2096055?ie=UTF8&amp;s=books">Dreadful Lemon Sky, The</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">MacDonald, John D.</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">320</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Finding-Fish-Antwone-Q-Fisher/dp/0688176992/ref=ed_oe_h/002-6979142-2096055">Finding Fish: A Memoir</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Quenton Fisher, Antwone</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">352</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Flashman-Charge-George-MacDonald-Fraser/dp/0006512984/ref=ed_oe_p/002-6979142-2096055">Flashman at the Charge</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">MacDonald Fraser, George</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">336</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Freedom-Flashman-Papers-George-MacDonald/dp/0006511279/ref=ed_oe_p/002-6979142-2096055">Flash for Freedom</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">MacDonald Fraser, George</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">352</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Hamlet-Pelican-Shakespeare-William/dp/0140714545/sr=1-2/qid=1169403488/ref=pd_bbs_sr_2/002-6979142-2096055?ie=UTF8&amp;s=books">Hamlet</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Shakespeare, William</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">208</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/King-Leopolds-Ghost-Heroism-Colonial/dp/0395759242/sr=1-2/qid=1169404206/ref=pd_bbs_2/002-6979142-2096055?ie=UTF8&amp;s=books">King Leopold's Ghost</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Hochschild, Adam</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">384</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.alternet.org/columnists/story/45952/?comments=view&amp;cID=410672&amp;pID=410587">Alternet</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Lincoln-Purpose-Power-Richard-Carwardine/dp/1400044561/sr=1-1/qid=1169402194/ref=pd_bbs_1/002-6979142-2096055?ie=UTF8&amp;s=books">Lincoln: A Life of Purpose and Power</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Carwardine, Richard</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">416</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Lincolns-Greatest-Speech-Second-Inaugural/dp/0743299620/sr=1-2/qid=1169403385/ref=sr_1_2/002-6979142-2096055?ie=UTF8&amp;s=books">Lincoln's Greatest Speech: The Second Inaugural</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">White Jr., Ronald C.</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">256</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Macbeth-Penguin-Shakespeare-S-William/dp/0141013699/sr=1-1/qid=1169403529/ref=pd_bbs_sr_1/002-6979142-2096055?ie=UTF8&amp;s=books">Macbeth</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Shakespeare, William</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">256</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Manhunt-12-Day-Chase-Lincolns-Killer/dp/0060518499/sr=1-1/qid=1169402010/ref=pd_bbs_1/002-6979142-2096055?ie=UTF8&amp;s=books">Manhunt: The 12-Day Chase for Lincoln's Killer</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Swanson, James L.</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">464</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Mao-Story-Jung-Chang/dp/0679422714/sr=8-2/qid=1170622571/ref=pd_bbs_2/002-6979142-2096055?ie=UTF8&amp;s=books">Mao: The Unknown Story</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Chang, Jung &amp; Halliday, Jon</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">832</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.usnews.com/usnews/news/articles/060817/17bushbooks.htm">US News</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Mayflower-Story-Courage-Community-War/dp/0670037605/sr=1-1/qid=1169401961/ref=pd_bbs_sr_1/002-6979142-2096055?ie=UTF8&amp;s=books">Mayflower: A Story of Courage, Community and War</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Philbrick, Nathanial</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">480</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Messenger-Daniel-Silva/dp/0399153357/sr=1-1/qid=1169402127/ref=pd_bbs_sr_1/002-6979142-2096055?ie=UTF8&amp;s=books">Messenger, The</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Silva, Daniel</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">352</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Nine-Parts-Desire-Geraldine-Brooks/dp/0385475764/ref=ed_oe_h/002-6979142-2096055">Nine Parts of Desire: The Hidden World of Islamic Women</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Brooks, Geraldine</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">255</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.usnews.com/usnews/news/articles/060817/17bushbooks.htm">US News</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Places-Between-Rory-Stewart/dp/0156031566/sr=1-1/qid=1169402145/ref=pd_bbs_sr_1/002-6979142-2096055?ie=UTF8&amp;s=books">Places in Between, The</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Stewert, Rory</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">320</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Polio-American-David-M-Oshinsky/dp/0195152948/sr=8-2/qid=1169403320/ref=pd_bbs_2/002-6979142-2096055?ie=UTF8&amp;s=books">Polio: An American Story</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Oshinsky, David</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">368</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Promised-Land-Crusader-State-Encounter/dp/0395901324/sr=1-1/qid=1169403416/ref=pd_bbs_sr_1/002-6979142-2096055?ie=UTF8&amp;s=books">Promised Land, Crusader State: The American Encounter with the World Since 1776</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">McDougall, Walter</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">304</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Quick-Red-Fox-John-Macdonald/dp/0449224406/sr=8-1/qid=1169401717/ref=pd_bbs_1/002-6979142-2096055?ie=UTF8&amp;s=books">Quick Red Fox</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">MacDonald, John D.</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">320</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Revolutionary-Characters-What-Founders-Different/dp/1594200939/sr=1-1/qid=1169401897/ref=pd_bbs_sr_1/002-6979142-2096055?ie=UTF8&amp;s=books">Revolutionary Characters: What Made the Founders Different</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Wood, Gordon S.</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">336</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Savage-War-Peace-1954-1962-Classics/dp/1590172183/sr=1-1/qid=1169404226/ref=pd_bbs_sr_1/002-6979142-2096055?ie=UTF8&amp;s=books">A Savage War of Peace</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Horne, Alistair</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">624</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://select.nytimes.com/2007/01/17/opinion/17dowd.html">NYTimes</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Stranger-Everymans-Library-Cloth/dp/0679420266/sr=8-2/qid=1169403341/ref=pd_bbs_2/002-6979142-2096055?ie=UTF8&amp;s=books">Stranger, The</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Camus, Albert</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">160</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 474px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Through-Glass-Darkly-Commissario-Brunetti/dp/0871139375/sr=1-3/qid=1169401988/ref=pd_bbs_sr_3/002-6979142-2096055?ie=UTF8&amp;s=books">Through a Glass Darkly: A Commissario Guido Brunetti Myster</a></font></td>
+
+<td style="width: 222px" align="left" bgcolor="#ffffff"><font size="2">Leon, Donna</font></td>
+
+<td style="width: 42px" align="center" bgcolor="#ffffff"><font size="2">272</font></td>
+
+<td style="width: 65px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.booktv.org/misc/081706_bush.asp">CSPAN</a></font></td>
+
+</tr>
+
+</table>
+
+
+
+
+
+<p class="MsoNormal">According to listings at Amazon.com, the total page count is 11,647 pages. If you divide that number by 365 you get 31.9, which is how many pages someone would have to read every single day of the year to finish all 31 books.</p>
+
+<p class="MsoNormal">Impressive enough, right? Does anyone here read more than 30 pages a day?</p>
+
+
+
+<p>Yet, remember, the claim isn't that President Bush read 31 books last year. No, the claim is that he read 60 books - and all of them by August 20.</p>
+
+
+
+<p>Without knowing the complete list of titles, it's impossible to generate an exact page total. One alternative is to assume that the rest of the books were of approximately the same length as the titles we do know. The average length of the 31 books listed above is just over 375 pages. Since we're 29 books short of our total, let's multiply that by 375, which rounds out to about 10,895 additional pages of reading. That nearly doubles our earlier total of 11,647 up to an estimated 22,543 pages of reading.</p>
+
+
+
+<p>A quick run through the calendar shows August 20 to have been the 232nd day of the year. What's 22,543 divided by 232? It's 97. So, according to our calculations, President Bush would have to had to read approximately 97 pages every day for 232 consecutive days to have mowed through a sixty-book reading list.</p>
+
+
+
+<p>Without getting into the academic research on reading rates and comprehension, let's just assume that the President proceeded at the straightforward and brisk pace of one page per minute. The simple 1:1 page-to-minute ratio demands more than an hour and a half of reading time each and every day. Two minutes per page? That, of course, doubles the president's daily reading regime to more than three hours every day.</p>
+
+
+
+<p>Now, far be it from me to judge anyone here, but assuming my math is right that's  a pretty steep hill for anyone to climb. My guess is that it's likely to have been a wee bit of an exaggeration.</p>
+
+
+
+<p>For anyone interested, here are the presidential book titles I found from before 2006.</p>
+
+
+
+<table>
+
+<tr>
+
+<td style="width: 457px"><font size="2"><strong>Title</strong></font></td>
+
+<td style="width: 121px"><font size="2"><strong>Author(s)</strong></font></td>
+
+<td style="width: 20px" align="center"><font size="2"><strong>Pages</strong></font></td>
+
+<td style="width: 88px" align="center"><font size="2"><strong>Source</strong></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 457px" bgcolor="#ffffff"><font size="2">Unnamed  Devotional</font></td>
+
+<td style="width: 121px" bgcolor="#ffffff"><font size="2">Chambers, Oswald</font></td>
+
+<td style="width: 20px" align="center" bgcolor="#ffffff"><font size="2"> ?</font></td>
+
+<td style="width: 88px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.nytimes.com/2005/02/07/politics/07letter.html?ex=1265518800&amp;en=1b13d87f6bb97b02&amp;ei=5090&amp;partner=rssuserland">NYTimes</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 457px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Alexander-Hamilton-Ron-Chernow/dp/1594200092/sr=1-1/qid=1169403907/ref=pd_bbs_1/002-6979142-2096055?ie=UTF8&amp;s=books">Alexander Hamilton</a></font></td>
+
+<td style="width: 121px" bgcolor="#ffffff"><font size="2">Chernow, Ronald C.</font></td>
+
+<td style="width: 20px" align="center" bgcolor="#ffffff"><font size="2">832</font></td>
+
+<td style="width: 88px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.nytimes.com/2005/02/07/politics/07letter.html?ex=1265518800&amp;en=1b13d87f6bb97b02&amp;ei=5090&amp;partner=rssuserland">NYTimes</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 457px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Alexander-II-Last-Great-Tsar/dp/074327332X/sr=1-1/qid=1169404165/ref=pd_bbs_1/002-6979142-2096055?ie=UTF8&amp;s=books">Alexander II: The Last Great Tsar</a></font></td>
+
+<td style="width: 121px" bgcolor="#ffffff"><font size="2">Radzinsky, Edvard</font></td>
+
+<td style="width: 20px" align="center" bgcolor="#ffffff"><font size="2">480</font></td>
+
+<td style="width: 88px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.readersread.com/cgi-bin/bookblog.pl?bblog=816052">The Book Blog</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 457px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/April-1865-Month-Saved-America/dp/0060187239/ref=ed_oe_h/002-6979142-2096055">April 1865: The Month That Saved America</a></font></td>
+
+<td style="width: 121px" bgcolor="#ffffff"><font size="2">Winik, Jay</font></td>
+
+<td style="width: 20px" align="center" bgcolor="#ffffff"><font size="2">480</font></td>
+
+<td style="width: 88px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.cnn.com/2005/ALLPOLITICS/01/10/bush.readinglist.tm/">CNN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 457px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Case-Democracy-Freedom-Overcome-Tyranny/dp/1586482610/sr=1-2/qid=1169403547/ref=pd_bbs_2/002-6979142-2096055?ie=UTF8&amp;s=books">Case for Democracy, The: The Power of Freedom to Overcome Tyranny and Terror</a></font></td>
+
+<td style="width: 121px" bgcolor="#ffffff"><font size="2">Sharansky, Natan</font></td>
+
+<td style="width: 20px" align="center" bgcolor="#ffffff"><font size="2">303</font></td>
+
+<td style="width: 88px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.cnn.com/2005/ALLPOLITICS/01/10/bush.readinglist.tm/">CNN</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 457px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Great-Influenza-Deadliest-Plague-History/dp/0670894737/sr=1-6/qid=1169404186/ref=sr_1_6/002-6979142-2096055?ie=UTF8&amp;s=books">Great Influenza, The: The Epic Story of the Deadliest Plague in History</a></font></td>
+
+<td style="width: 121px" bgcolor="#ffffff"><font size="2">Barry, John</font></td>
+
+<td style="width: 20px" align="center" bgcolor="#ffffff"><font size="2">560</font></td>
+
+<td style="width: 88px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.readersread.com/cgi-bin/bookblog.pl?bblog=816052">The Book Blog</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 457px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/His-Excellency-Washington-Joseph-Ellis/dp/1400032539/ref=bxgy_cc_text_b/002-6979142-2096055">His Excellency: George Washington</a></font></td>
+
+<td style="width: 121px" bgcolor="#ffffff"><font size="2">Ellis, Joseph J.</font></td>
+
+<td style="width: 20px" align="center" bgcolor="#ffffff"><font size="2">352</font></td>
+
+<td style="width: 88px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.nytimes.com/2005/02/07/politics/07letter.html?ex=1265518800&amp;en=1b13d87f6bb97b02&amp;ei=5090&amp;partner=rssuserland">NYTimes</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 457px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Holy-Bible-Burgundy-Imitation-Apocrypha/dp/1565637119/sr=1-1/qid=1169403985/ref=sr_1_1/002-6979142-2096055?ie=UTF8&amp;s=books">Bible, The (Standard NRSV copy)</a></font></td>
+
+<td style="width: 121px" bgcolor="#ffffff">&nbsp;</td>
+
+<td style="width: 20px" align="center" bgcolor="#ffffff"><font size="2"> ?</font></td>
+
+<td style="width: 88px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.nytimes.com/2005/02/07/politics/07letter.html?ex=1265518800&amp;en=1b13d87f6bb97b02&amp;ei=5090&amp;partner=rssuserland">NYTimes</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 457px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/I-Am-Charlotte-Simmons-Novel/dp/0374281580/sr=1-2/qid=1169404081/ref=pd_bbs_2/002-6979142-2096055?ie=UTF8&amp;s=books">I Am Charlotte Simmons</a></font></td>
+
+<td style="width: 121px" bgcolor="#ffffff"><font size="2">Wolfe, Tom</font></td>
+
+<td style="width: 20px" align="center" bgcolor="#ffffff"><font size="2">688</font></td>
+
+<td style="width: 88px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.nytimes.com/2005/02/07/politics/07letter.html?ex=1265518800&amp;en=1b13d87f6bb97b02&amp;ei=5090&amp;partner=rssuserland">NYTimes</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 457px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Imperial-Grunts-American-Military-Ground/dp/1400061326/sr=1-1/qid=1169404127/ref=pd_bbs_1/002-6979142-2096055?ie=UTF8&amp;s=books">Imperial Grunts: The American Military on the Ground</a></font></td>
+
+<td style="width: 121px" bgcolor="#ffffff"><font size="2">Kaplan, Robert</font></td>
+
+<td style="width: 20px" align="center" bgcolor="#ffffff"><font size="2">448</font></td>
+
+<td style="width: 88px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.zmag.org/content/showarticle.cfm?ItemID=9428">Znet</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 457px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Salt-World-History-Mark-Kurlansky/dp/0802713734/sr=1-2/qid=1169404145/ref=pd_bbs_sr_2/002-6979142-2096055?ie=UTF8&amp;s=books">Salt: A World History</a></font></td>
+
+<td style="width: 121px" bgcolor="#ffffff"><font size="2">Kurlansky, Mark</font></td>
+
+<td style="width: 20px" align="center" bgcolor="#ffffff"><font size="2">496</font></td>
+
+<td style="width: 88px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.readersread.com/cgi-bin/bookblog.pl?bblog=816052">The Book Blog</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 457px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/Supreme-Command-Soldiers-Statesmen-Leadership/dp/B00009NDAH/sr=1-1/qid=1169404105/ref=pd_bbs_sr_1/002-6979142-2096055?ie=UTF8&amp;s=books">Supreme Command</a></font></td>
+
+<td style="width: 121px" bgcolor="#ffffff"><font size="2">Cohen, Eliot A.</font></td>
+
+<td style="width: 20px" align="center" bgcolor="#ffffff"><font size="2">288</font></td>
+
+<td style="width: 88px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.washingtonpost.com/ac2/wp-dyn?pagename=article&amp;contentId=A37785-2002Aug19&amp;notFound=true">WashingtonPost</a></font></td>
+
+</tr>
+
+<tr>
+
+<td style="width: 457px" bgcolor="#ffffff"><font size="2"><a href="http://www.amazon.com/When-Trumpets-Call-Theodore-Roosevelt/dp/0684864770/ref=ed_oe_h/002-6979142-2096055">When Trumpets Calls: Theodore Roosevelt After the White House</a></font></td>
+
+<td style="width: 121px" bgcolor="#ffffff"><font size="2">O'Toole, Patricia</font></td>
+
+<td style="width: 20px" align="center" bgcolor="#ffffff"><font size="2">512</font></td>
+
+<td style="width: 88px" align="center" bgcolor="#ffffff"><font size="2"><a href="http://www.zmag.org/content/showarticle.cfm?ItemID=9428">Znet</a></font></td>
+
+</tr>
+
+</table>

--- a/coltrane/content/posts/2007-02-14--sql-recipe-the-number-of-federal-government-working-days-between-two-dates.md
+++ b/coltrane/content/posts/2007-02-14--sql-recipe-the-number-of-federal-government-working-days-between-two-dates.md
@@ -1,0 +1,425 @@
+---
+title: 'SQL Recipe: Federal gov''t working days between two dates'
+slug: sql-recipe-the-number-of-federal-government-working-days-between-two-dates
+published_at: '2007-02-14T07:52:24-08:00'
+wordpress_id: 49
+---
+<p>If you'd ever like to programmatically determine the number of federal working days between two dates, here's a quick and dirty solution I cooked up the other day in Microsoft SQL Server. It can be useful in monitering deadlines and evaluating bureaucratic processing speeds (say, for example, a log of Freedom of Information Act requests).</p>
+
+
+
+<p>It's a three-step process.</p>
+
+
+
+<ol>
+
+	<li>Create a calendar table that distinguishes working days from weekends and holidays.</li>
+
+	<li>Create a user-defined function that will use that calendar to count the number of working days between two dates.</li>
+
+	<li>Count the days.</li>
+
+</ol>
+
+
+
+<p>Below you can find a calendar creation script I adapted from one published on <a href="http://classicasp.aspfaq.com/date-time-routines-manipulation/how-do-i-count-the-number-of-business-days-between-two-dates.html" target="_blank">aspfaq.com</a>. Besides distinguishing weekdays from weekends, it marks off all federal holidays -- as specificed by the U.S. Office of Personnel Management -- from Jan. 1, 2000 to Dec. 31, 2010.</p>
+
+
+
+<p>First we create the calendar table. It will have three fields, one for the date and then two binary fields, one that will automatically determine the weekdays using the DATEPART function, and another that we will use later to designate working days.</p>
+
+
+
+<pre lang="SQL">CREATE TABLE dbo.FederalCalendar (
+
+dt SMALLDATETIME PRIMARY KEY CLUSTERED,
+
+isWeekDay AS CONVERT(BIT, CASE
+
+WHEN DATEPART(dw, dt) IN (1,7) THEN 0
+
+ELSE 1 END),
+
+isWorkDay BIT DEFAULT 1
+
+);
+
+GO</pre>
+
+
+
+<p>Next we need to populate the date field, dt, with the range of days in our calendar. In this case, it will be from Jan. 1, 2000 through Dec. 31, 2010.</p>
+
+
+
+<pre lang="SQL">DECLARE @dt SMALLDATETIME;
+
+SET @dt = '20000101';
+
+WHILE @dt <= '20101231'
+
+BEGIN
+
+INSERT dbo.FederalCalendar(dt) SELECT @dt;
+
+SET @dt = @dt + 1;
+
+END</pre>
+
+
+
+<p>Then winnow down our working days field by eliminating the weekends.</p>
+
+
+
+<pre lang="SQL">UPDATE dbo.FederalCalendar
+
+SET isWorkDay = 0
+
+WHERE isWeekday = 0;</pre>
+
+
+
+<p>And finish the job by knocking out all of the federal holidays. Of course you could modify this to reflect any other schedule you'd like to work with, such as trading days on Wall Street or the official holidays in your state.</p>
+
+
+
+<pre lang="SQL">UPDATE dbo.FederalCalendar
+
+SET isWorkDay = 0
+
+WHERE isWorkDay = 1
+
+AND dt IN
+
+(
+
+--2000 Federal Holidays
+
+-- New Year's Day holiday was observed on 12/31/1999
+
+'20000117', -- Martin Luther King's Birthday
+
+'20000221', -- George Washington's Birthday
+
+'20000529', -- Memorial Day
+
+'20000704', -- Independence Day
+
+'20000904', -- Labor Day
+
+'20001009', -- Columbus Day
+
+'20001110', -- Veterans Day
+
+'20001123', -- Thanksgiving Day
+
+'20001225', -- Christmas Day
+
+
+
+--2001 Federal Holidays
+
+'20010101', -- New Year's Day
+
+'20010115', -- Martin Luther King's Birthday
+
+'20010219', -- George Washington's Birthday
+
+'20010528', -- Memorial Day
+
+'20010704', -- Independence Day
+
+'20010903', -- Labor Day
+
+'20011008', -- Columbus Day
+
+'20011112', -- Veterans Day
+
+'20011122', -- Thanksgiving Day
+
+'20011225', -- Christmas Day
+
+
+
+--2002 Federal Holidays
+
+'20020101', -- New Year's Day
+
+'20020117', -- Martin Luther King's Birthday
+
+'20020218', -- George Washington's Birthday
+
+'20020527', -- Memorial Day
+
+'20020704', -- Independence Day
+
+'20020902', -- Labor Day
+
+'20021014', -- Columbus Day
+
+'20021111', -- Veterans Day
+
+'20021128', -- Thanksgiving Day
+
+'20021225', -- Christmas Day
+
+
+
+--2003 Federal Holidays
+
+'20030101', -- New Year's Day
+
+'20030120', -- Martin Luther King's Birthday
+
+'20030217', -- George Washington's Birthday
+
+'20030526', -- Memorial Day
+
+'20030704', -- Independence Day
+
+'20030901', -- Labor Day
+
+'20031013', -- Columbus Day
+
+'20031111', -- Veterans Day
+
+'20031127', -- Thanksgiving Day
+
+'20031225', -- Christmas Day
+
+
+
+--2004 Federal Holidays
+
+'20040101', -- New Year's Day
+
+'20040119', -- Martin Luther King's Birthday
+
+'20040216', -- George Washington's Birthday
+
+'20040531', -- Memorial Day
+
+'20040705', -- Independence Day
+
+'20040906', -- Labor Day
+
+'20041011', -- Columbus Day
+
+'20041111', -- Veterans Day
+
+'20041125', -- Thanksgiving Day
+
+'20041224', -- Christmas Day
+
+
+
+--2005 Federal Holidays
+
+'20041231', -- New Year's Day
+
+'20050117', -- Martin Luther King's Birthday
+
+'20050221', -- George Washington's Birthday
+
+'20050530', -- Memorial Day
+
+'20050704', -- Independence Day
+
+'20050905', -- Labor Day
+
+'20051010', -- Columbus Day
+
+'20051111', -- Veterans Day
+
+'20051124', -- Thanksgiving Day
+
+'20051226', -- Christmas Day
+
+
+
+--2006 Federal Holidays
+
+'20060102', -- New Year's Day
+
+'20060116', -- Martin Luther King's Birthday
+
+'20060220', -- George Washington's Birthday
+
+'20060529', -- Memorial Day
+
+'20060704', -- Independence Day
+
+'20060904', -- Labor Day
+
+'20061009', -- Columbus Day
+
+'20061110', -- Veterans Day
+
+'20061123', -- Thanksgiving Day
+
+'20061225', -- Christmas Day
+
+
+
+--2007 Federal Holidays
+
+'20070101', -- New Years Day
+
+'20070115', -- Martin Luther King's Birthday
+
+'20070219', -- George Washington's Birthday
+
+'20070528', -- Memorial Day
+
+'20070704', -- Independence Day
+
+'20070903', -- Labor Day
+
+'20071008', -- Columbus Day
+
+'20071112', -- Veterans Day
+
+'20071122', -- Thanksgiving Day
+
+'20071225',  -- Christmas Day
+
+
+
+--2008 Federal Holidays
+
+'20080101', -- New Years Day
+
+'20080121', -- Martin Luther King's Birthday
+
+'20080218', -- George Washington's Birthday
+
+'20080526', -- Memorial Day
+
+'20080704', -- Independence Day
+
+'20080901', -- Labor Day
+
+'20081013', -- Columbus Day
+
+'20081111', -- Veterans Day
+
+'20081127', -- Thanksgiving Day
+
+'20081225',  -- Christmas Day
+
+
+
+--2009 Federal Holidays
+
+'20090101', -- New Years Day
+
+'20090119', -- Martin Luther King's Birthday
+
+'20090216', -- George Washington's Birthday
+
+'20090525', -- Memorial Day
+
+'20090703', -- Independence Day
+
+'20090907', -- Labor Day
+
+'20091012', -- Columbus Day
+
+'20091111', -- Veterans Day
+
+'20091126', -- Thanksgiving Day
+
+'20091225',  -- Christmas Day
+
+
+
+--2010 Federal Holidays
+
+'20100101', -- New Years Day
+
+'20100118', -- Martin Luther King's Birthday
+
+'20100215', -- George Washington's Birthday
+
+'20100531', -- Memorial Day
+
+'20100705', -- Independence Day
+
+'20100906', -- Labor Day
+
+'20101011', -- Columbus Day
+
+'20101111', -- Veterans Day
+
+'20101125', -- Thanksgiving Day
+
+'20101225'  -- Christmas Day
+
+);</pre>
+
+
+
+<p>Now that the calendar's done, here's a script that will create a user-defined function to take two dates and count the number of federal working days between the them.</p>
+
+
+
+<pre lang="SQL">CREATE FUNCTION [dbo].[FederalWorkingDays]
+
+(
+
+@startDate SMALLDATETIME,
+
+@endDate SMALLDATETIME
+
+)
+
+RETURNS INT
+
+AS
+
+BEGIN
+
+
+
+DECLARE @result INT
+
+
+
+SELECT @result = COUNT(*)
+
+FROM dbo.FederalCalendar
+
+WHERE dt >= @startDate
+
+AND dt <= @endDate
+
+AND isWorkDay = 1;
+
+
+
+RETURN  @result
+
+
+
+END</pre>
+
+
+
+<p>Once you've run that, all you should need to do to is write a query that uses your new function. Here are two examples:</p>
+
+
+
+<pre lang="SQL">SELECT dbo.FederalWorkingDays(datefield1, datefield2)
+
+FROM table
+
+
+
+SELECT dbo.FederalWorkingDays('01/01/2007', '02/14/2007')</pre>
+
+
+
+<p>And that's the end of our journey. I hope it can be helpful to somebody. As always, if there's something screwed up or missed, just drop a comment. We'll sort things out.</p>

--- a/coltrane/content/posts/2008-03-24--go-snoop-yourself.md
+++ b/coltrane/content/posts/2008-03-24--go-snoop-yourself.md
@@ -1,0 +1,121 @@
+---
+title: Go snoop yourself
+slug: go-snoop-yourself
+published_at: '2008-03-24T06:46:31-07:00'
+wordpress_id: 92
+---
+<p>Considering <a href="http://news.google.com/news/url?sa=t&amp;ct=us/1-0&amp;fp=47e74540eb9a1af4&amp;ei=qqznR_LOG52EqwP1jfinCw&amp;url=http%3A//www.timesonline.co.uk/tol/news/world/us_and_americas/us_elections/article3595065.ece&amp;cid=0&amp;sig2=D9yaDdbIKFaPIXsFM72uKQ&amp;usg=AFrqEzeTYwcKl9B4ktA0YLRLUTb9fdZaPA">all</a> <a href="http://www.google.com/url?sa=t&amp;ct=res&amp;cd=8&amp;url=http%3A%2F%2Fwww.msnbc.msn.com%2Fid%2F23736254%2F&amp;ei=pK7nR9q4NZ-SpwTXmviYBg&amp;usg=AFQjCNF_zZ7b1sYMIH4F70611ylsUDr_QA&amp;sig2=UBTUZ0ebl_tcMt8pajGI_A" target="_blank">the</a> <a href="http://www.bloomberg.com/apps/news?pid=20601087&amp;sid=a0siWJbT95AI&amp;refer=home" target="_blank">hoopla,</a> I can't be the only one wondering what the hell is actually in a passport file.</p>
+
+
+
+<p>According to <a href="http://blogs.state.gov/index.php/entries/your_passport_file/">the State Department's official blog</a> (yes, the State Department has an official blog), here's what they keep:</p>
+
+
+
+<blockquote>Generally, after the State Department issues a passport, all personal documents are returned to the applicant â€“ the only document kept in the Departmentâ€™s passport file is the passport application. Passport files do not contain travel information, such as visa and entry stamps, from previous passports. Almost all passport files contain only a passport application form as completed by the applicant.</blockquote>
+
+
+
+<p>And, according to Under Secretary of State for Management <a href="http://www.google.com/url?sa=t&amp;ct=res&amp;cd=2&amp;url=http%3A%2F%2Fdosfan.lib.uic.edu%2FERC%2Fbiographies%2Fkennedy.html&amp;ei=PLDnR6PfM52ypgTrr_2YBg&amp;usg=AFQjCNFcxZqkgvTu4fPWL8YrDbzc6h_uZA&amp;sig2=-VkRTRLCD5lRQYg_RvD2Vw" target="_blank">Patrick F. Kennedy</a>, here's what the paper trail looks like.</p>
+
+
+
+<blockquote>When you send in your passport application, it might go to a State Department office around the country, it might go to a clerk of the court, it might go to a library or a post office. That information is -- your application is assembled with others and transmitted via registered mail, via Federal Express -- all of it is traceable -- to one of our facilities, a facility such as the one that we work with the Department of the Treasury on in Newark, Delaware . And the information then is -- the envelopes are opened, the checks are removed so that they can be deposited to the Treasury's account, and then they are processed for onward transmission to one of the State Department's facilities that actually print out the passport books in your name (<a href="http://www.state.gov/r/pa/ei/coffee/102504.htm">Source</a>).</blockquote>
+
+
+
+<p>If you review <a href="http://www.state.gov/documents/organization/100004.pdf" target="_blank">the passport application form</a>, you're not going to find much more than what's printed on your driver's license. At first blush, that hardly seems like the sort of thing that contains much to get excited about.</p>
+
+
+
+<p>But, being good paranoids, we should be sure to note the <a href="http://en.wikipedia.org/wiki/Weasel_word">weasel words</a> in the State Department's blog post. They are "generally" and "almost all," which I can only take to mean that while most passport files may only contain the application form, some files contain other documents. What documents those are, it doesn't say.</p>
+
+
+
+<p>On <a href="&amp;eurl=http://dandelionsalad.wordpress.com/2008/03/20/olbermann-obamas-passport-breach/" target="_blank">this particularly alarmist segment of The Countdown with Keith Olbermann</a>, the host and his guests seem to think there's the potential for quite a lot more to be in there. (In a memorable bit of hype, Keith speculates that the file might be of "Watergatian" proportions). On the other hand, <a href="http://www.time.com/time/nation/article/0,8599,1724759,00.html?imw=Y" target="_blank">the reporting of Time's Brian Bennett</a> seems more in line with the State Department's blog.</p>
+
+
+
+<p>But hell if I know.</p>
+
+
+
+<p>The good news is that we live in a free country, governed by laws, one of the best of which is <a href="http://www.google.com/url?sa=t&amp;ct=res&amp;cd=1&amp;url=http%3A%2F%2Fwww.gwu.edu%2F~nsarchiv%2Fnsa%2Ffoia.html&amp;ei=zK3nR__WB4WIpATamp2ZBg&amp;usg=AFQjCNETE0mlrhsTBkE-4Y0vG6jSlWdzvQ&amp;sig2=QGJ-0STQGz92YeZ3wRFlvw" target="_blank">the Freedom of Information Act</a> (a.k.a FOIA). And, thereby, we all have the right to review government documents pertaining to ourselves.</p>
+
+
+
+<p>So, getting to the bottom of this should only be a matter of paperwork and collective effort. Below is a form letter I've prepared using<a href="http://www.state.gov/documents/organization/86672.pdf"> the State Department's FOIA handbook</a> as a guide. I've already filled in my own information and will, later today, mail it off as a formal request.</p>
+
+
+
+<p>You should feel free to do the same. Just don't expect a rapid response. <a href="http://www.state.gov/documents/organization/100129.pdf" target="_blank">The State Department annual report</a> says the median response time on a typical request last year was 212 days. (Though, if you're willing to pay a little more money, the State Department's manual suggests you might get your documents quicker if you bypass FOIA law and make your document request with <a href="http://travel.state.gov/passport" target="_blank">the Passport Services office</a>.)</p>
+
+
+
+<p>If you want to share what you get back, drop a comment when the time comes. I'll be sure to do the same.</p>
+
+
+
+<blockquote>[Today's Date]
+
+<br><br>
+
+[Your Name]<br>
+
+[Your Street Address]<br>
+
+[Your City, State and Zipcode]<br>
+
+<br><br>
+
+Office of Information Programs and Services
+
+<br><br>
+
+A/ISS/IPS<br>
+
+Department of State, SA-2<br>
+
+Washington, DC 20522-8001<br>
+
+Re: Freedom of Information Act Request<br>
+
+<br><br>
+
+Dear Sir or Madame:
+
+<br><br>
+
+I am writing to request the release of personal records under the Privacy Act and the Freedom of Information Act.
+
+<br><br>
+
+I, [Your Name], born [Your Place of Birth] on [Your Date of Birth], request the release of any and all documents contained in my passport file. I believe the Department of State is likely to have maintained such records since I am a current passport holder who has traveled abroad.
+
+<br><br>
+
+I further request that the results of your search be forwarded to my current address, detailed above. If the expense required to perform this search is estimated to exceed $25 dollars, I expect notification from your office and the option to reformulate the request as stipulated in your agency's official policy. If any information is withheld, I request to be notified of the amount of information withheld, the basis for its withholding and my options for appeal, as is my right.
+
+<br><br>
+
+I [declare, certify, verify, of state] under penalty of perjury under the laws of the United
+
+<br><br>
+
+States of America, that the foregoing is true and correct.
+
+<br><br>
+
+If you have any questions or concerns, I can be reached by telephone at [Your Phone Number].
+
+<br><br>
+
+Sincerely,
+
+<br><br>
+
+[Your Signature]</blockquote>
+
+
+
+<p>If you're going to play along, you don't have to send the exact same letter, but you should be sure to include that line about verifying your own identity under penalty of perjury. Otherwise you'll either have to have the letter notarized or the government won't take you on your word that this is a personal request. At least that's what the manual says.</p>

--- a/coltrane/content/posts/2008-04-05--python-recipe-open-a-file-read-through-it-print-each-line-matching-a-search-term.md
+++ b/coltrane/content/posts/2008-04-05--python-recipe-open-a-file-read-through-it-print-each-line-matching-a-search-term.md
@@ -1,0 +1,201 @@
+---
+title: 'Python Recipe: Open a file, read it, print matching lines'
+slug: python-recipe-open-a-file-read-through-it-print-each-line-matching-a-search-term
+published_at: '2008-04-05T08:49:58-07:00'
+wordpress_id: 93
+---
+<p>A couple of friends out there are valiantly teaching themselves the <a href="http://www.google.com/url?sa=t&amp;ct=res&amp;cd=3&amp;url=http%3A%2F%2Fen.wikipedia.org%2Fwiki%2FPython_(programming_language)&amp;ei=dYn3R_GUHYyKpwTA2uSCAQ&amp;usg=AFQjCNH9Zj5BO1JqfEoXtYHusciWciPhyw&amp;sig2=wUObhPmolLlcHaWLfM2jIQ">Python</a> programming language in their free time. Who are they? Hack reporters like me, picking up computer skills in a continuing quest to better sift, organize and analyze information. And, in the process, maybe keep our jobs.</p>
+
+
+
+<p>There are <a href="http://www.google.com/url?sa=t&amp;ct=res&amp;cd=1&amp;url=http%3A%2F%2Fwww.diveintopython.org%2F&amp;ei=soD3R9zRI4_SpgSlvrGXAQ&amp;usg=AFQjCNGQNAs7-XfPQXeZePlQKHmTA13dJQ&amp;sig2=STTYEjUUr__P0LCYzugcqA">a</a> <a href="http://www.greenteapress.com/thinkpython/">couple</a> great books available free online but it's pretty tough to start stringing all the fundamentals into a problem-solving script all on your own. So why not write up some simple recipes that attack problems common to our particular tribe?</p>
+
+
+
+<p>One of the ways computer programming can be of great use to a reporter is as a text parser. We all have more documents than we have time.  So a common challenge is training your computer to read through a big blob of text and return any hits on terms you're interested in (i.e. the name of the mayor, a popular pesticide, a roster of local police officers).</p>
+
+
+
+<p>If it's a one-off effort, you can probably get this done quickly using search tools included in common quality text editors (ex. <a href="http://www.ultraedit.com/">Ultraedit,</a> <a href="http://notepad-plus.sourceforge.net/uk/site.htm">Notepad++</a>, <a href="http://macromates.com/">TextMate</a>). But if you've got a steady stream of files, like a weekly dump of court filings, or a really big bad file, sometimes it's preferable to train your computer to do the work for you.</p>
+
+
+
+<p>In that spirit, the following instructions are designed to show you how to use Python to search through a text file (The Sonnets of William Shakespeare), find any lines that contain our sample search term ("love"), and then print out the hits into a new file we can keep as a memento.</p>
+
+
+
+<p>We'll be dealing with a source file that's probably cleaner than most documents you'll get from the government, and certainly a lot tidier than anything you've converted from a PDF file using an <a href="http://www.google.com/url?sa=t&amp;ct=res&amp;cd=2&amp;url=http%3A%2F%2Fen.wikipedia.org%2Fwiki%2FOCR&amp;ei=Don3R6TqA5OkpwTwr-B-&amp;usg=AFQjCNHMFPblFGTHSM76WDSX2SkNbxkqaQ&amp;sig2=uwlPh0CUVchwL5Hp_rDZ4Q">OCR</a> application, but if you're a totally newbie, my hope is that this can help you get a grip on how the hell all the pieces described in the textbooks fit together into something almost useful.</p>
+
+
+
+<p>Since I'm now a full-time geek, I do most of my work on computers that run some flavor of Linux. The step-by-step instructions that follow will walk you through each keystroke on the command line in <a href="http://www.google.com/url?sa=t&amp;ct=res&amp;cd=3&amp;url=http%3A%2F%2Fen.wikipedia.org%2Fwiki%2FUbuntu_(Linux_distribution)&amp;ei=t4j3R8z6IKi-pgSXhtF3&amp;usg=AFQjCNEm1W3O1_OsDnkAl5emlxHmgPxPAQ&amp;sig2=f8zSJLp9T0AquKr-oWMTPg">Ubuntu</a>, which is what I run at home. But since most people who might be interested in this are probably running Windows XP or Mac OS X, I'll try to include translations as we go.</p>
+
+
+
+<p>The one prerequsite for the whole endeavor is that you already have a working installation of Python. If you're working in Windows and you don't, I'd recommend visiting <a href="http://www.activestate.com/Products/activepython/">ActiveState</a> and downloading the installer for their ActivePython distribution. If you're rocking a Macbook, you can find out whether you're rolling with Python by opening your terminal and entering the following:</p>
+
+
+
+<pre lang="Bash">which python</pre>
+
+
+
+<p>If you've got it properly installed, it should return something like</p>
+
+
+
+<pre lang="Bash">/usr/bin/python</pre>
+
+
+
+<p>If it's not working out, I'd recommend <a href="http://www.diveintopython.org/installing_python/index.html">the installation instructions</a> in Mark Pilgrim's excellent book, Dive Into Python.</p>
+
+
+
+<p>Alright, with all that out of the way, let's get to the recipe.</p>
+
+
+
+<h2>1. Open the command line, create a working directory, move there.</h2>
+
+
+
+<pre lang="Bash">cd $HOME
+mkdir Documents/py-search
+cd Documents/py-search</pre>
+
+
+
+<p>The three commands above, which should work just as easily in Mac as in Linux, will move us to our home directory, create a new subdirectory in your Documents folder, and relocate to the new folder.</p>
+
+
+
+<p>If you're working in Windows, you'll be on the "C:/" file structure, rather than the Unix-style structure above. So you might "mkdir" a new working directory in your "C:/TEMP" folder or wherever else you'd like to work. Or just make a folder wherever through Windows Explorer and "cd" there after the fact through the command line.</p>
+
+
+
+<h2>2. Download our source file, The Sonnets of William Shakespeare.</h2>
+
+
+
+<pre lang="Bash">curl -O http://www.gutenberg.org/dirs/etext97/wssnt10.txt</pre>
+
+
+
+<p>The line above uses the curl command line utility to download a copy of Shakespeare's work from the <a href="http://www.google.com/url?sa=t&amp;ct=res&amp;cd=1&amp;url=http%3A%2F%2Fwww.gutenberg.org%2F&amp;ei=BI73R6_pPISmpwTs8qiGAQ&amp;usg=AFQjCNEwWvhQCQqfxd5f1CbKz4kDmWOgtw&amp;sig2=zRLSSO5_tlJUa4Q_YjXXRQ">Project Gutenberg</a> Web site. Mac users with curl installed should be able to issue the same command. Windows users, or anyone without curl, will probably be able to most easily snatch the file just by visiting <a href="http://www.gutenberg.org/dirs/etext97/wssnt10.txt">the link</a> in a web browser and saving the file to the working directory created in step one.</p>
+
+
+
+<h2>3. Create our python script in the text editor of your choice.</h2>
+
+
+
+<pre lang="Bash">vim py-search.py</pre>
+
+
+
+<p>The line above, which again should work for Linux or Mac, will open a new file in <a href="http://www.google.com/url?sa=t&amp;ct=res&amp;cd=1&amp;url=http%3A%2F%2Fwww.vim.org%2F&amp;ei=fI_3R7rdEIHUpgTsleWSAQ&amp;usg=AFQjCNE8C6iOb5uQLy74YKg-WBd9hikKaw&amp;sig2=MmXWcI-I3tIW0vBQUWiXgA">vim</a>, the command-line text editor that I prefer. You can follow along, or feel free to make your own file in the application you prefer. If you're a newbie Windows user, <a href="http://en.wikipedia.org/wiki/Notepad">Notepad</a> should work great.</p>
+
+
+
+<p>If you're following along in vim, you'll need to enter "insert mode" so you can start entering text.  Do that by hitting:</p>
+
+
+
+<pre lang="Bash">i</pre>
+
+
+
+<h2>4. Write the code!</h2>
+
+
+
+<pre lang="Python" line="1" colla="+">#!/usr/bin/env python
+
+import re
+
+shakes = open("wssnt10.txt", "r")
+
+for line in shakes:
+    if re.match("(.*)(L|l)ove(.*)", line):
+        print line,</pre>
+
+
+
+<p>If, like my friends, you've been working through some common Python tutorials, I'm guessing a lot of that looks familar to you.</p>
+
+
+
+<p>The first line is a <a href="http://en.wikipedia.org/wiki/Shebang_(Unix)">"shebang"</a> that, on execution of the file, instructs the computer to process the script using the python interpreter. The "import re" pulls in <a href="http://docs.python.org/lib/module-re.html">Python's standard regular expression module</a> so we can use it later to search the text. The open() command grabs the Shakespeare file we've just downloaded and opens it up. The "r" is for read mode.</p>
+
+
+
+<p>The three staggered statements that follow are a loop that runs through each line in the document, as dictated by the first statement. The second statement uses <a href="http://www.google.com/url?sa=t&amp;ct=res&amp;cd=1&amp;url=http%3A%2F%2Fwww.regular-expressions.info%2Fpython.html&amp;ei=qJT3R9GRFabopASVx7yOAQ&amp;usg=AFQjCNHl7XwdC7m3xt26uu6oInBwYX1lOw&amp;sig2=SgkINQJUbkJB1FIERp8qmw">the re.match() function</a> we imported at the top to evaluate the latest line on each iteration through the loop by testing it against that scary looking mess in its first parameter.</p>
+
+
+
+<p>So, what is that thing? "(.*)(L|l)ove(.*)", say what?</p>
+
+
+
+<p>That's a regular expression I designed specifically to catch any instances of the search term I'm after.  If you're not familar with <a href="http://en.wikipedia.org/wiki/Regular_expression">regular expressions</a>, they're a powerful language for matching strings of text. When you first get started, they can be a bit intimidating, but once you learn a couple tricks, you'll quickly see how useful they can be. One of my favorite geek jokes is <a href="http://xkcd.com/208/">this cartoon</a> on the utility of a well-timed "regex"</p>
+
+
+
+<p>So how does it work? There are two tricks to learn. Remember, our goal is to find any line in Shakespeare's sonnets that include the word love. But, when we think about it, we can't just search for "love" because our loop is evaluating the text line by line, not word by word. So if we just ask for "love," we'd only get lines that include <em>only</em> the word "love." Plus the word could appear in any number of common grammatical variations (ex. "Love," "lover," "lovesick," "self-love") that we'd also like to capture.</p>
+
+
+
+<p>That's where the regular expressions come in. You'll notice that the expression is bracketed by two "(.*)" statements. In regular expression language, the "." command matches any string and the "*" repeats whatever command precedes it zero or more times, so together they will match any string of any length. When bracketed around a search term, like "love," it should return a match on a line of text regardless of where in the line "love" appears. In other words, it would match <a href="http://www.youtube.com/watch?v=cO9GB_KUAQI">"She loves you,"</a> <a href="http://www.youtube.com/watch?v=LLv_VaTGxH0">"love is a many spendored thing"</a> or <a href="http://www.youtube.com/watch?v=YzB-3oKIfRw">"ain't talking 'bout love."</a></p>
+
+
+
+<p>But, all by itself "(.*)love(.*) wouldn't match <a href="http://www.youtube.com/watch?v=nrvNzH9aaUE">"America: What Time is Love?"</a> or  <a href="http://www.youtube.com/watch?v=50EALZU4D6A">"Love Is Only A Feeling."</a> Why not? Because those songs have an uppercase L and we're just asking for lowercase. Bummer, right?</p>
+
+
+
+<p>One way to fix that would be to add an option that gives the regular expression variations on the term to look for. You can do that by adding another parenthesis set and separating the options with a "|" pipe. That's where the "(L|l)" above came from. Combine that with the (.*) commands and we should have a quick and dirty regex to catch the lines we're after. Though quick studies will catch a flaw in the design. As we'll see in our result set later, this sort of dragnet approach will also yield hits on things we might not want to catch, words like "glove" and "lovely" will match just as easily as "lovesick" or "lover." Feel free to tweak the statement and try to finetune your results. There's a ton more you can do with regular expressions than what I've described. So don't take my example too seriously. I just wanted to show off a couple of the most common regex commands.</p>
+
+
+
+<h2>5. Save your script and run it.</h2>
+
+
+
+<p>If you're working along with me in vim, you'll need to save your work before exiting. The easiest way to do that is to exit insert mode by hitting the ESC key and then hold SHIFT and hit the Z key twice in a row.  If you're working in your own text editor, just save it however you're comfortable.</p>
+
+
+
+<p>Now jump back onto the command line resting in your working directory and tell python to fire that mother off.</p>
+
+
+
+<pre lang="Bash">python py-search.py</pre>
+
+
+
+<p>Voila. There they are, flying across your screen is every line in Shakespeare's sonnets containing the word love. And if you wanted to print them out to a new text file, rather than just dump them on the screen, jump back into your script and try something more like this.</p>
+
+
+
+<pre lang="Python" line="1" colla="+">#!/usr/bin/env python
+import re
+
+shakes = open("wssnt10.txt", "r")
+love = open("love.txt", "w")
+
+for line in shakes:
+    if re.match("(.*)(L|l)ove(.*)", line):
+        print >> love, line,</pre>
+
+
+
+<p>Now just open love.txt and you should find the same results as before.</p>
+
+
+
+<p>The only difference in this script is that we're now opening an outfile called love (notice that it's "w" mode, for write, rather than "r" mode like the source) and modifying our print line to kick the results there, instead of the console.</p>
+
+
+
+<p>That's all folks. Per usual, if I've screwed something up, or I'm not being clear, just shoot me an email or drop a comment and we'll sort it out. Hope this is helpful to somebody.</p>

--- a/coltrane/content/posts/2008-04-07--python-recipe-open-multiple-files-search-for-matches-count-your-hits-on-the-fly.md
+++ b/coltrane/content/posts/2008-04-07--python-recipe-open-multiple-files-search-for-matches-count-your-hits-on-the-fly.md
@@ -1,0 +1,305 @@
+---
+title: 'Python Recipe: Open files, find matches, count hits'
+slug: python-recipe-open-multiple-files-search-for-matches-count-your-hits-on-the-fly
+published_at: '2008-04-07T01:06:45-07:00'
+wordpress_id: 95
+---
+<p>I got some feedback from our beginners on the <a href="http://www.palewire.com/2008/04/05/python-recipe-open-a-file-read-through-it-print-each-line-matching-a-search-term/">Python recipe</a> I put up yesterday. They had a couple good questions about ways they can branch off, which I think we can cover pretty quick in another post.</p>
+
+
+
+<p>To recap, Saturday's script opened a single file (Shakespeare's sonnets), searched the text line by line for a search term ("love") using a basic regular expression, and  then closed by printing the hits to a new text file. Today's recipe will do all that, and a couple other things that might be helpful.</p>
+
+
+
+<p>For reason's discussed in my previous post, I think munching through text with Python is going to be most useful for a reporter when she can leverage its power against large bodies of text.  Our first example only operated on a single file. Out there in the real world, with deadlines, diets and kids to pick up at soccer practice, why should we invest the time learning to write a computer script to process a single file when we might be able to hack out the job with CTRL-F and just be done with it?</p>
+
+
+
+<p>I feel that.</p>
+
+
+
+<p>So, let's take the next step. Let's learn how to crack open a whole directory full of files and slam each one through our wood chipper.</p>
+
+
+
+<p>But before we get going, let me just say that I'm going to assume you read <a href="http://www.palewire.com/2008/04/05/python-recipe-open-a-file-read-through-it-print-each-line-matching-a-search-term/">yesterday's recipe</a> and won't be working too hard to explain the stuff covered there. And keep in mind that my keystrokes are coming right off my home computer, which runs <a href="http://www.ubuntu.com/">Ubuntu Linux</a>. I'll try to provide Mac and Windows translations as we go, but I might muck a phoneme here and there. If anything is screwed up and doesn't work on your end, just shoot me an email or drop a comment. We'll iron it out.</p>
+
+
+
+<p>Formalities aside, here the example task I've selected to achieve our mission.</p>
+
+
+
+<ol>
+
+	<li>Download the works of Friedrich Nietzsche.</li>
+
+	<li>Train our computer to open the books one by one.</li>
+
+	<li>Read through the text of each.</li>
+
+	<li>Find all the lines that contain the german word for hate (<em>hasse</em>, <em>hasst</em>, <em>hassen</em>)</li>
+
+	<li>Print out the hits.</li>
+
+	<li>Count up the totals for each book and figure which one is the hatenest (<em>das meisten hassten!</em>).</li>
+
+</ol>
+
+
+
+<p>Sound good? Let's do it.</p>
+
+
+
+<h2>1. Open the command line, create a working directory, move there.</h2>
+
+
+
+<pre lang="Bash">cd $HOME/Documents
+mkdir py-search-multiple-files
+cd py-search-multiple-files/
+mkdir nietzsche</pre>
+
+
+
+<p>We're going to start the same way we did yesterday, creating a working folder for all our files and moving in with our command line. The only difference this time is that we're making an additional subdirectory to hold the source files we'll be searching.</p>
+
+
+
+<p>The commands should work just as easily in Mac as in Linux. If you're working in Windows, you'll be on the "C:/" file structure, rather than the Unix-style structure above. So you might "mkdir" a new working directory in your "C:/TEMP" folder or wherever else you'd like to work. Or just make a folder wherever through Windows Explorer and "cd" there after the fact through the command line.</p>
+
+
+
+<h2>2. Download our source files, the works of Friedrich Nietzsche.</h2>
+
+
+
+<p>If you <a href="http://www.gutenberg.org/browse/authors/n#a779">visit Project Gutenberg</a>, you can find variety of Nietzsche's work available for download. For our purposes, we're going to take all of the books available there printed in the author's native tongue, German. We could point and click our way through the process -- visiting each book's profile page and downloading its text to our new nietzsche folder -- but if your aim is to become a big-time computer nerd, you might be interested in a command-line trick that can pull them all down with a single line of code.</p>
+
+
+
+<p>Yesterday we used the curl utility to pull down our Shakespeare file. If you pulled that off, I'm sure you can easily imagine how it could be replicated with each of today's files, provided that you know the right urls to hit. And I'm guessing it might look something like this.</p>
+
+
+
+<pre lang="Bash">curl -O http://www.gutenberg.org/dirs/etext05/7zara10.txt
+curl -O http://www.gutenberg.org/dirs/etext05/7ecce10.txt
+curl -O http://www.gutenberg.org/dirs/etext05/7gbrt10.txt
+curl -O http://www.gutenberg.org/dirs/etext05/7gtzn10.txt
+curl -O http://www.gutenberg.org/dirs/etext05/7jnst10.txt
+curl -O http://www.gutenberg.org/dirs/etext05/7msch10.txt</pre>
+
+
+
+<p>But, man, that hardly seems easier that clicking around, does it? Thankfully, one of the great things you pick up as you learn your way around the command line is that there's almost always a way to trim down a repetitive task into an elegant, simple string of code. Here's how those six separate curls can be combined.</p>
+
+
+
+<pre lang="Bash">cd nietzsche
+
+curl -O "http://www.gutenberg.org/dirs/etext05/7{zara,ecce,gbrt,gtzn,jnst,msch}10.txt"
+
+cd ..</pre>
+
+
+
+<p>Remember how we used the (L|l) option statement in our regular expression yesterday to match our search pattern to phrases containing either an upper or lowercase 'L'? We can do a similar thing here with curl, reducing the six urls to their common parts and providing a list of options between the {}'s where we plug each link's unique string. We just use "cd" to commute down to our subdirectory and back. For more details on how curl works, try typing in:</p>
+
+
+
+<pre lang="Bash">curl --help</pre>
+
+
+
+<p>or</p>
+
+
+
+<pre lang="Bash">curl --man</pre>
+
+
+
+<p>Each should include instructions on all other sorts of crazy tricks you can pull off. And if you have something in mind, don't forget to ask <a href="http://www.google.com/search?hl=en&amp;client=firefox-a&amp;rls=com.ubuntu%3Aen-US%3Aofficial&amp;hs=bH6&amp;q=curl+tricks+linux&amp;btnG=Search">our good friend Google</a>.</p>
+
+
+
+<p>If you can't get curl to work on your system, but you still want to play along, just go ahead and download the Nietzsche files one by one through your web browser. As long as you put them in the subdirectory we named after him, the stuff that follows should still work just fine.</p>
+
+
+
+<h2>3. Create our python script in the text editor of your choice.</h2>
+
+
+
+<pre lang="Bash">vim search.py</pre>
+
+
+
+<p>The line above, which again should work for Linux or Mac, will open a new file in <a onclick="javascript:pageTracker._trackPageview ('/outbound/www.google.com');" href="http://www.google.com/url?sa=t&amp;ct=res&amp;cd=1&amp;url=http%3A%2F%2Fwww.vim.org%2F&amp;ei=fI_3R7rdEIHUpgTsleWSAQ&amp;usg=AFQjCNE8C6iOb5uQLy74YKg-WBd9hikKaw&amp;sig2=MmXWcI-I3tIW0vBQUWiXgA">vim</a>, the command-line text editor that I prefer. You can follow along, or feel free to make your own file in the application you prefer. If you're a newbie Windows user, <a href="http://en.wikipedia.org/wiki/Notepad">Notepad</a> should work great.</p>
+
+
+
+<p>If you're following along in vim, you'll need to enter "insert mode" so you can start entering text.  Do that by hitting:</p>
+
+
+
+<pre lang="Bash">i</pre>
+
+
+
+<h2>4. Write the code!</h2>
+
+
+
+<pre lang="Python" line="1" colla="+">#!/usr/bin/env python
+import re, os
+
+path = "./nietzsche"
+freddys_library = os.listdir(path)
+
+for book in freddys_library:
+    file = os.path.join(path, book)
+    text = open(file, "r")
+    for line in text:
+        if re.match("(.*)(hasse|hasst)(.*)", line):
+            print line,</pre>
+
+
+
+<p>Here's what we'll start with. If you cover up the top part of the script with your hand, you'll see that the three statements at the end look almost identical to what we wrote in the first lesson. The script iterates through each line in a file (in this case dubbed "text"), seeks out a match using the same methods described in detail yesterday, and then finally prints out cases where we find a hit.</p>
+
+
+
+<p>The only major difference is that we've replaced portions of yesterday's statement designed to seek out variations on the word "love" with another quick-fix regex designed to net the common German forms of the word hate (<em>hasse</em>, <em>hasst,</em> <em>hassen</em>).</p>
+
+
+
+<p>And then we've got all that junk up there above it. What's going on there?</p>
+
+
+
+<p>The first thing to notice is that we added another module to the import statement. In addition to the "re" module we're using to match regular expressions, we've also introduced the "<a href="http://docs.python.org/lib/module-os.html">os" module</a>. The os library hooks you up with a bunch of easy ways to pull in basic information about your operating system and file structure for use in Python. Our next two statements put it to use right away. First we store our nietzsche subdirectory in a variable called "path," which is then passed to the os function listdir(). That will return a list of all the files contained within the directory. Regardless of how few, or how many, are stuffed down in there, the filenames will now all be stored in our second variable, "freddys_library."</p>
+
+
+
+<p>Our next step is to open up a loop that will iterate through each file name in "freddys_library." Since the function simply returns each file's name, not its path, we have to link the two before we can open the file. So the first step is another os function brought in to meld the two. Then we're free to open the file the same way we did yesterday, which leads the way to the search-and-print loop we're already familar with. And since it's stored within the loop stepping through each book's file, it will be repeated for every title before the script ends.</p>
+
+
+
+<p>Now save and quit out of your script (ESC, SHIFT+ZZ in vim) and fire it up from the command-line...</p>
+
+
+
+<pre lang="Bash" line="1" colla="+">python py-search.py</pre>
+
+
+
+<p>...and, voila, you should now have every line in Nietzsche that contains the word hate flying by on your screen.</p>
+
+
+
+<p>Now here's the next set of tricks.</p>
+
+
+
+<pre lang="Python" line="1" colla="+">#!/usr/bin/env python
+import re, os
+
+path = "./nietzsche"
+freddys_library = os.listdir(path)
+hate = open("hate.txt", "w")
+
+for book in freddys_library:
+    file = os.path.join(path, book)
+    text = open(file, "r")
+    hit_count = 0
+    for line in text:
+        if re.match("(.*)(hasse|hasst)(.*)", line):
+            hit_count = hit_count + 1
+            print >>  hate, book + "|" + line,
+
+    print book + " => " + str(hit_count)
+    text.close()</pre>
+
+
+
+<p>This second snippet is identical to our first draft, with a few additions. The simplest change is first, to create a new file ("hate.txt") where our matches are now printed. You'll notice that the print statement has also been modified to output the book's file name and a pipe-delimiter along with each hit on hate. So each line in your out file should be labeled with the source file where it was found.</p>
+
+
+
+<p>The second change is to introduce a new "hit_count" variable designed to keep a running count of the matches found in each book and report back the results. Since it's enclosed within the outer loop, the first "hit_count = 0" variable will reset the number to nil on each book's iteration. And then the placement of "hit_count + 1" within the subsequent if statement will click the variable's total up one each time a match is made and the interpreter runs through that portion of the script. The final touch is to close each run through the loop by printing the book's file name along with the total number of hits found after all of the lines had been evaluated. The number is enclosed in a str() function so that it's converted from an integer into a string, which can be easily concatenated with other strings for our print statement.</p>
+
+
+
+<p>When you run version two, it'll now print out the total number of hits for each book, looking something like this:</p>
+
+
+
+<pre lang="Bash">7msch10.txt => 13
+7zara10.txt => 34
+7ecce10.txt => 2
+7gtzn10.txt => 5
+7gbrt10.txt => 2
+7jnst10.txt => 4</pre>
+
+
+
+<p>It works, but it's pretty ugly. How can you tell the different books apart without memorizing their file names? Good thing we can fix that too. Check out how.</p>
+
+
+
+<pre lang="Python" line="1" colla="+">#!/usr/bin/env python
+import re, os
+
+title = {
+    "7ecce10.txt": "Ecce homo, Wie man wird, was man",
+    "7gtzn10.txt": "Gotzen-Dammerung",
+    "7msch10.txt": "Menschliches, Allzumenschliches",
+    "7gbrt10.txt": "Die Geburt der Tragodie",
+    "7jnst10.txt": "Jenseits von Gut und Bose",
+    "7zara10.txt": "Also sprach Zarathustra"
+}
+
+path = "./nietzsche"
+freddys_library = os.listdir(path)
+hate = open("hate.txt", "w")
+
+for book in freddys_library:
+    file = os.path.join(path, book)
+    text = open(file, "r")
+    hit_count = 0
+    for line in text:
+        if re.match("(.*)(hasse|hasst)(.*)", line):
+            hit_count = hit_count + 1
+            print >>  hate, title[book] + "|" + line,
+
+    print title[book] + " => " + str(hit_count)
+    text.close()</pre>
+
+
+
+<p>After referring back to our text files to figure out which files contain which books, I made the Python "dictionary" at the top of this snippet. It pairs up the files with the titles for later reference, which happens easy peasy there at bottom when the loop's current "book" variable is run against the dictionary to return its title for our output.</p>
+
+
+
+<p>Now if you save your changes and fire it off again, you should be getting something more like this:</p>
+
+
+
+<pre lang="Bash">Menschliches, Allzumenschliches => 13
+Also sprach Zarathustra => 34
+Ecce homo, Wie man wird, was man => 2
+Gotzen-Dammerung => 5
+Die Geburt der Tragodie => 2
+Jenseits von Gut und Bose => 4</pre>
+
+
+
+<p>Much nicer, nein?</p>
+
+
+
+<p>Alright. That's all for tonight. I hope this helps y'all kick the can a little further down the road. Per usual, if I've screwed something up, or I'm not being clear, just shoot me an email or drop a comment and we'll sort it out. Hope this is helpful to somebody.</p>

--- a/coltrane/content/posts/2008-04-14--python-recipe-read-a-file-search-for-a-pattern-print-your-matches.md
+++ b/coltrane/content/posts/2008-04-14--python-recipe-read-a-file-search-for-a-pattern-print-your-matches.md
@@ -1,0 +1,152 @@
+---
+title: 'Python Recipe: Read file, find pattern, print matches'
+slug: python-recipe-read-a-file-search-for-a-pattern-print-your-matches
+published_at: '2008-04-14T22:52:41-07:00'
+wordpress_id: 100
+---
+<p>Our <a href="http://www.palewire.com/2008/04/05/python-recipe-open-a-file-read-through-it-print-each-line-matching-a-search-term/">first</a> <a href="http://www.palewire.com/2008/04/07/python-recipe-open-multiple-files-search-for-matches-count-your-hits-on-the-fly/">two</a> recipes focused primarily on how to open one or more files and loop through them line by line. While we paid a little attention to how we could search for patterns using <a href="http://www.amk.ca/python/howto/regex/regex.html#SECTION000310000000000000000">regular expressions</a>, we didn't try to do a whole lot with what we caught. Hell, we didn't even try very hard to write a good regex.</p>
+
+
+
+<p>But when you start to get serious about searching for patterns in text, one of the obvious goals is to single out and collect your matches. Maybe you want to pull all the phone numbers out of big blobs of text. Or email addresses. Or anything enclosed in quotation marks. Whatever.</p>
+
+
+
+<p>Here's one way to try it.</p>
+
+
+
+<p>But before we get going, let me just say that I'm going to assume you read the first couple recipes and won't be working too hard to explain the stuff covered there. And keep in mind that my keystrokes are coming right off my home computer, which runs <a href="http://www.ubuntu.com/">Ubuntu Linux</a>. I'll try to provide Mac and Windows translations as we go, but I might muck a phoneme here and there. If anything is screwed up and doesn't work on your end, just shoot me an email or drop a comment. We'll iron it out.</p>
+
+
+
+<p>Formalities aside, here's the example task I've selected to achieve our mission.</p>
+
+
+
+<ol>
+
+	<li>Download the King James Version of the Holy Bible.</li>
+
+	<li>Read through each line of text.</li>
+
+	<li>Capture each four-letter word.</li>
+
+	<li>Print them out.</li>
+
+</ol>
+
+
+
+<p>Let's do it.</p>
+
+
+
+<h2>1. Open the command line, create a working directory, move there.</h2>
+
+
+
+<p>We're going to start the same way we did in the first two lessons, creating a working folder for all our files and moving in with our command line. </p>
+
+
+
+<pre lang="bash">cd Documents/
+mkdir py-search-and-capture
+cd py-search-and-capture/</pre>
+
+
+
+<p>The commands should work just as easily in Mac as in Linux. If you're working in Windows, you'll be on the "C:/" file structure, rather than the Unix-style structure above. So you might"mkdir" a new working directory in your "C:/TEMP" folder or wherever else you'd like to work. Or just make a folder wherever through Windows Explorer and "cd" there after the fact through the command line.</p>
+
+
+
+<h2>2. Download our source file, The King James Version of the Holy Bible</h2>
+
+
+
+<p>We're going to use <a href="http://www.gutenberg.org/ebooks/10">the text file</a> provided Project Gutenberg as our source. As in the earlier lessons, I'm going to use the curl command-line utility to retrieve the file, but you should feel free to download it to our working directory using your web browser, if you prefer.</p>
+
+
+
+<pre lang="bash">curl -O http://www.gutenberg.org/dirs/etext92/bible11.txt</pre>
+
+
+
+<h2>3. Create our python script in the text editor of your choice.</h2>
+
+
+
+<pre lang="bash">vim search.py</pre>
+
+
+
+<p>The line above, which again should work for Linux or Mac, will open a new file in <a href="http://www.google.com/url?sa=t&ct=res&cd=1&url=http%3A%2F%2Fwww.vim.org%2F&ei=uzoESIj8LKnmpgTRy43VBw&usg=AFQjCNE8C6iOb5uQLy74YKg-WBd9hikKaw&sig2=vP2XqMTTDBFF49Gy22gxJQ">vim</a>, the command-line text editor that I prefer. You can follow along, or feel free to make your own file in the application you prefer. If you're a newbie Windows user, <a href="http://www.google.com/url?sa=t&ct=res&cd=1&url=http%3A%2F%2Fen.wikipedia.org%2Fwiki%2FNotepad&ei=zToESKWNL4uqpwT2k73dBw&usg=AFQjCNEXWgXDcow8vXjueJBIOmWghv1lhw&sig2=aDintKlEbbRHHWcaHXoz1w">Notepad</a> should work great.</p>
+
+
+
+<p>If you're following along in vim, you'll need to enter "insert mode" so you can start entering text. Do that by hitting:</p>
+
+
+
+<pre lang="bash">i</pre>
+
+
+
+<h2>4. Write the code!</h2>
+
+
+
+<pre lang="python">#!/usr/bin/env python
+import re
+
+bible = open("kjv10.txt", "r")
+regex = re.compile(r'\b\w{4}\b')
+
+for line in bible:
+    four_letter_words = regex.findall(line)
+    for word in four_letter_words:
+        print word</pre>
+
+
+
+<p>Our file opens by importing the re module, which will allow us to call upon Python's regular expression library. We then open our Bible into a variable of the same name and, as in previous recipes, open a loop that will iterate through each line in the file.</p>
+
+
+
+<p>The new stuff comes next. The first statement above our loop uses re's compile method to store our regular expression pattern into a variable called "regex." (As commenter Paddy suggested <a href="http://www.palewire.com/2008/04/14/python-recipe-read-a-file-search-for-a-pattern-print-your-matches/#comment-73091">below</a>, it's a good idea to put it above the loop so it doesn't have to be repeated on each iteration.) Remember, our goal is to match any four-letter words. There are three regex symbols I squished together to give it a hack. They are defined as follows. I've drawn the definitions from <a href="http://www.amk.ca/python/howto/regex/regex.html#SECTION000310000000000000000">this</a> Python reference, which can probably help you crack most nuts.</p>
+
+
+
+<ul>
+
+	<li>\b - Word boundary. This is a zero-width assertion that matches only at the beginning or end of a word.</li>
+
+	<li>\w - Matches any alphanumeric character</li>
+
+	<li>{m,n} - There must be at least m repetitions, and at most n.</li>
+
+</ul>
+
+
+
+<p>So when you piece them together like so, "\b\w{4}\b", what you're asking for is any stretch of four alphanumeric characters between two word boundaries. Make sense?</p>
+
+
+
+<p>Next, equipped with our regex, we create another variable called "four_letter_words." In it we see our regex variable pressed against a re method we haven't used before. In the previous lessons we used the kludgy match() function to make our hits. Here we're using something more elegant. It's findall(), which will return all the matches within our line as a list. And by connecting it to our pre-compiled "regex" variable, we're setting that as the pattern it should look for. </p>
+
+
+
+<p>We can expect plenty of lines with more than one match, so we'll set up another loop to run through "four_letter_words" and print out all the hits. And then we're done. Save and quit out of your script (ESC, SHIFT+ZZ in vim) and fire it up from the command-line:</p>
+
+
+
+<pre lang="bash">python py-search.py</pre>
+
+
+
+<p>And, voila, there you have it. All the four-letter words in the KJV. Every f*cking one.</p>
+
+
+
+<p>Unless I messed something up, of course. Per usual, if you spot a screw up, or I'm not being clear, just shoot me an email or drop a comment and we'll sort it out. Hope this is helpful to somebody.</p>

--- a/coltrane/content/posts/2008-04-20--python-recipe-grab-a-page-scrape-a-table-download-a-file.md
+++ b/coltrane/content/posts/2008-04-20--python-recipe-grab-a-page-scrape-a-table-download-a-file.md
@@ -1,0 +1,487 @@
+---
+title: 'Python Recipe: Grab page, scrape table, download file'
+slug: python-recipe-grab-a-page-scrape-a-table-download-a-file
+published_at: '2008-04-20T13:43:13-07:00'
+wordpress_id: 107
+---
+<p>Here's a change of pace. Our <a href="http://www.palewire.com/2008/04/05/python-recipe-open-a-file-read-through-it-print-each-line-matching-a-search-term/">first</a> <a href="http://www.palewire.com/2008/04/07/python-recipe-open-multiple-files-search-for-matches-count-your-hits-on-the-fly/">few</a> <a href="http://www.palewire.com/2008/04/14/python-recipe-read-a-file-search-for-a-pattern-print-your-matches/">lessons</a> focused on how you can use Python to goof with a bunch of local files. This time we're going to try something different: using Python to go online and screw around with the Web. </p>
+
+
+
+<p>Whenever I caucus with aspiring <a href="http://www.google.com/url?sa=t&ct=res&cd=1&url=http%3A%2F%2Fwww.nicar.org%2F&ei=1HYLSJWzII6IiwGuhvj7Ag&usg=AFQjCNFv1OMXDU_2U5mOn6I-DfJcHnfT7Q&sig2=PRhstdzVRiSElCZCCA9pQA">NICARians</a> and other data hungry reporters, it's not long before the topic of <a href="http://en.wikipedia.org/wiki/Web_scraping">web scraping</a> comes up. While automated text processing and database management may sound well and good, there's something sexy about pulling down a fatty government database that catches people's imagination and inspires them to take on the challenge of learning a new programming language. Or at least entertain the idea until they run into a road block.</p>
+
+
+
+<p>A number of fellow travelers do a noble job instructing people on the basics during NICAR's annual seminars. But scraping seems like such a sought-after skill that it feels like a good idea to throw up a basic walkthrough here, where beginners can cut and paste code and any feedback can be memorialized. </p>
+
+
+
+<p>But before we get going, let me just say that I'm going to assume you read the first couple recipes and won't be working too hard to explain the stuff covered there. And keep in mind that my keystrokes are coming right off my home computer, which runs Ubuntu Linux. I'll try to provide Mac and Windows translations as we go, but I might muck a phoneme here and there. If anything is screwed up and doesn't work on your end, just shoot me an email or drop a comment. We'll iron it out.</p>
+
+
+
+<p>Formalities aside, here's the example task I've selected to achieve our mission.</p>
+
+
+
+<ol>
+
+	<li>Install the necessary Python modules, mechanize and Beautiful Soup.</li>
+
+	<li>Train our computer to visit Ben's list of <a href="http://www.palewire.com/scrape/albums/2007.html">The Greatest Albums in the History of 2007</a>.</li>
+
+	<li>Parse the html and scrape out Ben's rankings.</li>
+
+	<li>Click through to Ben's list of <a href="http://www.palewire.com/scrape/albums/2006.html">The Greatest Albums in the History of 2006</a> and repeat the scrape.</li>
+
+        <li>Do it all over again, but this time download the cover art.</li>
+
+</ol>
+
+
+
+<h2>1. Download the mechanize and Beautiful Soup modules. Install them. </h2>
+
+
+
+<p>There are a dozen different methods for going about our task, so you shouldn't assume the one I'm about to show you is the only or the best. It's just one way to do it. And doing it this way requires a couple additions to your Python installation, which might seem a little daunting but should be doable unless IT has your computer on double secret probation. </p>
+
+
+
+<p>A <a href="http://www.python.org/doc/2.0.1/tut/node8.html">module</a> is a collection of functions, defintions and statements contained in a separate file that you can import into your script. Examples native to Python used in our earlier scripts included "re", "os" and "string." </p>
+
+
+
+<p>Out there on the Web, kind and ambitious programmers are constantly drafting, updating and publishing new modules to boil down complicated tasks into simpler forms. It it wasn't for these people, praise be upon them, I probably wouldn't have a job. </p>
+
+
+
+<p>If you want to take advantage of their contributions, you need to plug their creations into your local Python installation. It's usually not that hard, even on Windows!</p>
+
+
+
+<p>To accomplish today's task, we're going to rely on two third-party modules. The first is <a href="http://www.google.com/url?sa=t&ct=res&cd=1&url=http%3A%2F%2Fwwwsearch.sourceforge.net%2Fmechanize%2F&ei=WokLSJr3A52qiAHS6L38Ag&usg=AFQjCNGUEUs6Jn1FSoo0YYjpZ2PJe6E6Ag&sig2=I3rdoLQ5AV843Eignvjxgg">mechanize</a>, a Python translation of <a href="http://www.google.com/url?sa=t&ct=res&cd=1&url=http%3A%2F%2Fsearch.cpan.org%2Fdist%2FWWW-Mechanize%2F&ei=gIkLSOmaMY-ShAOc38TDAw&usg=AFQjCNEsooTEHj6bN2UHDi0OfZ2krEX-EA&sig2=zPl5yUdSVr0loDl4qaaUYQ">the popular Perl module</a> for calling up and walking through Web pages. The second is <a href="http://www.google.com/url?sa=t&ct=res&cd=1&url=http%3A%2F%2Fwww.crummy.com%2Fsoftware%2FBeautifulSoup%2F&ei=tIkLSITRIYjGigHqmez7Ag&usg=AFQjCNHAxwplurFOBqg5cehWQEVKi-TuLQ&sig2=UhVMcFqeJrnKIp2wIF5t6g">Beautiful Soup</a>, a superlatively elegant means for parsing HTML and XML documents. Working hand-in-hand, they can accomplish most simple web scrapes.</p>
+
+
+
+<p>If you're working Linux or Mac OS X, this is going to be a piece of cake. All you need is to use Python's auto-installer <a href="http://peak.telecommunity.com/DevCenter/EasyInstall">Easy Install</a> to issue the following commands:</p>
+
+
+
+<pre lang="Bash">sudo easy_install mechanize
+sudo easy_install BeautifulSoup</pre>
+
+
+
+<p>And now you can check if the modules are available for use by cracking open your python interpreter...</p>
+
+
+
+<pre lang="Bash">python</pre>
+
+
+
+<p>...and attempting to import the new modules...</p>
+
+
+
+<pre lang="Python">
+from mechanize import Browser
+from BeautifulSoup import BeautifulSoup</pre>
+
+
+
+<p>If the interpreter accepts the commands and kicks down the next line without an error, you know you're okay. If it throws an error, you know something is off. </p>
+
+
+
+<p>I don't have a lot of Python experience working in Windows, but the method for adding modules that I've had success with is simply downloading the .py files to my desktop and dumping them in the "lib" folder of my Python installation. If, like me, you use Activestate's <a href="http://www.activestate.com/Products/activepython/?_x=1">ActivePython</a> distribution for Windows, it should be easily found at C:/Python25/lib/. And when you browse around the directory, you should already see os.py, re.py and other modules we're already familar with. So just visit the <a href="http://wwwsearch.sourceforge.net/mechanize/">mechanize</a> and <a href="http://www.crummy.com/software/BeautifulSoup/">Beautiful Soup</a> homepages and retrieve the latest download. Dump the .py files in your lib folder and now you should be able to fire up your python interpreter just the same as above and introduce yourself to our new friends.</p>
+
+
+
+<p>With that out of the way, we now have all the tools we need to grip and rip. So let's do it!</p>
+
+
+
+<h2>2. Open the command line, create a working directory, move there.</h2>
+
+
+
+<p>We're going to start the same way we did in the first three lessons, creating a working folder for all our files and moving in with our command line.</p>
+
+
+
+<pre lang="Bash">cd Documents/
+mkdir py-scrape-and-download
+cd py-scrape-and-download/</pre>
+
+
+
+<p>The commands should work just as easily in Mac as in Linux. If you're working in Windows, you'll be on the C:/ file structure, rather than the Unix-style structure above. So you might mkdir a new working directory in your C:/TEMP folder or wherever else you'd like to work. Or just make a folder wherever through Windows Explorer and cd there after the fact through the command line.</p>
+
+
+
+<h2>3. Create our python script in the text editor of your choice.</h2>
+
+
+
+<pre lang="Bash">vim py-scrape-and-download.py</pre>
+
+
+
+<p>The line above, which again should work for Linux or Mac, will open a new file in <a href="http://www.google.com/url?sa=t&ct=res&cd=1&url=http%3A%2F%2Fwww.vim.org%2F&ei=uzoESIj8LKnmpgTRy43VBw&usg=AFQjCNE8C6iOb5uQLy74YKg-WBd9hikKaw&sig2=vP2XqMTTDBFF49Gy22gxJQ">vim</a>, the command-line text editor that I prefer. You can follow along, or feel free to make your own file in the application you prefer. If you're a newbie Windows user, <a href="http://www.google.com/url?sa=t&ct=res&cd=1&url=http%3A%2F%2Fen.wikipedia.org%2Fwiki%2FNotepad&ei=zToESKWNL4uqpwT2k73dBw&usg=AFQjCNEXWgXDcow8vXjueJBIOmWghv1lhw&sig2=aDintKlEbbRHHWcaHXoz1w">Notepad</a> should work great.</p>
+
+
+
+<p>If you're following along in vim, you'll need to enter "insert mode" so you can start entering text. Do that by hitting:</p>
+
+
+
+<pre lang="Bash">i</pre>
+
+
+
+<h2>4. Write the code!</h2>
+
+
+
+<pre lang="Python">#!/usr/bin/env python
+from mechanize import Browser
+from BeautifulSoup import BeautifulSoup
+
+mech = Browser()
+url = "http://www.palewire.com/scrape/albums/2007.html"
+page = mech.open(url)
+html = page.read()
+
+soup = BeautifulSoup(html)
+print soup.prettify()</pre>
+
+
+
+<p>Our first snippet of code, seen above, shows a basic introduction to each of our new modules.</p>
+
+
+
+<p>After they've been imported in lines two and three, we put mechanize's browser to use right away, storing it a variable I've decided to call mech, but which you could call anything you wanted (ex. browser, br, ie, whatever). We then use its open() method to grab the location of our first scrape target, <a href="http://www.palewire.com/2008/04/14/python-recipe-read-a-file-search-for-a-pattern-print-your-matches/">my favorite albums of 2007</a>, and store that in another variable we'll call page. </p>
+
+
+
+<p>That's enough to go out on the web and grab the page, now we need to tell Python what to do with it. Mechanize's read() method will return all of the HTML in the page, which we store, simply, in an variable called html and then pass to BeautifulSoup's default method so it can be prepared for processing.</p>
+
+
+
+<p>The reason we need to pass the page to Beautiful Soup is that there is a ton of HTML code in the page we don't want. Our ultimate goal isn't to print out the complete page source. We don't want all the junky td and img and body tags. We want to free the data from the HTML by printing it out in a machine readable format we can repurpose for our own needs. In the next step we'll ask Beautiful Soup to step through the code and pull out only the good parts, but here in the first iteration we'll pause with just printing out the complete page code using a fun Beautiful Soup method called prettify(). It will spit out the HTML in a well-formed format. To take a look, save and quit out of your script (ESC, SHIFT+ZZ in vim) and fire it up from the command-line:</p>
+
+
+
+<pre lang="Bash">python py-scrape-and-download.py</pre>
+
+
+
+<p>And you should see something like....</p>
+
+
+
+<pre lang="HTML"><html>
+ <head>
+  <title>
+   According to Ben...
+  </title>
+ </head>
+ <body>
+  <h2>
+   The 10 Greatest Albums in the History of 2007
+  </h2>
+  <table padding="1" width="60%" border="1" style="text-align:center;">
+   <tr style="font-weight:bold">
+    <td>
+     Rank
+    </td>
+    <td>
+     Artist
+    </td>
+...</pre>
+
+
+
+<p>...which means that you've successfully retrieved and printed out our first target. Now let's move on to scraping the data out from the HTML.</p>
+
+
+
+<pre lang="Python">#!/usr/bin/env python
+from mechanize import Browser
+from BeautifulSoup import BeautifulSoup
+
+mech = Browser()
+url = "http://www.palewire.com/scrape/albums/2007.html"
+page = mech.open(url)
+
+html = page.read()
+soup = BeautifulSoup(html)
+table = soup.find("table", border=1)
+
+for row in table.findAll('tr')[1:]:
+    col = row.findAll('td')
+    rank = col[0].string
+    artist = col[1].string
+    album = col[2].string
+    cover_link = col[3].img['src']
+    record = (rank, artist, album, cover_link)
+    print "|".join(record)</pre>
+
+<p>The second version of our script, seen above, removes the prettify() command that concluded version one and replaces it with the Beautiful Soup code necessary to parse the rankings from the page. </p>
+
+
+
+<p>When you're scraping a real target out there on the wild Web, the mechanize part of the script is likely to remain pretty much the same, but the Beautiful Soup portion that pulls the data from the page is going to have change each time, tailored to work with however your target HTML is structured. </p>
+
+
+
+<p>So your job as the scraper is to inspect your target table and figure out how you can get Beautiful Soup to hone in on the elements you want to harvest. I like to do this using the Firefox plugin <a href="https://addons.mozilla.org/en-US/firefox/addon/1843">Firebug</a>, which allows you to right-click and, by choosing the "Inspect Element" option, have the browser pull up and highlight the HTML underlying any portion of the page. But all that's really necessary is that you take a look at the page's source code. </p>
+
+
+
+<p>Since most HTML pages you'll be targeting, including my sample site, will include more than one set of table tags, you often have to find something unique about the table you're after. This is necessary so that Beautiful Soup knows how to zoom in on that section of the code you're after and ignore all the flotsam around it. </p>
+
+
+
+<p>If you look closely at this particular page, you'll note that while both table tags have the same width value, an easy way to distinguish them is that they have different border values...</p>
+
+
+
+<pre lang="HTML"><table width="60%" border="1" style="text-align: center;" padding="1">
+...
+<table width="60%" border="0"></pre>
+
+
+
+<p>...and the one we want to harvest has a border value of one. That's why the first Beautiful Soup command seen in the snippet above uses the find() method to capture the table with that characteristic.</p>
+
+
+
+<pre lang="Python">table = soup.find("table", border=1)</pre>
+
+
+
+<p>Once that's been accomplished, the new table variable is immediately put to use in a loop that is designed to step through each row and pull out the data we want.</p>
+
+
+
+<pre lang="Python">for row in table.findAll('tr')[1:]:</pre>
+
+
+
+<p>It uses Beautiful Soup's findAll() method to put all of the tr tags (which is the HTML equivalent of a row) into a list. The [1:] modifier at the end instructs the loop to skip the first item, which, from looking at the page, we can tell is an unneeded header line. </p>
+
+
+
+<p>Then, after the loop is set up on the tr tags, we set up another list that will grab all of the td tags (the HTML equivalent of a column) from each row. </p>
+
+
+
+<pre lang="Python">    col = row.findAll('td')</pre>
+
+
+
+<p>Now pulling out the data is simply a matter of figuring out which order we can expect the data to appear in each row and pulling the corresponding values from the list. Since we expect rank, artist, album and cover to appear in each row from left to right, the first element of the col variable (col[0]) can always be expected to be the rank and the last element (col[3]) can always be expected to be the cover. So we create a new set of values to retrieve each, with some Beautiful Soup specific objects tacked on the end to grab only the bits we want.</p>
+
+
+
+<pre lang="Python">    rank = col[0].string
+    artist = col[1].string
+    album = col[2].string
+    cover_link = col[3].img['src']</pre>
+
+
+
+<p>The ".string" object will return the text within the target tag (similar to javascript's innerHTML method). But in the case of something like the cover art, which is an image tag, not a string value, we can step down to the next tag nested within the td column -- img -- and access its source attribute by tacking on ['src']. This would work just the same for a hyperlink (.a['href']) or any other attibute. And if you've got multiple layers of nested tags, you can simply step down through them with a linked set of objects. For example, "b.a.string" would retrieve the string within a link within a bold tag. There's great documentation on these and other Beautiful Soup tricks <a href="http://www.crummy.com/software/BeautifulSoup/documentation.html">here</a>. </p>
+
+
+
+<p>After we've wrangled out the data we want from the HTML, the only challenge remaining is to print it out. I accomplish that above by loading the column values into a list called record and printing it out use a trick that will print them with a pipe-delimiter using the .join method.</p>
+
+
+
+<pre lang="Python">
+    record = (rank, artist, album, cover_link)
+    print "|".join(record)
+</pre>
+
+
+
+<p>Phew. That's a lot of explaining. I hope it made sense. I'm happy to clarify or elaborate on any of it. But if you save the snippet above and run it. You should get a simple print out of the data that looks something like this:</p>
+
+
+
+<pre lang="bash">10|LCD Soundsystem|Sound of Silver|http://www.palewire.com/scrape/albums/covers/sound%20of%20silver.jpg
+9|Ulrich Schnauss|Goodbye|http://www.palewire.com/scrape/albums/covers/goodbye.jpg
+8|The Clientele|God Save The Clientele|http://www.palewire.com/scrape/albums/covers/god%20save%20the%20clientele.jpg
+7|The Modernist|Collectors Series Pt. 1: Popular Songs|http://www.palewire.com/scrape/albums/covers/collectors%20series.jpg
+6|Bebel Gilberto|Momento|http://www.palewire.com/scrape/albums/covers/memento.jpg
+5|Various Artists|Jay Deelicious: 1995-1998|http://www.palewire.com/scrape/albums/covers/jaydeelicious.jpg
+4|Lindstrom and Prins Thomas|BBC Essential Mix|http://www.palewire.com/scrape/albums/covers/lindstrom%20prins%20thomas.jpg
+3|Go Home Productions|This Was Pop|http://www.palewire.com/scrape/albums/covers/this%20was%20pop.jpg
+2|Apparat|Walls|http://www.palewire.com/scrape/albums/covers/walls.jpg
+1|Caribou|Andorra|http://www.palewire.com/scrape/albums/covers/andorra.jpg</pre>
+
+
+
+<p>See the difference?! Pretty cool, right?</p>
+
+
+
+<p>But, really, you could of done that with copy and paste. Or, if you're slick, maybe even <a href="http://articles.techrepublic.com.com/5100-10877_11-6115870.html?part=rss&tag=feed&subj=tr">Excel's Web Query</a>.</p>
+
+
+
+<p>As with our previous recipes, the real efficiencies aren't found until you can train your computer to repeat a task over a large body of data. One of the great things mechanize can do is step through pages one by one and help Beautiful Soup suck the data out of each. This is very helpful when you're trying to scrape the search results from online web queries, which are commonly displayed in paginated sets that run into hundreds and hundreds of pages.</p>
+
+
+
+<p>Today's example is only two pages in length, though the principles we learn here can later be applied to broader data sets. But before we can run, we have to learn how to walk. So, in that spirit, here's a simple expansion of our script above that will click on the "Next" link at the bottom of our example page and repeat the scrape on <a href="http://www.palewire.com/scrape/albums/2006.html">my 2006 list</a>.</p>
+
+
+
+<pre lang="Python">#!/usr/bin/env python
+from mechanize import Browser
+from BeautifulSoup import BeautifulSoup
+
+def extract(soup, year):
+    table = soup.find("table", border=1)
+    for row in table.findAll('tr')[1:]:
+        col = row.findAll('td')
+        rank = col[0].string
+        artist = col[1].string
+        album = col[2].string
+        cover_link = col[3].img['src']
+        record = (str(year), rank, artist, album, cover_link)
+        print "|".join(record)
+
+mech = Browser()
+url = "http://www.palewire.com/scrape/albums/2007.html"
+page1 = mech.open(url)
+html1 = page1.read()
+soup1 = BeautifulSoup(html1)
+extract(soup1, 2007)
+page2 = mech.follow_link(text_regex="Next")
+html2 = page2.read()
+soup2 = BeautifulSoup(html2)
+extract(soup2, 2006)</pre>
+
+
+
+<p>Note that our Beautiful Soup snippet remains the same as above, but we've moved it to the top of the script and placed it in a <a href="http://www.penzilla.net/tutorials/python/functions/">Python function</a> called extract. Structured this way, the extract function is reusable on any number of pages as long as the HTML you're looking to parse is formatted the same way. </p>
+
+
+
+<p>The function accepts two parameters, soup and year, which are passed in the lower part of our script after Beautiful Soup captures each page's contents. The first snippet ...</p>
+
+
+
+<pre lang="Python">page1 = mech.open(url)
+html1 = page1.read()
+soup1 = BeautifulSoup(html1)
+extract(soup1, 2007)</pre>
+
+
+
+<p>...essentially does the same thing as our early versions: visits the URL for my 2007 list and parses out the table. The only change is that the soup variable is now being passed to the extract function along with the year, so that it can be printed alongside the data columns in our output by adding it to the "record" list inside the function here:</p>
+
+
+
+<pre lang="Python">        record = (str(year), rank, artist, album, cover_link)</pre>
+
+
+
+<p>I figured it's a nice add since then our eventual results will contain a field that discerns the 2007 list from the 2006 list. </p>
+
+
+
+<p>Now check out easy it is to get mechanize to step through to the next page.</p>
+
+
+
+<pre lang="Python">page2 = mech.follow_link(text_regex="Next")
+html2 = page2.read()
+soup2 = BeautifulSoup(html2)
+extract(soup2, 2006)</pre>
+
+
+
+<p>All it takes is feeding the link's string value to mechanize's follow_link() method and, boom, you're walking over to the next page. Treat what you get back the same as we did our first "page" and, bam, you've done it. Save the script, run it, and you should see something more like this:</p>
+
+
+
+<pre lang="Bash">2007|10|LCD Soundsystem|Sound of Silver|http://www.palewire.com/scrape/albums/covers/sound%20of%20silver.jpg
+2007|9|Ulrich Schnauss|Goodbye|http://www.palewire.com/scrape/albums/covers/goodbye.jpg
+2007|8|The Clientele|God Save The Clientele|http://www.palewire.com/scrape/albums/covers/god%20save%20the%20clientele.jpg
+2007|7|The Modernist|Collectors Series Pt. 1: Popular Songs|http://www.palewire.com/scrape/albums/covers/collectors%20series.jpg
+2007|6|Bebel Gilberto|Momento|http://www.palewire.com/scrape/albums/covers/memento.jpg
+2007|5|Various Artists|Jay Deelicious: 1995-1998|http://www.palewire.com/scrape/albums/covers/jaydeelicious.jpg
+2007|4|Lindstrom and Prins Thomas|BBC Essential Mix|http://www.palewire.com/scrape/albums/covers/lindstrom%20prins%20thomas.jpg
+2007|3|Go Home Productions|This Was Pop|http://www.palewire.com/scrape/albums/covers/this%20was%20pop.jpg
+2007|2|Apparat|Walls|http://www.palewire.com/scrape/albums/covers/walls.jpg
+2007|1|Caribou|Andorra|http://www.palewire.com/scrape/albums/covers/andorra.jpg
+2006|10|Lily Allen|Alright, Still|http://www.palewire.com/scrape/albums/covers/alright%20still.jpg
+2006|9|Nouvelle Vague|Nouvelle Vague|http://www.palewire.com/scrape/albums/covers/nouvelle%20vague.jpg
+2006|8|Bookashade|Movements|http://www.palewire.com/scrape/albums/covers/movements.jpg
+2006|7|Charlotte Gainsbourg|5:55|http://www.palewire.com/scrape/albums/covers/555.jpg
+2006|6|The Drive-By Truckers|The Blessing and the Curse|http://www.palewire.com/scrape/albums/covers/blessing%20and%20curse.jpg
+2006|5|Basement Jaxx|Crazy Itch Radio|http://www.palewire.com/scrape/albums/covers/crazy%20itch%20radio.jpg
+2006|4|Love is All|Nine Times The Same Song|http://www.palewire.com/scrape/albums/covers/nine%20times.jpg
+2006|3|Ewan Pearson|Sci.Fi.Hi.Fi_01|http://www.palewire.com/scrape/albums/covers/sci%20fi%20hi%20fi.jpg
+2006|2|Neko Case|Fox Confessor Brings The Flood|http://www.palewire.com/scrape/albums/covers/fox%20confessor.jpg
+2006|1|Ellen Allien & Apparat|Orchestra of Bubbles|http://www.palewire.com/scrape/albums/covers/orchestra%20of%20bubbles.jpg</pre>
+
+
+
+<p>Now all that's left on our checklist is to figure out a way to download the cover art in addition to recording the urls. When we're interested in just snatching a simple file off the web, I like to use the urlretrieve() function found in Python's urlib module. All you have to do is add it to your import line, as below, and tell it where to save the files. I just stuff it in the extract loop so it pulls down the file immediately after scraping its row in the table. Check it out.</p>
+
+
+
+<pre lang="Python">#!/usr/bin/env python
+from mechanize import Browser
+from BeautifulSoup import BeautifulSoup
+import urllib, os
+
+def extract(soup, year):
+    table = soup.find("table", border=1)
+    for row in table.findAll('tr')[1:]:
+        col = row.findAll('td')
+        rank = col[0].string
+        artist = col[1].string
+        album = col[2].string
+        cover_link = col[3].img['src']
+        record = (str(year), rank, artist, album, cover_link)
+        print >> outfile, "|".join(record)
+        save_as = os.path.join("./", album + ".jpg")
+        urllib.urlretrieve("http://www.palewire.com" + cover_link, save_as)
+        print "Downloaded %s album cover" % album
+
+outfile = open("albums.txt", "w")
+mech = Browser()
+url = "http://www.palewire.com/scrape/albums/2007.html"
+page1 = mech.open(url)
+html1 = page1.read()
+soup1 = BeautifulSoup(html1)
+extract(soup1, 2007)
+page2 = mech.follow_link(text_regex="Next")
+html2 = page2.read()
+soup2 = BeautifulSoup(html2)
+extract(soup2, 2006)
+outfile.close()</pre>
+
+<p>While I was at it, I also added in an outfile where the scrape results are saved in a text file, just like we did in our previous recipes. Run this version and then check out your working directory, where you should see all the images as well as the new outfile.</p>
+
+
+
+<p>Voila. I think we're done. If this is useful for people, next time we can cover how you leverage these basic tools against search forms and larger result sets. Per usual, if you spot a screw up, or I'm not being clear, just shoot me an email or drop a comment and we'll sort it out. Hope this is helpful to somebody.</p>
+
+
+
+<p>And, as a postscript, since we're kind of on a roll here, I thought it might be fun to cook up an LAT version of the <a href="http://www.oreilly.com/catalog/pythoncook/">Python Cookbook</a> cover, in the classic O'Reilly style. What do you think? I couldn't quite find the right font.</p>
+
+
+
+<img src="http://www.palewire.com/images/oreilly_lat.gif" alt="The Reporter's Python Cookbook" border=1/>

--- a/coltrane/content/posts/2008-04-21--python-recipe-print-a-future-date-in-the-format-you-want.md
+++ b/coltrane/content/posts/2008-04-21--python-recipe-print-a-future-date-in-the-format-you-want.md
@@ -1,0 +1,26 @@
+---
+title: 'Python Recipe: Print a future date in the format you want'
+slug: python-recipe-print-a-future-date-in-the-format-you-want
+published_at: '2008-04-21T10:31:59-07:00'
+wordpress_id: 109
+---
+<p>Enough with all the talky talky, here's a simple snippet I cooked up for a friend this morning to solve his problem of the moment: how to coax Python into printing out a future date (6 weeks in the future, to be exact) in the format he wants. Hope it's useful to somebody. Let me know if I screwed anything up.</p>
+
+
+
+<pre lang="Python">
+>>> import datetime
+>>> now = datetime.datetime.now()
+>>> print now
+2008-04-21 10:19:35.832928
+>>> from datetime import timedelta
+>>> diff = datetime.timedelta(days=42)
+>>> print diff
+42 days, 0:00:00
+>>> print now + diff
+2008-06-02 10:19:35.832928
+>>> future = now + diff
+>>> future.strftime("%m/%d/%Y")
+'06/02/2008'</pre>
+
+<p>Documentation on how you can customize strftime to print dates in the format you need can be found <a href="http://docs.python.org/lib/module-time.html">here</a>. Scroll down to the middle-ish part of the page.</p>

--- a/coltrane/content/posts/2008-04-26--python-recipe-connect-to-mysql-database-execute-a-query-print-the-results.md
+++ b/coltrane/content/posts/2008-04-26--python-recipe-connect-to-mysql-database-execute-a-query-print-the-results.md
@@ -1,0 +1,192 @@
+---
+title: 'Python Recipe: Connect to MySQL, query, print the results'
+slug: python-recipe-connect-to-mysql-database-execute-a-query-print-the-results
+published_at: '2008-04-26T10:28:57-07:00'
+wordpress_id: 112
+---
+<p>Today let's take a look at how you can use Python to connect to your MySQL database, issue a SQL query and do things with the results.</p>
+
+<p>It's not that hard to write a simple SQL command by hand and muck with the results, so why bother? Like earlier recipes, our reward will be saving time and energy by automating a task that would normally require manual labor. It becomes clear when you bump into something you need to do 500 times, or make part of your daily routine.</p>
+
+<p>For example, one thing I try to do at work is keep documentation related to all of my datasets. I keep a series of wiki pages devoted to each database that lists its data sources, explains its origins, catalogs helpful SQL snippets and defines the fields in each table.</p>
+
+<p>The wiki application I use -- <a href="http://twiki.org/">TWiki</a> -- accepts HTML code and the convention I've settled on is to format each table's field definitions in a standard set of <a href="http://www.w3schools.com/tags/tag_table.asp">table tags</a>. So every time I add a new MySQL table and want to document it, I need to build another HTML table for the wiki. That's a pain to do by hand, especially when the table has a lot of fields. To save Ben the trouble, let's write a simple Python script that will...</p>
+
+<ol>
+	<li>Log into the MySQL database</li>
+	<li>Acquire the list of columns from a MySQL table</li>
+	<li>Print the columns out in an HTML table</li>
+</ol>
+
+<p>It's not very exciting, but it'll introduce you to the basics. And once you start walking you'll quickly be able to run.</p>
+
+<h2>1. Install the MySQLdb module.</h2>
+
+<p>Before you can tap into your MySQL db with Python, you need to install the "MySQL for Python" module (a.k.a. MySQLdb). The file is found <a href="http://sourceforge.net/projects/mysql-python/">here</a>, and, while I haven't tested it, it looks like there's a .exe installer for you Windows kids. There's also a nice stab and cataloging different methods <a href="http://docs.turbogears.org/1.0/DatabaseMySQL">here</a>. If, like me, you're running Ubuntu Linux, installation is as simple as opening GNOME's package manager and selecting the "python-mysqldb" package, or running an "apt-get" from your terminal.</p>
+
+<p>You can test whether its been properly installed by opening up your python shell and trying to import the module. So fire up the shell...</p>
+
+<pre lang="Bash">python</pre>
+
+<p>...and pop it off...</p>
+
+<pre lang="Python">Python 2.5.1 (r251:54863, Mar  7 2008, 04:10:12)
+[GCC 4.1.3 20070929 (prerelease) (Ubuntu 4.1.2-16ubuntu2)] on linux2
+Type "help", "copyright", "credits" or "license" for more information.
+>>> import MySQLdb
+>>> </pre>
+
+<p>If the interpreter accepts the commands and kicks down the next line without an error, you know you're okay. If it throws an error, you know something is off.</p>
+
+<h2>2. Open the command line, create a working directory, move there.</h2>
+
+<p>Before we get going, let me just say that I'm going to assume you read the first couple recipes and won't be working too hard to explain the stuff covered there. And keep in mind that my keystrokes are coming right off my home computer, which runs Ubuntu Linux. I'll try to provide Mac and Windows translations as we go, but I might muck a phoneme here and there. If anything is screwed up and doesn't work on your end, just shoot me an email or drop a comment. We'll iron it out.</p>
+
+<p>We're going to start the same way we did in the first lessons, creating a working folder for all our files and moving in with our command line.</p>
+
+<pre lang="Python">cd Documents/
+mkdir py-connect-to-mysql
+cd py-connect-to-mysql/</pre>
+
+<p>The commands should work just as easily in Mac as in Linux. If you're working in Windows, you'll be on the C:/ file structure, rather than the Unix-style structure above. So you might mkdir a new working directory in your C:/TEMP folder or wherever else you'd like to work. Or just make a folder wherever through Windows Explorer and cd there after the fact through the command line.</p>
+
+<h2>3. Create our python script in the text editor of your choice.</h2>
+
+<pre lang="Bash">vim py-connect-to-mysql.py</pre>
+
+<p>The line above, which again should work for Linux or Mac, will open a new file in <a href="http://www.google.com/url?sa=t&amp;ct=res&amp;cd=1&amp;url=http%3A%2F%2Fwww.vim.org%2F&amp;ei=uzoESIj8LKnmpgTRy43VBw&amp;usg=AFQjCNE8C6iOb5uQLy74YKg-WBd9hikKaw&amp;sig2=vP2XqMTTDBFF49Gy22gxJQ">vim</a>, the command-line text editor that I prefer. You can follow along, or feel free to make your own file in the application you prefer. If you're a newbie Windows user, <a href="http://www.google.com/url?sa=t&amp;ct=res&amp;cd=1&amp;url=http%3A%2F%2Fen.wikipedia.org%2Fwiki%2FNotepad&amp;ei=zToESKWNL4uqpwT2k73dBw&amp;usg=AFQjCNEXWgXDcow8vXjueJBIOmWghv1lhw&amp;sig2=aDintKlEbbRHHWcaHXoz1w">Notepad</a> should work great.</p>
+
+<p>If you're following along in vim, you'll need to enter "insert mode" so you can start entering text. Do that by hitting:</p>
+
+<pre lang="Bash">i</pre>
+
+<h2>4. Write the code!</h2>
+
+<pre lang="Python" line="1">#!/usr/bin/env python
+import sys, MySQLdb
+
+def PrintFields(database, table):
+    """ Connects to the table specified by the user and prints out its fields in HTML format used by Ben's wiki. """
+    host = 'localhost'
+    user = 'user'
+    password = 'password'
+    conn = MySQLdb.Connection(db=database, host=host, user=user, passwd=password)
+    mysql = conn.cursor()
+    sql = """ SHOW COLUMNS FROM %s """ % table
+    mysql.execute(sql)
+    fields=mysql.fetchall()
+    print '<table border="0"><tr><th>order</th><th>name</th><th>type</th><th>description</th></tr>'
+    print '<tbody>'
+    counter = 0
+    for field in fields:
+        counter = counter + 1
+        name = field[0]
+        type = field[1]
+        print '<tr><td>' + str(counter) + '</td><td>' + name + '</td><td>' + type + '</td><td></td></tr>'
+    print '</tbody>'
+    print '</table>'
+    mysql.close()
+    conn.close()
+
+users_database = sys.argv[1]
+users_table = sys.argv[2]
+print "Wikified HTML for " + users_database + "." + users_table
+print "========================"
+PrintFields(users_database, users_table)</pre>
+
+<p>Obviously, the first thing you need to do is import the modules we need. The <a href="http://docs.python.org/lib/module-sys.html">"sys" module</a> will allow us to accept inputs from the command line later, and our new friend, MySQLdb, will help us connect to the database. </p>
+
+<p>Then you can see that the bulk of the script is taken up by a function, named PrintFields, that extends from line four to line 32. That contains all of the card tricks we'll need to connect to our local db, run a query and print it out however we want. In this case, we're spitting out the data in an HTML shell I've concocted to create a complete table when it's all done. </p>
+
+<p>After the loop closes at line 32, the remainder of the script uses sys to grab the first two arguments passed in by the user and hand them over to the function. So this way, by providing the database and table names at the time of execution, I can ask the script to print out the fields from any table I've got. For instance, we can print out the generic time_zone table that comes MySQL's "mysql" settings database like so...</p>
+
+<pre lang="Bash">python py-connect-to-mysql.py mysql time_zone</pre>
+
+<p>And you should get something like ...</p>
+
+<pre lang="Bash">Wikified HTML for mysql.time_zone
+========================
+<table border="0"><tr><th>order</th><th>name</th><th>type</th><th>description</th></tr>
+<tbody>
+<tr><td>1</td><td>Time_zone_id</td><td>int(10) unsigned</td><td></td></tr>
+<tr><td>2</td><td>Use_leap_seconds</td><td>enum('Y','N')</td><td></td></tr>
+</tbody>
+</table></pre>
+
+<p>Then what I'd normally do is just copy and paste that into my wiki. The script doesn't have any error handling or fancy tricks, which I think makes it a good starter example on the basics. Let's pull out the things you'll need to know. So let's walk through a few of them.</p>
+
+<pre lang="Python" line="7">
+    host = 'localhost'
+    user = 'user'
+    password = 'password'
+</pre>
+
+<p>This first snippet contains all the local information about your MySQL that will need to be customized to fit your rig. You'll need to change the definitions for user and password to whatever it is you use. And if the database you want to tap isn't on your localhost, but perhaps networked elsewhere, you'll need to change the host definition to its IP address or alias.</p>
+
+<pre lang="Python" line="10">
+    conn = MySQLdb.Connection(db=database, host=host, user=user, passwd=password)
+    mysql = conn.cursor()
+</pre>
+
+<p>Then this next step will pass all of your local specifics to MySQLdb and open up a "cursor." You can use that to interact with the database in the same way you normally would with Microsoft Access or another piece of <a href="http://en.wikipedia.org/wiki/Graphical_user_interface">GUI software</a>. A lot of people might name the variable containing the cursor as "cursor," but it really doesn't matter. As seen above, I like to name it mysql. It's just personal preference. Notice that we didn't define the database variable in the earlier snippet. That's because it's being passed into the function by the user. We know that because it's up there at the top of our function...</p>
+
+<pre lang="Python" line="4">def PrintFields(database, table):</pre>
+
+<p>...and fed in at the bottom after we capture the user input with sys...</p>
+
+<pre lang="Python" line="34">users_database = sys.argv[1]</pre>
+
+<p>...and then passed in with our function call...</p>
+
+<pre lang="Python" line="38">PrintFields(users_database, users_table)</pre>
+
+<p>But what the hell is in that argv variable, anyway? Let's find out. I'm going to edit our script to include the following line...</p>
+
+<pre lang="Python">print sys.argv</pre>
+
+<p>...run the script again...</p>
+
+<pre lang="Bash">python py-connect-to-mysql.py mysql time_zone</pre>
+
+<p>...and here's what we get...</p>
+
+<pre lang="Bash">['py-connect-to-mysql.py', 'mysql', 'time_zone']</pre></pre>
+
+<p>Pretty self-explanatory, right? Now back to our function.</p>
+
+<pre lang="Python" line="13">
+    sql = " SHOW COLUMNS FROM %s " % table
+    mysql.execute(sql)
+</pre>
+
+
+
+<p>With our connection set, the next thing to do is to use MySQL to run a query. I do it by storing a SQL command in a variable and then passing it to to MySQLdb execute function. You'll note that I use Python's magic "%s" command to write in the contents of the table variable, which, like the database variable, has been passed into the function by the user. By doing that, we're now able to run that same SHOW COLUMNS command on whatever database and table combination we pass in. Provided the table actually exists. </p>
+
+
+
+<p>It's simple tricks like that which will enable you to really start flying with automation. What if your job required you to kick out data reports for each or any of the 50 states on command, or if you wanted to automate a web scrape to deposit its findings in your database every time it runs, or maybe even make an RSS feed that updates every 15 minutes. A simple concept like this, which allows for some of the SQL specifics to be specified programmatically, could save you a ton of time.</p>
+
+
+
+<pre lang="Python" line="16">   fields=mysql.fetchall()</pre>
+
+
+
+<p>This next line will store the results of the query in a variable called fields, which we'll print out using one of the simple loops I covered in <a href="http://www.palewire.com/2008/04/05/python-recipe-open-a-file-read-through-it-print-each-line-matching-a-search-term/">previous recipes</a>, pulling out the first and second fields (name and datatype) for my table. You could take a look what's in the list by printing it out to your terminal before running the loop. Let's try that by adding...</p>
+
+
+
+<pre lang="Python">print fields</pre>
+
+
+
+<p>...to our script. Run it again from the top and now you'll get the ...</p>
+
+
+
+<pre lang="Bash">(('Time_zone_id', 'int(10) unsigned', 'NO', 'PRI', None, 'auto_increment'), ('Use_leap_seconds', "enum('Y','N')", 'NO', '', 'N', ''))</pre>
+
+
+
+<p>Since I don't want all of the settings for my docs, just the name and field type, as we loop through each row I only pull out the first two items (field[0], field[1]). All the rest of the mess around there is designed to print out the data in my custom HTML shell, which really shouldn't matter for your purposes, so why bother here. So, what the hell, I think we're done. Per usual, if you spot a screw up, or I'm not being clear, just shoot me an email or drop a comment and we'll sort it out. Hope this is helpful to somebody.</p>

--- a/coltrane/content/posts/2008-04-27--ubuntu-recipe-how-to-automagically-post-you-lastfm-feed-to-twitter.md
+++ b/coltrane/content/posts/2008-04-27--ubuntu-recipe-how-to-automagically-post-you-lastfm-feed-to-twitter.md
@@ -1,0 +1,83 @@
+---
+title: 'Ubuntu Recipe: Post your Last.fm feed to Twitter'
+slug: ubuntu-recipe-how-to-automagically-post-you-lastfm-feed-to-twitter
+published_at: '2008-04-27T12:12:13-07:00'
+wordpress_id: 114
+---
+<p>I signed up for Twitter this morning, opening an account at <a href="http://twitter.com/palewire">http://twitter.com/palewire</a>. Since I haven't seen or heard from my cell phone in a week or two, don't count on much on the scene reporting. But I did take a few minutes this morning to line up <a href="http://www.last.fm/user/palewire">my Last.fm feed</a>, so that my lastest listenings are now automatically Twittered to the huddled masses yearning to have my musical taste shoved down their throat.</p>
+
+
+
+<p>For any other Ubuntu users who'd like to follow along, here's a quick recap on how I made it happen.</p>
+
+
+
+<p>1. Move to the folder where you store random scripts. Me, I use...</p>
+
+
+
+<pre lang="bash">cd /usr/local/bin</pre>
+
+
+
+<p>2. Create a new Perl script and open it in gedit.</p>
+
+
+
+<pre lang="bash">sudo gedit twitter_fm.pl</pre>
+
+
+
+<p>3. Copy and paste in the <a href="http://walterhiggins.net/lastfm_to_twitter.html">ready-to-serve code</a> provided by Walter Higgins.</p>
+
+
+
+<p>4. Edit in your Twitter and Last.fm login information. Save and exit the file.</p>
+
+
+
+<p>5. Create a new shell script.</p>
+
+
+
+<pre lang="bash">sudo gedit twitter_fm.sh</pre>
+
+
+
+<p>6. Paste in the following, editing the folder structure to reflect wherever you stuck your steez.</p>
+
+
+
+<pre lang="shell">#!/bin/sh
+
+
+
+perl /usr/local/bin/twitter_fm.pl</pre>
+
+
+
+<p>7. Set the shell script so it becomes executable.</p>
+
+
+
+<pre lang="bash">sudo chmod +x twitter_fm.sh</pre>
+
+
+
+<p>8. Navigate through the System>Preferences>Session menu as described <a href="http://www.howtogeek.com/howto/ubuntu/how-to-add-a-program-to-the-ubuntu-startup-list-after-login/">here</a> and add the shell script to your startup processes.</p>
+
+
+
+<p>9. Restart!</p>
+
+
+
+<p>I just patched this mess together a couple minutes ago, so there might be some bugs. Either in my setup or in Walter's script. Don't know yet. Let me know if you see anything idiotic on my part. </p>
+
+
+
+<p>I also installed Wordpress's <a href="http://wordpress.org/extend/plugins/twitter-tools/">Twitter Tools</a> plugin, so now my latest blog posts will also be sent out via Twitter.</p>
+
+
+
+<p>Also on the Twitter tip, earlier this week we launched a feed at work for our popular political blog, <a href="http://latimesblogs.latimes.com/washington/">Top of the Ticket</a>. It includes the latest posts from our team of writers, and, on election nights, live election results as they come in. You can sign up <a href="http://twitter.com/latimestot">here</a>. For anyone looking to reroute their own data streams to Twitter, I can't recommend Chris Thompon's <a href="http://search.cpan.org/~cthom/Net-Twitter-1.06/lib/Net/Twitter.pm">Net::Twitter</a>  Perl module enough. Easy. Peasy.</p>

--- a/coltrane/content/posts/2008-05-18--bill-oreilly-flips-out-the-ringtone.md
+++ b/coltrane/content/posts/2008-05-18--bill-oreilly-flips-out-the-ringtone.md
@@ -1,0 +1,19 @@
+---
+title: Bill O'Reilly Flips Out, The Ringtone
+slug: bill-oreilly-flips-out-the-ringtone
+published_at: '2008-05-18T22:04:00-07:00'
+wordpress_id: 119
+---
+<p>I must admit, I've fallen in love with <a href="http://www.youtube.com/watch?v=2tJjNVVwRCY">that amazing video</a> of Bill O'Reilly flipping out during his old Inside Edition days. Especially <a href="http://www.youtube.com/watch?v=5j2YDq6FkVE">the hot remix</a>. So, in homage, I've cut down the first 20 seconds into an mp3 file that should be easily portable as a ringtone to your smart phone of choice. Be it <a title="Instructions for you." href="http://www.wired.com/software/coolapps/news/2007/09/ringtone_hacks">iPhone</a>, <a title="Instructions for you." href="http://www.palminfocenter.com/news/9606/how-to-add-mp3-ringtones-on-your-treo/">Treo</a>,  <a title="Instructions for you." href="http://thinkhole.org/wp/2006/06/26/howto-make-your-own-mp3-ringtones/">Motorola</a>, <a title="Instructions for you." href="http://stephenjungels.com/jungels.net/articles/nokia-verizon-ringtone-hacking.html">Nokia or LG</a>.</p>
+
+
+
+<p>Just right click the file below and save it to your computer. After that, you're on your own.</p>
+
+
+
+<ul>
+
+	<li><strong><a href="/media/mp3/bill_oreilly_do_it_live_remix.mp3">Bill O'Reilly Flips Out, The Ringtone.mp3</a></strong></li>
+
+</ul>

--- a/coltrane/content/posts/2008-05-19--la-red-light-cameras-on-your-tomtom-or-garmin.md
+++ b/coltrane/content/posts/2008-05-19--la-red-light-cameras-on-your-tomtom-or-garmin.md
@@ -1,0 +1,41 @@
+---
+title: LA red light cameras on your TomTom or Garmin
+slug: la-red-light-cameras-on-your-tomtom-or-garmin
+published_at: '2008-05-19T07:53:02-07:00'
+wordpress_id: 120
+---
+<p>Today our A1 features <a href="http://www.latimes.com/news/local/la-me-redlight19-2008may19,0,5321069.story">Rich Connell's look</a> at the effectiveness of all those automated red light cameras positioned around Los Angeles. Here's the nut:</p>
+
+
+
+<blockquote>In Los Angeles, officials estimate that 80% of red light camera tickets go not to those running through intersections but to drivers making rolling right turns, a Times review has found.</blockquote>
+
+
+
+<blockquote>
+
+One of the most powerful selling points for photo enforcement systems, which now monitor 175 intersections in Los Angeles County and hundreds more across the United States, has been the promise of reducing collisions caused by drivers barreling through red lights.</p>
+
+<br><br>
+
+But it is the right-turn infraction -- a frequently misunderstood and less pressing safety concern -- that drives tickets and revenue in the nation's second-biggest city and at least half a dozen others across the county.</blockquote>
+
+
+
+<p>Our web package includes some <a href="http://www.latimes.com/news/local/la-me-redlight-vid,0,1506317.worldnowvideo">hot tape</a> put together by Rich, an awesome <a href="http://www.latimes.com/news/local/la-me-redlight12-2008may12-f,0,2138553.flash">interactive explainer</a> by Raoul Ranoa, the now perfunctory <a href="http://www.google.com/maps/ms?ie=UTF8&amp;hl=en&amp;msa=0&amp;msid=117631292961056724014.00044d231a97bc45a81a3&amp;ll=34.232242,-118.218384&amp;spn=0.967344,1.702881&amp;t=p&amp;z=9">Google Map</a>, and my own little goofy idea: portable downloads for TomTom and Garmin GPS devices (check out the roadblock halfway down <a href="http://www.latimes.com/news/local/la-me-redlight19-2008may19,0,5321069.story">the main story</a>).</p>
+
+
+
+<p>Loading the points into your device will not only map them on your dashboard monitor -- but you can also easily program your system to give you an audio warning as you approach upcoming lights. And in that same soothing computer voice that already tells you when to turn.</p>
+
+
+
+<p>I'm not sure how interested readers will be in this sort of product, but it seemed like a fun experiment. And since Rich had put in a great effort collecting the data from LA's many fragmented municipalities, it seemed like we had to look for some extra yard to go for.</p>
+
+
+
+<p>The technical part is pretty easy. Both manufacturers have handy developer guides that -- once the data is prepared -- only take a couple hours to suss out. Here's <a href="http://www.tomtom.com/addto/">TomTom</a>. Here's <a href="http://www8.garmin.com/products/poiloader/">Garmin</a>.</p>
+
+
+
+<p>Any thoughts on other newspapery data projects that might work for GPS? The most dangerous intersections? The location of famous landmarks around town?</p>

--- a/coltrane/content/posts/2008-05-26--californias-war-dead.md
+++ b/coltrane/content/posts/2008-05-26--californias-war-dead.md
@@ -1,0 +1,35 @@
+---
+title: California's War Dead
+slug: californias-war-dead
+published_at: '2008-05-26T15:08:59-07:00'
+wordpress_id: 122
+---
+<p>This Memorial Day weekend marked the formal launch of <a href="http://projects.latimes.com/wardead/">California's War Dead</a>, our database of the state's casualties from the wars in Afghanistan and Iraq. It's the result of a lot of hard work by many people at the paper, a large share of which had already been carried through the years by our many obituary writers.</p>
+
+
+
+<p>The site intends to allow users to explore the data using a variety of criteria (for example, you can quickly look up fallen troops by <a href="http://projects.latimes.com/wardead/hometown">hometown</a>, <a href="http://projects.latimes.com/wardead/high-school/">high school</a> or <a href="http://projects.latimes.com/wardead/marital-status/">marital status</a>). And to learn more about individuals by reading their obituaries from our back archives. Choice quotes have been selected to "pop" out of the individual profile pages and visitors are encouraged to leave memories and thoughts as comments.</p>
+
+
+
+<p>Besides all my coworkers who pitched in to make this happen on a tight deadline, thank yous should be extended to all the great developers in <a href="http://www.google.com/url?sa=t&amp;ct=res&amp;cd=1&amp;url=http%3A%2F%2Fwww.djangoproject.com%2F&amp;ei=YCo7SN7vJpGqsAOzmvW2DQ&amp;usg=AFQjCNGfxYhHSLrgk6aVrm5Bbc2ozc89rA&amp;sig2=Qb22Q47-imtI1Y6zxu-gFA">the Django community</a>. They not only provided the Web programming tools that made this idea possible, but also the <a href="http://holovaty.com/blog/archive/2006/09/06/0307/">leadership</a> that showed me how the tools can be used to make journalism <em>for</em> the Web, not just <em>on</em> the Web. The same goes for all the people in <a href="http://www.google.com/url?sa=t&amp;ct=res&amp;cd=1&amp;url=http%3A%2F%2Fwww.nicar.org%2F&amp;ei=ZSs7SKncIZmIsAPhnv27DQ&amp;usg=AFQjCNFv1OMXDU_2U5mOn6I-DfJcHnfT7Q&amp;sig2=It6TrOcpwh1486leIvWaAw">the NICAR community</a> who, by leading by example, have pushed me to keep learning new things and have the courage to take chances outside of journalism's well worn comfort zones. Personally, I just hope that first group can forgive me for ripping off their ideas and that the second group doesn't resent my getting the opportunity to do things like this without having to put in the once requisite 5 to 10 years on the cops-and-courts beat.</p>
+
+
+
+<p>If you're stretched for time, or maybe doubting there's anything new to be learned about the war, let me promote a couple spots that might interest you.</p>
+
+<ul>
+
+	<li>Over the course of assembling the data, I was surprised to learn how many immigrants to California have died. It's more than fifty, from Mexico and the Phillipines and South Korea and a number of other places. Check out the lists <a href="http://projects.latimes.com/wardead/country-of-birth/mexico/">here</a>. A fascinating story is of Sgt. Rafael Peralta of San Diego, who enlisted the same day he received his Green Card and died in Fallouja, Iraq, when he sacrificed himself to save his compatriots from a grenade attack. His profile is <a href="http://projects.latimes.com/wardead/name/rafael-peralta/">here</a> and the story of his heroic death is <a href="http://articles.latimes.com/2004/dec/06/local/me-marine6">here</a>.</li>
+
+
+
+	<li>The most rewarding part of the project for me has been to see how quickly we're getting great, thoughtful comments submitted by friends and family members of the deceased. One of my goals in the design was to give their writing equal footing with our previous reporting. It can be heartbreaking to read, but I'm proud to have helped make something that people think is worthy of such sensitive information. Examples I find particularly moving are the memories shared by the family of <a href="http://projects.latimes.com/wardead/name/jason-j-buzzard/">Sgt. Jason J. Buzzard</a> of Ukiah and <a href="http://projects.latimes.com/wardead/name/christopher-d-leon/">Corporal Christopher D. Leon</a> of Lancaster, who I'm honored to know better now than I did before our commentors contributed.</li>
+
+
+
+	<li>It seems natural to expect that spending so much time with casualty data would have a numbing effect. But I think that's only the case when we let the very real people we've lost remain numbers in a casualty count or unknown names on a page. It's the stories that bring them to life, and my experience has been that the more stories you hear, the less numb you feel. The pain is in the details. A moving example is <a href="http://articles.latimes.com/2007/02/16/local/me-daily16">Teresa Watanabe's obituary</a> of <a href="http://projects.latimes.com/wardead/name/mark-j-daily/">Lt. Mark J. Daily</a> of Irvine, who was inspired to join the war by the political writing of war advocate Christopher Hitchens. Hitchens has since gone to write a moving response to learning of Daily's readership, and sacrifice, that you can find <a href="http://www.vanityfair.com/politics/features/2007/11/hitchens200711">here</a>.</li>
+
+	<li>Finally, I'd suggest checking out <a href="http://www.latimes.com/video/?autoStart=true&amp;topVideoCatNo=default&amp;clipId=2521929">the video of California's Riverside Cemetery</a> by the LAT's Saatchi Cunningham. Riverside is home to dozens of veterans of Iraq and Afghanistan, the top resting place in the state.</li>
+
+</ul>

--- a/coltrane/content/posts/2008-06-01--bens-hip-hop-twitter-bot.md
+++ b/coltrane/content/posts/2008-06-01--bens-hip-hop-twitter-bot.md
@@ -1,0 +1,15 @@
+---
+title: Ben's hip hop Twitter bot
+slug: bens-hip-hop-twitter-bot
+published_at: '2008-06-01T03:56:05-07:00'
+wordpress_id: 126
+---
+<p>Has anyone else seen <a href="http://twitter.com/hemingway">@hemingway</a>, this weird Twitter feed that just spouts Ernie quotes every once in a while? Well, tonight I decided to code up my own twist on the idea. Follow <a href="http://twitter.com/mistadobalina">@mistadobalina</a> to receive hourly bursts of verse from one of my favorite albums, <a href="http://www.google.com/url?sa=t&amp;ct=res&amp;cd=2&amp;url=http%3A%2F%2Fwww.amazon.com%2FWish-Brother-George-Was-Here%2Fdp%2FB000002H9I&amp;ei=dn5CSOOeFonysAOLhNSjBg&amp;usg=AFQjCNE1R96LmcdFVDxaD33kaB_JJb3sIA&amp;sig2=4qG3KmVJGtOOuHwESjD9Mw">I Wish My Brother George Were Here</a> by <a href="http://www.google.com/url?sa=t&amp;ct=res&amp;cd=2&amp;url=http%3A%2F%2Fen.wikipedia.org%2Fwiki%2FDel_tha_Funkee_Homosapien&amp;ei=k35CSIz9EIm6sAPWvaiyBg&amp;usg=AFQjCNH0SiAPqRbXaXxHFXzZwu3v8NQxeQ&amp;sig2=rORRx4DJwQAeoU7DVEsNUA">Del Tha Funkee Homosapien</a>.</p>
+
+
+
+<img src="http://www.palewire.com/images/mistadobalina.png" alt="" />
+
+
+
+<p>The whole thing is automated by about 30-45 minutes worth of work. So don't expect any miracles. But all the code is over <a href="http://github.com/palewire/mistadobalina/tree/master/mistadobalina.py">on github</a> if anybody wants it. I had a couple problems (no matter what album I asked for, I was only getting track listings for Staind), but <a href="http://lyricwiki.org/LyricWiki:SOAP">the LyricWiki SOAP service</a> is a pretty sweet Web service.</p>

--- a/coltrane/content/posts/2008-06-15--terminal-recipe-how-to-download-an-entire-web-site-with-wget.md
+++ b/coltrane/content/posts/2008-06-15--terminal-recipe-how-to-download-an-entire-web-site-with-wget.md
@@ -1,0 +1,39 @@
+---
+title: 'Terminal Recipe: Download an entire Web site with wget'
+slug: terminal-recipe-how-to-download-an-entire-web-site-with-wget
+published_at: '2008-06-15T09:05:15-07:00'
+wordpress_id: 128
+---
+<p>From time to time, an occasion might arise when you'd like to download an entire Web site. At my old job, I liked to pull down government sites and go on fishing expeditions with Google Desktop Search for hot terms (ex. names of corporations and political appointees) or certain file types (ex. Excel, Access, CSV, et cetera). And the other day at my current job <a href="http://www.latimes.com/la-me-kozinski12-2008jun12,0,778115.story">a situation</a> cropped up where the newsroom wanted to download a bunch of files quickly, so it was handy to set a spider loose rather than sit there and try to download everything click by click.</p>
+
+<p>One way to handle the job is to use a command-line utility called <a href="http://www.gnu.org/software/wget/">wget</a> to crawl your target and mirror its files on your local computer.</p>
+
+<p>If you're working on a Macbook, the first thing you'll need to do is install wget. I'd suggest you do that by downloading the latest version and compiling the binary from the source code. That might sound scary, but it's just a fancy way of saying you're going to install something from the command line instead of clicking a bunch of pretty boxes. Some other sites are going to push you toward pretty boxes and maybe even this big bloated thing called Fink, but, trust me on this one, it's going to be a lot easier for you down the road if you learn how to install stuff yourself. And this is a simple enough example that it's worth the shot.</p>
+
+<p>So, if you're with me, before you do anything else, download and install <a href="http://developer.apple.com/tools/xcode/">Mac's XCode</a>, which includes the compilers you'll need to build stuff on your own.</p>
+
+<p>Then just open your terminal and let rip with the following...</p>
+
+<pre lang="Bash">mkdir src
+cd src
+curl -O http://ftp.gnu.org/gnu/wget/wget-latest.tar.gz
+tar xvfz wget-latest.tar.gz
+cd wget-1.11.3
+./configure
+sudo make install</pre>
+
+<p>You've just compiled your first program. We just made a new directory for storing source code, downloaded wget's source, unzipped it, and then "made" the file with our XCode compiler. Pretty easy, right? The only catch is that you'll need your computer's administrator password to run the "sudo" command that will create wget's binary in your system folder.</p>
+
+<p>In the future, that configure/make part is going to be the same for most of the source code you run into. When you encounter a new batch, just check the INSTALL or README docs where they'll usually let you know if there's anything else fancy you need to do.</p>
+
+<p>Now test it out by hammering in the following...</p>
+
+<pre lang="Bash">wget</pre>
+
+<p>And there's your new utility, waiting to run things down on your behalf. Check out how it easy it is. Want to mirror a Web site? Here's all you need to type...</p>
+
+<pre lang="Bash">wget -mk http://www.foo.com</pre>
+
+<p>Blammo, you're off to the races, walking your target's directory structure and saving all the files to your hard drive. The -m option puts wget in mirror mode and the -k option will convert all the hyperlinks so they're suitable for local viewing. Then you just feed it the URL you're after.</p>
+
+<p>If you're a Linux or Windows user, the command should be the same.  If you're a Windows user, you can try it with a release like <a href="http://users.ugent.be/~bpuype/wget/">this one</a>. And if you run Linux, like I do, wget should already be installed and ready to roll in most distributions. No bothering with XCode or new downloads or any of that nonsense.</p>

--- a/coltrane/content/posts/2008-06-23--tickertube-bens-first-stab-at-amazon-web-services.md
+++ b/coltrane/content/posts/2008-06-23--tickertube-bens-first-stab-at-amazon-web-services.md
@@ -1,0 +1,19 @@
+---
+title: Tickertube, Ben's first stab at Amazon Web Services
+slug: tickertube-bens-first-stab-at-amazon-web-services
+published_at: '2008-06-23T08:36:39-07:00'
+wordpress_id: 129
+---
+<p>Yesterday I launched <a href="http://www.tickertube.org">Tickertube.org</a>, my first attempt at hosting a site using <a href="http://en.wikipedia.org/wiki/Amazon_Elastic_Compute_Cloud">Amazon's EC2 service</a>. It's a simple app, just an ever refreshing list of links from sites that write about telecommunications policy. I used to cover this stuff in DC, and I don't really like using RSS readers, so it's useful for me, if not anyone else.</p>
+
+
+
+<p>But my objective isn't to build a hit site. I just want to figure out Amazon's toys. What I learned is that while they aren't all that well documented, they can be a lot of fun once you figure out the basics. You'll have to do more hands-on server configuration than you would with <a href="www.feedjack.org/">Google App Engine</a>, but greater control does come with benefits.</p>
+
+
+
+<p>I'd like to use Tickertube to woodshop a little in developing for smart phones. But since I don't have an iPhone or Blackberry, I don't have any way to test it out. Or a lot of motivation to get it done. But if somebody out there would like to use the site with a mobile device (and wouldn't that be a shock!), just let me know and I'll try to put in the extra time to adapt the HTML. Same goes if there are any feeds you'd like me to add the pool. Just shout.</p>
+
+
+
+<p>Thanks to all the great tools that made this project easy. Besides Amazon, much love to <a href="www.djangoproject.com/">Django</a>, <a href="developer.yahoo.com/yui/">YUI</a> and <a href="www.feedjack.org/">Feedjack</a>.</p>

--- a/coltrane/content/posts/2008-07-06--permalinks-low-rent-data-viz-and-other-stupid-caspio-tricks.md
+++ b/coltrane/content/posts/2008-07-06--permalinks-low-rent-data-viz-and-other-stupid-caspio-tricks.md
@@ -1,0 +1,147 @@
+---
+title: Permalinks, low-rent data viz and other stupid Caspio tricks
+slug: permalinks-low-rent-data-viz-and-other-stupid-caspio-tricks
+published_at: '2008-07-06T20:20:33-07:00'
+wordpress_id: 134
+---
+<p>Today marked the release of <a href="http://www.latimes.com/news/local/la-me-charity6-2008jul06,0,6668563.story">a new Times investigation</a> into the poor performance of for-profit fundraisers hired by not-for-profit charities. The poster child is Citizens Against Government Waste (CAGW), an advocacy group that <a href="http://www.cagw.org/site/PageServer?pagename=about_Mission_History">rails against reckless government spending</a>.</p>
+
+
+
+<p>According to reporting and analysis by Charles Piller and Doug Smith:</p>
+
+
+
+<blockquote>Records filed with the California attorney general's office show that over the last decade, for-profit fundraisers for [CAGW] kept more than 94 cents of every donated dollar.</blockquote>
+
+
+
+<p>And the bigger picture:</p>
+
+
+
+<blockquote>In more than 5,800 campaigns on behalf of charities that were registered with the state attorney general from 1997 to 2006, the fundraisers reported taking in $2.6 billion. They kept nearly $1.4 billion -- about 54 cents of every dollar raised.</blockquote>
+
+
+
+<p>As part of our effort to package the story for the Web, I worked with <em>Times</em> staff to publish all of the records collected for analysis as an online database. What we came up with allows readers to look up the track record of individual charities, browse charities of similar types, and quickly seek out the most and least efficient charities using a goofball visualization I cooked up with our graphics guy, <a href="http://www.studioburbank.com/">Thomas Lauder</a>. You can check it out <a href="http://www.latimes.com/news/local/la-charity-search-home,0,7128706.htmlstory">here</a>.</p>
+
+
+
+<p>The app was pulled together using <a href="http://www.caspio.com/">Caspio</a>, a browser-based program for building data-driven web applications. While it is technically true, as the site claims, that developing a working Caspio app requires "no more programming," my experience has been that you're going to have to invest a significant amount of time hacking at its kludgey GUI to come up with something half-way decent. Whether you want to invest your time doing that, or mastering a more robust development option, is entirely up to you.</p>
+
+
+
+<p><a href="http://www.tubotu.com/?p=43">Other</a>, <a href="http://blog.thescoop.org/archives/2008/06/29/caspios-lessons/">smarter</a> <a href="http://blog.thescoop.org/archives/2007/12/07/trial-by-caspio/">people</a> have invested a goodly amount of space to explaining Caspio's deficiencies, so I'll leave that to <a href="http://commonsensej.blogspot.com/2007/10/caspio-dustup.html">the</a> <a href="http://www.jacobian.org/writing/2007/sep/12/db-journalism/">links</a>. Instead let's break out below a couple tricks that helped me at least marginally improve today's product, in hopes they might be useful to somebody. (Though I suppose any "improvement" is a matter of opinion! Let me know what I fucked up.)</p>
+
+
+
+<h2>Hack 01: Roll your own forms</h2>
+
+
+
+<p>Caspio offers several templates. The one I use most often is the "search-and-result" set. It accepts a user's input and returns any matching values. Might sound complicated, but it's the same thing as Google. You pop something in, and you get back any hits. You can examine specimens in the wild <a href="http://dunes.cincinnati.com/data/crime/fbi/">here</a>, <a href="http://www.tbo.com/news/reports/foreclosures/">here</a> and <a href="http://www.azcentral.com/news/datacenter/babynames.html">here</a>. (Thorough readers will notice that, at least at the time of writing, the Cincinnati app is dead on arrival, bearing only the cryptic message "<a href="http://www.palewire.com/images/dead-caspio-cropped.png">DataPage does not exist. (Caspio Bridge error) (50501)</a>.")</p>
+
+
+
+<p>Since the "search" and "result" sides of the app are glued together in a single panel, the search box can't be very easily plugged in around your site. You'll have to find a way to make Caspio's gunky JavaScript code work in each and every location where you want to encourage user input. The result is that most Caspio apps -- including all three linked above -- tend to live in backwater, standalone pages, lampooned by Matt Waite as "<a href="http://www.mattwaite.com/2008/01/02/data-ghettos/">data ghettos</a>." (Personally, I prefer "<a href="http://www.youtube.com/watch?v=SJ4EVnAxHIc">Ghettos of the Mind</a>.")</p>
+
+
+
+<p>That might be acceptable if you're looking to make a destination page for your corporate intranet, like an employee directory. But it's just not good enough for news Web sites, which draw a huge share of their incoming traffic on the homepage and the first page of featured stories. If your database isn't prominently displayed there -- and it isn't unless you've got a search box or other entry point gaping open on the page -- you've losing a whole lot of potential traffic. I think there's something to be said for a "data central" section, but you're probably giving up a lot of clicks if you're waiting for people to hit the vague looking "data" link in your left-nav bar.</p>
+
+
+
+<p>So what's the hack? It's pretty simple. Just build a search-and-result box without a search, which you then provide with your own custom HTML. You can then reuse the search box anywhere you want: the frontpage, right-rail, story-level reefer or -- heaven forfend -- standalone "data ghetto."</p>
+
+
+
+<p>Here's how you do it, shot by shot.</p>
+
+
+
+<img src="http://www.palewire.com/images/form-step1.png" alt="" />
+
+
+
+<p>First turn on the advanced options and allow parameters.</p>
+
+
+
+<img src="http://www.palewire.com/images/form-step2.png" alt="" />
+
+
+
+<p>Tell Caspio it should look for an external parameter in the URL, rather than use it's native search form.</p>
+
+
+
+<img src="http://www.palewire.com/images/form-step3.png" alt="" />
+
+
+
+<p>Tell it which field it should run the inputs against. In this case, we're building a search on a data table's "name" field.</p>
+
+
+
+<img src="http://www.palewire.com/images/form-step4a.png" alt="" />
+
+
+
+<p>Now instruct Caspio to look for the user input after a query string variable called "name," and to evaluate it against the data table using "contains" style matching, as opposed to "exact" or "starts with" matching. If you were using a unique identifer like a primary key for the lookup (as you likely would if you were building a dropdown menu rather than a search box), you would probably want to use an "exact" match instead of "contains."</p>
+
+
+
+<img src="http://www.palewire.com/images/form-step4b.png" alt="" />
+
+
+
+<p>Then finish up by telling Caspio how to handle what to do with blank variables or circumstances where you don't have a match.</p>
+
+
+
+<p>Now you should deploy the Caspio app as you normally would, and then craft an HTML form on a different page that points to its location, placing the user's input in the query string. For example, the search box in our charity app looks like this, with all the styling removed:</p>
+
+
+
+<pre lang="HTML"><form action="http://www.latimes.com/news/local/la-charity-search-name,0,5949050.htmlstory" method="get">
+
+<input maxlength="100" name="name" size="6" type="text" />
+
+<input type="submit" value="Go" />
+
+</form>
+
+</pre>
+
+
+
+<p>That'll send people to the following link, where they'll see the search results as they're formatted by the Caspio GUI.</p>
+
+
+
+<pre lang="HTML">http://www.latimes.com/news/local/la-charity-search-name,0,5949050.htmlstory?name=Red Cross</pre>
+
+
+
+<h2>Hack 02: Permalinks for easy deep linking</h2>
+
+
+
+<p>An added benefit of using Hack 01 is that your results pages can have permalinks, albeit long and ugly ones. The link above will always call up the results for a search of "Red Cross," and if you build all your drilldown pages this way, using a primary key as the external parameter, they'll each have a distinct URL. That came in handy with the charity story because it allowed me to deep link charity names and types from <a href="http://http://www.latimes.com/news/local/la-me-charity6-2008jul06,0,6668563.story">the story</a> down into the database (ex. <a href="http://www.latimes.com/news/local/la-charity-search-detail,0,922401.htmlstory?CharityCode=713">Citizens Against Government Waste</a> and <a href="http://www.latimes.com/news/local/la-charity-search-type,0,4633762.htmlstory?TypeCode=18">disaster relief</a>)</p>
+
+
+
+<h2>Hack 03: Low-rent data visualization as a novel entry point</h2>
+
+
+
+<p>Once you set up the query string, there's no reason that your custom entry point must be an HTML form. My editors wanted to group the charities by their fundraising efficiency and give readers the chance to look at them group by group (i.e. which are the best, average, worst, <em>et cetera</em>.) We could have made a dropdown box, ordered list or sortable table. But the idea Thomas Lauder and I hatched instead was an interactive grid modeled on the <a href="http://mutualfunds.about.com/od/mutualfunds101/fr/stylebox.htm">Morningstar Style Box</a> that sorts charities by the size and efficiency of their fundraising efforts. I built it with <a href="http://www.alistapart.com/articles/imagemap">an old A List Apart trick</a> so that each square links to the list of charities in its category. Take a look at it <a href="http://www.latimes.com/news/local/la-charity-search-home,0,7128706.htmlstory">here</a>. We also made a smaller version, currently on the site's frontpage and in a story-level reefer. Here's a hideous screenshot to prove it. You'll have to go to <a href="http://www.latimes.com/news/local/la-me-charity6-2008jul06,0,6668563.story">the site</a> if you actually want to play with it.</p>
+
+
+
+<img src="http://www.palewire.com/images/mini-grid.png" alt="" />
+
+
+
+<p>Alright, I've got a few more up my sleeve, but that's probably enough for now. Per usual, far be it from me to say that these methods are the only or most efficient way to solutions. They're just the ones I got done on deadline. Feel free to tell me where I screwed up, or how I can do it better next time.</p>

--- a/coltrane/content/posts/2008-07-20--how-we-got-here-or-which-past-are-we-prolouging-again.md
+++ b/coltrane/content/posts/2008-07-20--how-we-got-here-or-which-past-are-we-prolouging-again.md
@@ -1,0 +1,23 @@
+---
+title: How we got here, or Which past are we prolouging again?
+slug: how-we-got-here-or-which-past-are-we-prolouging-again
+published_at: '2008-07-20T10:36:17-07:00'
+wordpress_id: 135
+---
+<p>There are <a href="http://strange.corante.com/archives/2008/07/20/what_has_prevented_newspapers_from_being_successful_in_the_digital_age.php">some</a> <a href="http://www.depthreporting.com/2008/07/just-how-stupid-shortsighted-and-out-of.html">interesting</a> <a href="http://johnmcquaid.com/2008/07/04/the-big-die-off/">j-posts</a> floating around trying to puzzle out how and why big media companies missed the boat online.</p>
+
+
+
+<p>One piece of history that I'm interested in, but never see come up in these sorts of attempts to wring meaning out of the past, is <a href="http://www.museum.tv/archives/etv/U/htmlU/uspolicyt/uspolicyt.htm">the derregulation of major media</a> rammed through Congress in 1996.</p>
+
+
+
+<p>The lifting of ownership bans kickstarted a wave of consolidation across print and electronic media that gave us the doddering dinosaurs we all slag on today. Tribune Company, Clear Channel, McClatchey, et cetera simply could not exist in their present form if that bill hadn't passed. And my boss Sam Zell, telling the story of how he and Randy Michaels bonded at Jacor, said as much when he addressed our staff earlier in the year.</p>
+
+
+
+<p>My suspicion is that the perceived economic incentives offered by consolidation and cost-cutting opened up by the 1996 dereg might have been too tempting in the short term for media executives to ignore. And why should they invest time and resources online chasing speculative new revenues, when they could clearly see immediate "efficiencies," "synergies," and  other opportunities to increase profits through consolidation? Plus they got the rush of chasing business' biggest prize: The Deal. (<a href="http://www.amazon.com/Fighting-Air-Battle-Control-Americas/dp/143321332X/ref=pd_bbs_sr_2?ie=UTF8&amp;s=books&amp;qid=1216575528&amp;sr=8-2">Eric Klinenberg's book</a> has some great reporting on how driven a lot of media execs were in that direction.)</p>
+
+
+
+<p>So that's my long way of saying I'm interested in what degree the failure of the MSM to invest online was a victim of that opportunity cost. And I'd love to ask an executive who worked during the era as much.</p>

--- a/coltrane/content/posts/2008-09-18--five-ways-your-data-app-can-catch-the-big-news-hook.md
+++ b/coltrane/content/posts/2008-09-18--five-ways-your-data-app-can-catch-the-big-news-hook.md
@@ -1,0 +1,71 @@
+---
+title: Five ways your data app can catch the big news hook
+slug: five-ways-your-data-app-can-catch-the-big-news-hook
+published_at: '2008-09-18T08:15:53-07:00'
+wordpress_id: 147
+---
+<h2>01. Practice news-driven development</h2>
+
+
+
+<p>Most data-driven news applications I've encountered follow what I would call The Chicago Crime model, a name lifted from <a href="http://en.wikipedia.org/wiki/Adrian_Holovaty">Adrian Holovaty</a>'s famous site. Steady streams of government-provided data are repurposed into a flexible interface that allows users to compare disparate sources (<a href="http://en.wikipedia.org/wiki/Mashup_(web_application_hybrid)">"the mashup"</a>) and easily localize the information so it can provide particulars to a wide body of users (<a href="http://en.wikipedia.org/wiki/The_Long_Tail">"the long tail"</a>).</p>
+
+
+
+<p>It's a brilliant model, the app that launched a 1,000 ships. But it's not the only way to get things done.</p>
+
+
+
+<p>In news terms, where minutes matter, it can still require a relatively long time to do. Especially when it comes to data acquisition. Let's face it, if you're using government data as your starting point, the idea of an <a href="http://en.wikipedia.org/wiki/SOAP">SOAPy API</a> is laughable. So don't get your hopes up. Goofing around with <a href="http://delicious.com/help/api">delicious tags</a> or <a href="http://www.flickr.com/services/api/">Flickr photos</a> is fun, but if you want to do something original from the public sector, they're only going to get you so far. You're going to be <a href="http://en.wikipedia.org/wiki/Freedom_of_Information_Act_(United_States)">FOIA'ing</a>, or, if you're lucky, <a href="http://en.wikipedia.org/wiki/Web_scraping">scraping</a>. And then you're going to be cleaning. Especially if you're invested in serving accurate and consistant information. Because if there's a government database out there that's ready to serve, I've yet to see it.<p>
+
+
+
+<p>And there's usually not much of a news hook. Look, I appreciate Everyblock and Chicago Crime and that whole style. Hell, I've essentially remodeled my career to emulate them. But when you get down to it, they're essentially built around the idea that umpteen little news hooks ("Someone was robbed in my neighborhood," "A liquor store wants to open up on your block.") will add up to something greater than the sum of their parts. That <a href="http://en.wikipedia.org/wiki/Local_news">"hyperlocal"</a> or  "long tail" philosophy, to use the parlance of our time, may ultimately be where a lot of us end up, but blockbuster news is still happening and there's no reason all the same tools that made the Chicago Crime successful can't be used to cover the hell out of a big story when it breaks.</p>
+
+
+
+<p>I had just such an opportunity last Friday at the L.A. Times. Late in the afternoon, news broke that a commuter train had crashed in the Valley, potentially killing many riders on board. We didn't know how many fatalities to expect, nor how long it would take for their identities released. But we knew that our audience was going to want to know, and as soon as possible. The typical newspaper.com way to handle this sort of thing is to publish a simple list, or "blob of text", when it's available. And then follow up later with a scattershot of obituaries, usually released as they appear in the paper. But, when you think about it in terms of the <a href="http://www.holovaty.com/blog/archive/2006/09/06/0307/">Holovaty manifesto</a> and the general concept of the Internet, there's really no reason that information couldn't be better collected and presented as a browsable database application. It's a lesson the LA Times learned earlier this year when <a href="http://www.google.com/url?sa=t&amp;source=web&amp;ct=res&amp;cd=1&amp;url=http%3A%2F%2Fprojects.latimes.com%2Fwardead%2F&amp;ei=IWLSSMDgNImIsAPTs5HhBw&amp;usg=AFQjCNFmPX42hJtdAzy-E_MApizlUKuCfQ&amp;sig2=9pSonD-GzR_CrPweqiGY9w">our ripoff</a> of Adrian's <a href="http://projects.washingtonpost.com/fallen/">Faces of the Fallen</a> concept reinvigorated the way the paper covers military casualties.</p>
+
+
+
+<p>It meant staying late at work on a Friday night, busting ass most of my weekend, and putting more faith in <a href="http://en.wikipedia.org/wiki/Memcached">memcached</a> than most IT people are comfortable with, but the result was that when the government finally did cough up the fatality list we were ready to immediately publish it as a linked database that, over time, has been filled in by further reporting to include greater detail, photos, and more than 1,600 user comments, many of them extremely moving. It's a long way from perfect, but it provided some amount of public service, was way ahead of the competition and generated a pretty goodly amount of traffic along the way. The site is called <a href="http://www.google.com/url?sa=t&amp;source=web&amp;ct=res&amp;cd=9&amp;url=http%3A%2F%2Fprojects.latimes.com%2Fmetrolink-crash%2F&amp;ei=QWPSSPmUG5KmtQPi8sDfBw&amp;usg=AFQjCNGq8xaTWFwZuvgW0kHDf-teJBKJQg&amp;sig2=MeFRlF1YPn5r94yYRQcEBw">Chatsworth Metrolink Crash</a>.</p>
+
+
+
+<p>That's all my long way of saying that I think big events matter and that database journalists shouldn't be afraid to dive in when they happen. Whether it's posting the location of hurricane shelters, letting people know who the hell all those superdelegates are, or connecting survivors following a disaster, there are plenty of obvious opportunities to do our thing. But it's not going to happen if we don't see taking on big news as an opportunity, anticipate things like the next hot Google search term, or have the capability to deploy very very quickly.</p>
+
+
+
+<p>I'm a long way from an authority on the whole deal, but I'm stumbling my way through it. And here are a couple things I've learned along the way.</p>
+
+
+
+<h2>02. Let last year's data be your guide.</h2>
+
+
+
+<p>Earlier this month, we released <a href="http://projects.latimes.com/schools/">California Schools Guide</a>, a collection of data about public and private schools across the state, at the very moment the government lifted its embargo on this year's scores. I didn't have the newsworthy data in hand until less than 24 hours before it would be publicly released. But by developing the site in advance using the previous year's data as dummy entries, I was able to pre-script the loading of the 2008 data after only a few minor changes to the code. This meant that we were able to get our product out when the news hook dropped, at the same time as the paper was otherwise promoting <a href="http://www.latimes.com/news/local/la-me-scores5-2008sep05,0,2098428,full.story">an investigative story on the topic</a> and the state's propaganda arms were blasting its own message ("Things are getting better! Trust us!").</p>
+
+
+
+<h2>03. Don't Repeat Yourself, unless it saves you time.</h2>
+
+
+
+<p>Let me be clear. The <a href="http://en.wikipedia.org/wiki/Don't_repeat_yourself">DRY</a> goal of elegence through efficiency is laudable. And, as a guiding principle for development, you probably can't get any better. It is the single point of truth. It's like <a href="http://en.wikipedia.org/wiki/Natural_selection">natural selection</a>, except for awesomeness. But when you're on a tight deadline, and you've already got a code implementation that works, sometimes you JDFWI, Just Don't Fuck With It. Yeah, so maybe you just copied and pasted and introduced a little redundancy. And maybe your css is just a hodgepodge of div's repurposed from other apps. But it works, right? And what's more important, trimming down your code base, or getting the news out ahead of your competition?</p>
+
+
+
+<h2>04. Use Django's admin to your advantage.</h2>
+
+
+
+<p>For anyone who's already doing this stuff, it probably goes without saying, but <a href="http://docs.djangoproject.com/en/dev/ref/contrib/admin/#ref-contrib-admin">Django's admin</a> is really great. As soon as your database models are written, you've instantly got a set of entry forms that are ready to deploy. This is incredibly useful when trying to turn around simple data apps on deadline. For instance, when it came to the Metrolink crash, I was able to get the models and admin up Friday night so that reporters on Metro desk could begin working on entry as I shifted to work on the views and templates.</p>
+
+
+
+<h2>05. Publish now, or perish.</h2>
+
+
+
+<p>You can have the greatest app in the world, but if you can't push it out the web ASAP, you're nowhere. If you're going the Chicago Crime route, this isn't as big of a deal. But if you're trying to hit the big news hook, it's utterly essential. And treating big news like you would anything else on your "product schedule" or "iteration cycle" just isn't going to be good enough. You can call it a <a href="http://en.wikipedia.org/wiki/Waterfall_model">waterfall</a>, you can call it reckless, you can call it news-driven development.</p>

--- a/coltrane/content/posts/2009-02-15--django-recipe-add-an-auto-count-field-to-your-foreignkey-model.md
+++ b/coltrane/content/posts/2009-02-15--django-recipe-add-an-auto-count-field-to-your-foreignkey-model.md
@@ -1,0 +1,90 @@
+---
+title: 'Django recipe: Add an auto-count field to your model'
+slug: django-recipe-add-an-auto-count-field-to-your-foreignkey-model
+published_at: '2009-02-15T22:30:00-08:00'
+---
+<p>Nothing fancy here. A common thing I want to do with Django is publish an "object_list" generic view drawn out of a ForeignKey table that includes each object's total number of occurances.</p>
+
+<p>In English: A list with counts. Like this page reporting the occurrence of different ages in our <a href="http://projects.latimes.com/wardead/age/">California's War Dead</a> database.</p>
+
+<p>There are easy enough way to gets this done in your views.py, or with a custom manager. And it's getting increasingly easy thanks <a href="http://code.djangoproject.com/ticket/3566">the aggregates support</a> that's making it's way into Django 1.1. But, just for the hell of it, I thought I'd throw up my simple solution for these situations. It ain't the only way. But I think it's pretty easy.</p>
+
+<p>So, without any further whatnot, here is Ben's approximation of an auto-count field. The code is a simplification of my freshly published pluggable app, <a href="http://code.google.com/p/django-correx/">django-correx</a>, which you can now download from <a href=" 	 http://code.google.com/p/django-correx/">Google Code</a> or <a href="http://github.com/palewire/django-correx/tree/master">github</a>.</p>
+
+<p>First, in your models.py make two models with a foreign key relationship. (I'm going to keep the example very bare bones, simply for the purpose of demonstration. If you want to see my full file, check it out <a href="http://github.com/palewire/django-correx/blob/9978502dbd92ceb82ee8e9242f0d55da83d719dc/correx/models.py">here</a>.)</p>
+
+<pre lang="Python">from django.db import models
+
+class ChangeType(models.Model):
+  name = models.CharField(max_length=20)
+
+class Change(models.Model):
+  description = models.TextField()
+  change_type = models.ForeignKey(ChangeType)
+  pub_date = models.DateTimeField()
+  is_public = models.BooleanField(default=False)</pre>
+
+<p>Okay. So that's a start. The goal here is to add the auto-count field to ChangeType and have it regularly update itself with the total number of associated changes that have been set for publication.</p>
+
+<p>What I like to do is add a simple IntegerField that can't be futzed with from the admin, and then attach a method that make the join to the parent table and retrieves the current count. Like so:</p>
+
+<pre lang="Python">class ChangeType(models.Model):
+  name = models.CharField(max_length=20)
+  change_count = models.IntegerField(default=0, editable=False)
+
+  def count_changes(self):
+    """
+    Counts the total number of live changes of this type and saves the result to the `change_count` field.
+    """
+    count = self.change_set.filter(is_public=True).count()
+    self.change_count = count
+    self.save()</pre>
+
+<p>Now all you need to do is regularly schedule the counts. That's where <a href="http://docs.djangoproject.com/en/dev/topics/signals/">Django's cool signal dispatcher</a> comes in. With a small amount of code, you can instruct your project to loop through the ChangeType table and run our new count_changes method every time there's a change to the Change table. And here's how.</p>
+
+<p>First make a new signals.py file in your app directory that looks something like this:</p>
+
+<pre lang="Python">from django.db.models import signals
+from django.dispatch import dispatcher
+
+def count_changes(sender, instance, signal, *args, **kwargs):
+  """
+  Runs through all the change types and adds up their current numbers
+  """
+  from correx.models import ChangeType
+  for change_type in ChangeType.objects.all():
+    change_type.count_changes()</pre>
+
+<p>Then roll back to your models.py and rig up the signals to the post-save and post-delete hooks built into the system.</p>
+
+<pre lang="Python">from django.db import models
+from django.db.models import signals
+from correx.signals import count_changes
+
+class ChangeType(models.Model):
+  name = models.CharField(max_length=20)
+  change_count = models.IntegerField(default=0, editable=False)
+
+  def count_changes(self):
+    """
+    Counts the total number of live changes of this type and saves the result to the `change_count` field.
+    """
+    count = self.change_set.filter(is_public=True).count()
+    self.change_count = count
+    self.save()
+
+class Change(models.Model):
+  description = models.TextField()
+  change_type = models.ForeignKey(ChangeType)
+  pub_date = models.DateTimeField()
+  is_public = models.BooleanField(default=False)
+
+# Rerun the totals for each ChangeType whenever a Change is saved or deleted.
+signals.post_save.connect(count_changes, sender=Change)
+signals.post_delete.connect(count_changes, sender=Change)</pre>
+
+<p>And that should do it. Go into your admin and add a couple changes and see if it works.</p>
+
+<p>I love to use this sort of setup so that I can stick with a generic view snippet in my urls.py and avoid having to make joins across tables on simple list pages.</p>
+
+<p>I've been cutting and pasting pretty loose here. So let me know if something doesn't add up. Hope this can be useful to somebody. And, per usual, let me know where I screwed up and we'll sort it out. Thanks.</p>

--- a/coltrane/content/posts/2009-03-03--django-recipe-dump-your-queryset-out-as-a-csv-file.md
+++ b/coltrane/content/posts/2009-03-03--django-recipe-dump-your-queryset-out-as-a-csv-file.md
@@ -1,0 +1,49 @@
+---
+title: 'Django recipe: Dump your QuerySet out as a CSV file'
+slug: django-recipe-dump-your-queryset-out-as-a-csv-file
+published_at: '2009-03-03T13:53:00-08:00'
+---
+<p>I am lucky to work with really smart people. And part of what makes it fun is that they like to do data stuff. But they don't like to do Django. At least yet. They like SAS and Access and Excel and all the usual toys. So one thing I'm doing all the time is dumping data out of my systems into neutral formats for them to muck with. Here's a quick and dirty script I use that will take in a Django QuerySet and output a CSV file. It's lifted mainly from <a href="http://www.djangosnippets.org/snippets/790/">this awesome Django snippet from zbyte64</a>.</p>
+
+<pre lang="Python">
+import csv
+from django.db.models.loading import get_model
+
+def dump(qs, outfile_path):
+	"""
+	Takes in a Django queryset and spits out a CSV file.
+	
+	Usage::
+	
+		>> from utils import dump2csv
+		>> from dummy_app.models import *
+		>> qs = DummyModel.objects.all()
+		>> dump2csv.dump(qs, './data/dump.csv')
+	
+	Based on a snippet by zbyte64::
+		
+		http://www.djangosnippets.org/snippets/790/
+	
+	"""
+        model = qs.model
+	writer = csv.writer(open(outfile_path, 'w'))
+	
+	headers = []
+	for field in model._meta.fields:
+		headers.append(field.name)
+	writer.writerow(headers)
+	
+	for obj in qs:
+		row = []
+		for field in headers:
+			val = getattr(obj, field)
+			if callable(val):
+				val = val()
+			if type(val) == unicode:
+				val = val.encode("utf-8")
+			row.append(val)
+		writer.writerow(row)
+
+</pre>
+
+<p>Per usual. Let me know what sucks.</p>

--- a/coltrane/content/posts/2009-03-04--openlayers-recipe-how-to-map-proportional-symbols.md
+++ b/coltrane/content/posts/2009-03-04--openlayers-recipe-how-to-map-proportional-symbols.md
@@ -1,0 +1,16 @@
+---
+title: 'OpenLayers Recipe: How to map proportional symbols'
+slug: openlayers-recipe-how-to-map-proportional-symbols
+published_at: '2009-03-04T11:04:00-08:00'
+---
+<p>Have you heard of <a href="http://openlayers.org/">OpenLayers</a>? It's a JavaScript library you can use to throw up maps. And I think it's pretty awesome.</p>
+
+<p>I've used it at work to to plot out <a href="http://projects.latimes.com/mapping-la/neighborhoods/">the neighborhoods of Los Angeles</a>. But in the future, I'd like to use it for other stuff, like mapping proportional symbols.</p>
+
+<p>Today's L.A. Times has <a href="http://www.latimes.com/business/printedition/la-fallingroof-fl,0,4583412.flash">a nifty Flash map</a> made by my awesome coworkers that shows places in Southern California where real estate projects have stalled due to the recession.</p>
+
+<a href="http://www.palewire.com/openlayers-proportional-symbols/"><img src="http://www.palewire.com/openlayers-proportional-symbols/thumb.gif" alt="C'mon. Click it." /></a>
+
+<p>So I took an hour this morning to see if I could replicate the Flash map in OL. Guess what, it's pretty easy! Click the thumbnail above and have a look. Or just click <a href="http://www.palewire.com/openlayers-proportional-symbols/">here</a>.</p>
+
+<p>Per usual, all feedback and hatemail welcome. Let me know what sucks and we'll sort it.</p>

--- a/coltrane/content/posts/2009-03-16--dc-police-cite-privacy-to-rollback-public-access-to-crime-data.md
+++ b/coltrane/content/posts/2009-03-16--dc-police-cite-privacy-to-rollback-public-access-to-crime-data.md
@@ -1,0 +1,80 @@
+---
+title: 'OCTO: DC police cite privacy to rollback public access to crime data'
+slug: dc-police-cite-privacy-to-rollback-public-access-to-crime-data
+published_at: '2009-03-16T07:23:00-07:00'
+---
+<p><a href="#update-one"><strong>UPDATE I</strong></a>, <a href="#update-two"><strong>UPDATE II</strong>, </a><a href="#update-three"><strong>UPDATE III</strong>, </a><a href="#update-four"><strong>UPDATE IV</strong> </a></p>
+
+<p>After <a href="http://twitter.com/derekwillis/status/1324229013">Derek Willis</a> flagged the sudden absence of crime narratives in DC's public data feed last Friday, I buzzed a couple emails over to <a href="http://octo.dc.gov/octo/site/default.asp">the CTO's office in DC</a>. Here's the response I received Monday morning from David Strigel, program manager of the city's data warehouse:
+<blockquote>Good morning Ben.  MPD stopped sending the crime narratives and they release this statement on Friday.  We will continue to work with MPD to publish the crime data and if they bring the narratives back online we will make them available.<p>
+
+<p>Revision to Crime Data Summary Information The MPD is committed to providing crime data to our community partners to keep them informed about incidents in the different neighborhoods in DC. At the same time, we are also committed to protecting the privacy of crime victims and the integrity of ongoing investigations. In an effort to balance these objectives the MPD will no longer provide narrative information associated with the crime incidents. Narrative information will be for internal use only.</p>
+
+<p>The following crime information will continue to be available to the public through several websites as well as through the MPD’s community email discussion groups:</p>
+
+<ul>
+	<li>PSA</li>
+	<li>Criminal Complaint Number (CCN)</li>
+	<li>Block (block address provided; specific addresses are not available)</li>
+	<li>Offense</li>
+	<li>Method</li>
+	<li>Offense</li>
+	<li>Report Date</li>
+</ul>
+
+<p>Individuals interested in getting additional information about a particular incident are encouraged to reach out to their police district commander, their PSA lieutenant, or to attend one of their monthly PSA-Community meetings.</p>
+</blockquote>
+
+<p>As the RCFP and others have documented in the past, <a href="http://www.rcfp.org/newsitems/index.php?i=6058">privacy is one of the top reasons</a> that government agencies seek to withhold information. But why this data field and why now? Looking at the narratives that have been previously published can we see anything that presents a convincing case for withholding the information? Some recent examples include:</p>
+
+<blockquote><p>R-1REPORTS FOR C-1 THAT UNKNOWN SUBJECTS SMASHED OUT THE PASSENGER WINDOW AND ATTEMPTED TO STEAL THE LISTED PROPERTY FROM THE LISTED AUTO.</p></blockquote>
+
+<blockquote><p>C1 REPORTS CLOSING HIS BUSINESS FOR THE NIGHT WHEN HE OBSERVED S1 URINATING IN FRONT OF THE BUILDING. C1 CONFRONTED S1 AND TOLD HIM TO STOP AND LEAVE THE AREA. S1 STATED WHAT''S THE PROBLEM? AND WALKED TO THE SIDE OF C1''S BUSINESS AND AGAIN STARTED</p></blockquote>
+
+<blockquote><p>C1 REPORTS THAT AFTER A VERBAL AND PHYSICAL ALTERCATION WITH S1, THAT S1 STABBED C1 CAUSING THE LISTED INJURY. S1 FLED THE LOCATION IN AN UNKNOWN DIRECTION AND MANNER.</p></blockquote>
+
+<p>Have there been any real world examples of the narratives being used to identify a crime victim's identity against their will? What law is being cited as justification? And who made this decision exactly? David Strigel is hanging it on the police, who I'll be sending an annoying email shortly, but if you'd like to complain to him anyway, his personally identifying email is <a href="mailto:David.Strigel@dc.gov">David.Strigel@dc.gov</a>.</p>
+
+<p><strong><a name="update-one">UPDATE I</a></strong>: After hearing back from OCTO this morning, I got on the phone with the MPD and was quickly directed by several sources to Kaylin Castelli, <a href="mailto:kaylin.castelli@dc.gov">kaylin.castelli@dc.gov,</a> the department's manager of Internet communication. I left her a voicemail expressing my interest and then followed up with an email. She very soon responded by providing another copy of the release printed above and promised to answer my specific questions soon. In response, I reiterated my specific questions, which you can find printed below, and asked when I could expect a reply.</p>
+
+<blockquote>
+<ol>
+	<li>Why was this decision taken last Friday?</li>
+	<li>Who made the decision, and who else was involved in the process?</li>
+	<li>What specific legal grounding is being cited?</li>
+	<li>Are there any real world examples of the narrative data exposing a victim's identity?</li>
+</ol>
+</blockquote>
+
+<p>If there's anything obvious I'm forgetting to ask, please let me know.</p>
+
+<p><strong><a name="update-two">UPDATE II</a></strong>: No further communication came my direction Monday. This morning I've sent a follow-up email to Castelli reiterating my interest.</p>
+
+<p><strong><a name="update-three">UPDATE III</a></strong>: Still no word from Castelli. I put in another voicemail and email Thursday morning. Sorry for being so slow, but I'm nibbling at this on the edges around a busy work day, so I'm trying to stay in the take it slow mood. And there's still time to escalate. I'm going to start working other sources and consider some public information requests if I don't get an answer today.</p>
+
+<p><strong><a name="update-four">UPDATE IV</a></strong>: Friday morning I received the following response from Castelli, via email:</p>
+
+<blockquote>
+	<li>Why was this decision taken last Friday? Who made the decision?</li>
+
+<p>The narrative information was originally brought into question early January 2009, when some detailed information was released publically on one of the district email discussion groups (aka “listserv”). Chief Lanier instructed the district email discussion group administrators to stop posting narrative information to ensure no personal victim information was released. At the same time, staff was instructed to investigate ways that the crime information could easily be posted to the email discussion groups while maintaining victims’ privacy.</p>
+
+<p>Staff evaluated the process by which narratives were made public. We learned that, in order to provide “clean” narrative information – narratives without any victim’s personal information – the narratives were first reviewed and edited by staff in the Research and Analysis Division (RAD).</p>
+
+<p>The remaining data pieces (all data, excluding narratives) were available through a source that required no editing. The IT staff at MPD developed an application that could easily and automatically post summary crime data to the email discussion groups, provided the narratives were not included.</p>
+
+<p>After evaluating the process by which narrative information was made available to the public, and after learning about the application that could automatically post the crime data information (excluding the narratives), the Chief of Police chose to provide automatic data uploads to the email discussion groups, because they quickly provided the crime information that was most important to the community members – crime incident, date range, and block-level location – and because it didn’t require a person to be involved in the process on a day-to-day basis.</p>
+
+<p>In addition to opting for the automated posting process, the Chief of Police decided that it was inefficient for members of the RAD staff take hours out of their week to do perform the time-consuming editing, when community members could easily get that information (as well as additional public safety information) by reaching out to their district commander, and PSA lieutenants and officers.</p>
+	<li>What specific legal grounding is being cited?</li>
+<p>Under FOIA there is a general privacy exemption which protects information of a personal nature where public disclosure would be an unwarranted invasion of personal privacy. See D.C. Code 2-534 (a)(2).  Another provision provides that investigatory records compiled for law-enforcement purposes may be withheld only if release of the information would interfere with enforcement proceedings; deprive a person of a right to a fair trial; or would constitute an unwarranted invasion of personal privacy. See  D.C. Code 2-534 (a) (3) (A) (B) and (C).</p>
+
+<p>There is no legal requirement that the department provide narrative information.  The department is required to make the arrest book available for review by the public when not in actual use.  See D.C. Code 5-113.06.</p>
+	<li>Are there any real world examples of the narrative data exposing a victim's identity?</li>
+<p>There have been incidents in the past when a victim name or specific address was released publically. While no one was injured in these incidents, we don’t intend to wait for a tragedy to occur before we find a better solution.</p></blockquote>
+
+<p>Well, there's an answer. Sounds like an "it's too much work" argument is being hung on the chief. Since all this listserv business is new to me, I submitted a few follow up questions. They are:</p>
+
+<blockquote><p>Forgive my ignorance, but can I ask what email listservs you're talking about?</p>
+
+<p>And besides the Chief, what are the names of the people involved in the review? Who are the email discussion group administrators and other staff who conducted the review? Who was in charge of it? And did the review result in any kind of document or report of findings? ... Also, if possible, could you please direct me to the initial listserv incident that triggered this chain of events? And how did this issue come to chief's attention?</p></blockquote>

--- a/coltrane/content/posts/2009-07-25--palewire.md
+++ b/coltrane/content/posts/2009-07-25--palewire.md
@@ -1,0 +1,13 @@
+---
+title: This is palewire
+slug: palewire
+published_at: '2009-07-25T17:21:58-07:00'
+---
+<p>Here it is, the third-generation of my website, <a href="/">palewire.com</a>.</p>
+
+<p>This is the first version of the site I've cobbled together myself, and the process made me more appreciative of the people who enable a j-school brat to even consider something so foolish. I tried to thank them <a href="/colophon/">here</a>.</p>
+
+<p>I'll be trying to keep the blog busier. But I'm not making any promises.</p>
+
+<p>Thanks for stopping by.</p>
+

--- a/coltrane/content/posts/2009-07-29--new-improved-even-more-conspicuous-consumption.md
+++ b/coltrane/content/posts/2009-07-29--new-improved-even-more-conspicuous-consumption.md
@@ -1,0 +1,73 @@
+---
+title: New, improved, even more conspicuous consumption
+slug: new-improved-even-more-conspicuous-consumption
+published_at: '2009-07-29T09:42:08-07:00'
+---
+<p>This morning I added Readernaut support, with <a href="http://readernaut.com/palewire/">the latest books I post</a> syncing and republishing here.</p>
+
+<p>The system works almost identically to the other services, with a slightly different database structure. The Book model in my Django system inherits from an abstract model that is common to all of the third-party data like Flickr and Twitter. That helps simplify the code and ensure a baseline consistency so that I can reliably expect each data set to slot into the <a href="/ticker/page/1/">sitewide ticker</a>.</p>
+
+<p>Here's a taste. You can find <a href="http://github.com/palewire/palewire.com/tree/master">the whole codebase on github.</a></p>
+
+<pre lang="python">
+class ThirdPartyBaseModel(models.Model):
+    """
+    A base model for the data we'll be pulling from third-party sites.
+    """
+    url = models.URLField(max_length=1000)
+    pub_date = models.DateTimeField(default=datetime.datetime.now, verbose_name=_('publication date'))
+    tags = TagField(help_text=_('Separate tags with spaces.'), max_length=1000)
+    objects = models.Manager()
+    sync = SyncManager()
+	
+    class Meta:
+        ordering = ('-pub_date',)
+        abstract = True
+
+    def get_rendered_html(self):
+        template_name = 'coltrane/ticker_item_%s.html' % (self.__class__.__name__.lower())
+        return render_to_string(template_name, { 'object': self })
+
+    def get_absolute_icon(self):
+        name = u'%ss' % self.__class__.__name__.lower()
+        return u'/media/icons/%s.gif' % name
+
+    def get_tag_list(self, last_word='and'):
+        return get_text_list(self.tags.split(' '), last_word)
+    tag_list = property(get_tag_list)
+
+
+class Book(ThirdPartyBaseModel):
+    """
+    Books I've read.
+    """
+    isbn = models.CharField(max_length=20, unique=True)
+    title = models.CharField(max_length=250)
+    authors = models.CharField(max_length=250, blank=True, null=True)
+
+    def __unicode__(self):
+        if self.authors:
+            return "%s by %s" % (self.title, self.authors)
+        else:
+            return self.title
+
+
+class Shout(ThirdPartyBaseModel):
+    """
+    Shorter things I blast out.
+    """
+    message = models.TextField(max_length=140)
+
+    def __unicode__(self):
+        return self.message
+		
+    def get_short_message(self, words=8):
+        """
+        Trims message to the specified number of words.
+		
+        Good for use in the admin.
+        """
+        return truncate_words(strip_tags(self.message), words)
+    short_message = property(get_short_message)
+
+</pre>

--- a/coltrane/content/posts/2009-08-01--django-recipe-make-django-tagging-cloud-all-models.md
+++ b/coltrane/content/posts/2009-08-01--django-recipe-make-django-tagging-cloud-all-models.md
@@ -1,0 +1,93 @@
+---
+title: 'Django recipe: A django-tagging cloud for all models'
+slug: django-recipe-make-django-tagging-cloud-all-models
+published_at: '2009-08-01T10:45:25-07:00'
+---
+<p>As far as I can tell, <a href="http://code.google.com/p/django-tagging/">django-tagging</a> will only create a cloud for one particular database model. This is usually awesome, but sometimes not enough. What if, for instance, you wanted to make a combined cloud that consolidated tags across more than one model? Maybe your blog puts tags not just on posts, but also on tweets and bookmarks.</p>
+
+<p>That's pretty much the situation I was in, and here's how I hacked on the module's codebase to get it done. The code below accepts a queryset of TaggedItem objects and returns a list of tags and font sizes you can use to format the cloud, as I did <a href="/tags/">here</a>.</p>
+
+<pre lang="python">
+"""
+A modification of the tag cloud utilities in django-tagging. 
+
+Necessary so I can run a tagcloud for all the models, not just one.
+
+Tip: It's good to submit a select_related query to avoid a ton of
+database hits. This will run a join that really slims things down.
+
+>>> cloud.calculate_cloud(TaggedItem.objects.select_related().all())
+"""
+import math
+from django.utils.translation import ugettext as _
+
+# Font size distribution algorithms
+LOGARITHMIC, LINEAR = 1, 2
+
+def _calculate_thresholds(min_weight, max_weight, steps):
+    delta = (max_weight - min_weight) / float(steps)
+    return [min_weight + i * delta for i in range(1, steps + 1)]
+
+def _calculate_tag_weight(weight, max_weight, distribution):
+    """
+    Logarithmic tag weight calculation is based on code from the
+    `Tag Cloud`_ plugin for Mephisto, by Sven Fuchs.
+
+        .. _`Tag Cloud`: http://www.artweb-design.de/projects/mephisto-plugin-tag-cloud
+    """
+    if distribution == LINEAR or max_weight == 1:
+        return weight
+    elif distribution == LOGARITHMIC:
+        return math.log(weight) * max_weight / math.log(max_weight)
+    raise ValueError(_('Invalid distribution algorithm specified: %s.') % distribution)
+
+def _group_tagged_items(tagged_item_qs):
+    """
+    Accepts a queryset of TaggedItem objects, groups them by tag, and then counts their frequency.
+    """
+    tag_count = {}
+    for ti in tagged_item_qs:
+        try:
+            tag_count[ti.tag]['count'] += 1
+        except KeyError:
+            tag_count[ti.tag] = {'font-size': None, 'count': 1}
+    return tag_count
+
+def calculate_cloud(tagged_items_qs, steps=4, distribution=LOGARITHMIC, min_count=5):
+    """
+    Add a ``font_size`` attribute to each tag according to the
+    frequency of its use, as indicated by its ``count``
+    attribute.
+
+    ``steps`` defines the range of font sizes - ``font_size`` will
+    be an integer between 1 and ``steps`` (inclusive).
+
+    ``distribution`` defines the type of font size distribution
+    algorithm which will be used - logarithmic or linear. It must be
+    one of ``tagging.utils.LOGARITHMIC`` or ``tagging.utils.LINEAR``.
+    """
+    tag_counts = _group_tagged_items(tagged_items_qs)
+
+    if len(tag_counts) > 0:
+        counts = [i['count'] for i in tag_counts.values()]
+        min_weight = float(min(counts))
+        max_weight = float(max(counts))
+        thresholds = _calculate_thresholds(min_weight, max_weight, steps)
+        for tag in tag_counts.keys():
+            font_set = False
+            tag_weight = _calculate_tag_weight(tag_counts[tag]['count'], max_weight, distribution)
+            for i in range(steps):
+                if not font_set and tag_weight <= thresholds[i]:
+                    tag_counts[tag]['font_size'] = i + 1
+                    font_set = True
+
+    # Cut off the data at the minimum count
+    tag_list = [(k, v['font_size'], v['count']) for k,v in tag_counts.items() if v['count'] > min_count]
+    
+    # Sort by count
+    tag_list.sort(lambda x,y:cmp(x[2], y[2]))
+    
+    # Reverse that
+    tag_list.reverse()
+    return tag_list
+</pre>

--- a/coltrane/content/posts/2009-08-05--google-voice-fails-obama-test.md
+++ b/coltrane/content/posts/2009-08-05--google-voice-fails-obama-test.md
@@ -1,0 +1,24 @@
+---
+title: Google Voice fails the Obama test
+slug: google-voice-fails-obama-test
+published_at: '2009-08-05T23:28:54-07:00'
+---
+<p>Earlier tonight, we put <a href="http://www.youtube.com/watch?v=oFVXAqFNgic&eurl=http%3A%2F%2Fwww.google.com%2Fgooglevoice%2Fabout.html&feature=player_embedded">Google Voice's voicemail transcription service</a> to the test. The material: a recording of the most famous passage from the most famous speech made by the most famous man in America.
+
+<blockquote>Well, I say to them tonight, there's not a liberal America and a
+conservative America; there's the United States of America.
+
+There's not a black America and white America and Latino America and
+Asian America; there's the United States of America. (Source: <a href="http://www.washingtonpost.com/wp-dyn/articles/A19751-2004Jul27.html">Washington Post</a>)
+</blockquote>
+
+<p>The text was read into Google Voice via a landline telephone by a clean, articulate American citizen with elevated diction, whose name is not Barack Hussein Obama.</p>
+
+<p>Approximately two minutes later, Google Voice delivered the following transcript. Emphases mine.</p>
+
+<blockquote><strong style="font-weight:bold;">well hi jay</strong> to them tonight there's not a liberal america and <strong style="font-weight:bold;">i can
+servers of america</strong> there is the united states of america there's not a
+black america and white america and let you know <strong style="font-weight:bold;">i'm erica an agent
+america</strong> there is the united states of america</blockquote>
+
+<p>Alright, actually, not so bad. But let it be known, we played <a href="http://www.americanrhetoric.com/speeches/convention2004/barackobama2004dnc.htm">an audio clip of Obama</a> himself delivering the speech into our telephone two times, and in each case Google Voice failed to generate any transcription at all.</p>

--- a/coltrane/content/posts/2009-08-07--python-recipe-calculate-adjusted-monthly-values.md
+++ b/coltrane/content/posts/2009-08-07--python-recipe-calculate-adjusted-monthly-values.md
@@ -1,0 +1,60 @@
+---
+title: 'Python Recipe: Calculate adjusted monthly values'
+slug: python-recipe-calculate-adjusted-monthly-values
+published_at: '2009-08-07T20:40:28-07:00'
+---
+<p>Here's a function I wrote earlier today that should calculate an adjusted monthly average, prorating a monthly number as if the month was 30 days in length. The idea is to compare numbers from different months against each other and prevent longer months from returning higher values simply because they contain more days.</p>
+
+<p>The script is included with a variety of other math tools I've collected on Github under the name <a href="http://github.com/palewire/python-math/tree/master">python-math</a>.
+
+<p>Per usual, if I screwed something up, just let me know. We'll get it ironed out.</p>
+
+<pre lang="python">
+import calendar
+import datetime
+
+def adjusted_monthly_value(value, dt):
+    """
+    Accepts a value and a datetime object, and
+    then prorates the value to a 30-day figure
+    depending on how many days are in the month.
+    
+    This can be useful for month-to-month comparisons
+    in circumstances where fluctuations in the number
+    of days per month may skew the analysis. 
+    
+    For instance, February typically has only 28 days, in 
+    comparison to March, which has 31.
+    
+    h3. Example usage
+    
+        >> import calculate
+        >> calculate.adjusted_monthly_value(10, datetime.datetime(2009, 4, 1))
+        10.0
+        >> calculate.adjusted_monthly_value(10, datetime.datetime(2009, 2, 17))
+        10.714285714285714
+        >> calculate.adjusted_monthly_value(10, datetime.datetime(2009, 12, 31))
+        9.67741935483871
+	
+    h3. Documentation
+	
+        "calendar module":http://docs.python.org/library/calendar.html
+	
+    """
+    # Test to make sure the first input is a number
+    if not isinstance(value, (int,long,float)):
+        return ValueError('Input values should be a number, your input is a %s' % type(value))
+	
+    # Test to make sure the second input is a date
+    if not isinstance(dt, (datetime.datetime, datetime.date)):
+        return ValueError('The submitted month should be a date or datetime value, you input a %s' % type(dt))
+	
+    # Get the length of the month
+    length_of_month = calendar.monthrange(dt.year, dt.month)[1]
+    
+    # Determine the adjustment necessary to pro-rate the value to 30 days.
+    adjustment = 30.0/length_of_month
+    
+    # Multiply the value against the adjustment and return the result
+    return value * adjustment
+</pre>

--- a/coltrane/content/posts/2009-08-13--django-recipe-use-extent-your-querset-set-map-zoom.md
+++ b/coltrane/content/posts/2009-08-13--django-recipe-use-extent-your-querset-set-map-zoom.md
@@ -1,0 +1,64 @@
+---
+title: 'Django recipe: Use extent of a queryset to set the zoom'
+slug: django-recipe-use-extent-your-querset-set-map-zoom
+published_at: '2009-08-13T19:09:27-07:00'
+---
+<p>Here's a fun trick from <a href="http://geodjango.org/">Django's geospatial extensions</a> that can come in
+handy if you're ultimately displaying your points with a browser-based mapping system like <a href="http://openlayers.org/">
+OpenLayers</a>.
+
+<p>I sometimes find myself in a situation where I'd like the map to zoom in on a set of a points, but I'm not sure
+ahead of time where those points will be. Imagine I have a database of all the hotdog stands in America&mdash;and a
+tool that allows users to filter that set any number of ways, like state, county or address.</p>
+
+<p>Here's a simple imaginary query.</p>
+
+<pre lang="python">
+>> from models import HotdogStand
+>> queryset = HotdogStand.objects.filter(county='Johnson', state='Iowa')
+</pre>
+
+<p>Now here's the challenge: How can I write a OpenLayers template that will always center the map on my queryset, regardless
+of what filter is applied, be it Johnson County, Iowa, or every point within 10 miles of Dodger Stadium.</p>
+
+<p>I'm not sure I know the best way, but here's something I cooked up.</p>
+
+<p>The function below accepts a queryset, along with its srid code. It grabs the queryset's extent and loads it
+into an object. Then it converts that new object to srid 900913, the projection used by OpenLayers when displaying
+Google Maps tiles, as I do on my sites.</p>
+
+<pre lang="python">
+from django.contrib.gis.geos import fromstr
+
+def get_extent_for_openlayers(geoqueryset, srid):
+    """
+    Accepts a GeoQuerySet and SRID. 
+    
+    Returns the extent as a GEOS object in the Google Maps projection system favored by OpenLayers.
+    
+    The result can be directly passed out for direct use in a JavaScript map.
+    """
+    extent = fromstr('MULTIPOINT (%s %s, %s %s)' % geoqueryset.extent(), srid=srid)
+    extent.transform(900913)
+    return extent
+</pre>
+
+<p>The function can be called like so in a Django view.</p>
+
+<pre lang="python">
+>> from get_extent_for_openlayers import get_extent_for_openlayers
+>> extent = get_extent_for_openlayers(queryset, 4326)
+</pre>
+
+<p>And then utilized as a dynamic method for setting the map's extent in your OpenLayers templates.</p>
+
+<pre lang="javascript">
+{% if extent %}
+var wkt_f = new OpenLayers.Format.WKT();
+var extent = wkt_f.read('{{ extent.wkt }}');
+bounds = extent.geometry.getBounds();
+map.zoomToExtent(bounds);
+{% endif %}
+</pre>
+
+<p>Voilà. That's the whole trick. It seems to work for me, but if there's something I screwed up, feel free to tell me so.</p>

--- a/coltrane/content/posts/2009-08-23--django-recipe-rss-feed-every-tag.md
+++ b/coltrane/content/posts/2009-08-23--django-recipe-rss-feed-every-tag.md
@@ -1,0 +1,123 @@
+---
+title: 'Django recipe: Make an RSS feed for every tag'
+slug: django-recipe-rss-feed-every-tag
+published_at: '2009-08-23T17:09:49-07:00'
+---
+<p>This afternoon I made a small update to the site, adding RSS feeds for every tag in the database. So now, if you like, you can subscribe to the latest content about <a href="http://www.palewire.com/feeds/tag/python/">python</a> or <a href="http://www.palewire.com/feeds/tag/music/">music</a> or <a href="http://www.palewire.com/tags/media/">media</a> or <a href="http://www.palewire.com/tags/">anything else I've got</a>. The feeds are found in the hidden autodiscovery tag at the top of the page, so you'll have to use the pulldown in your browser's URL bar to get at them. But they're there.</p>
+
+<p>Thanks to a number of shortcuts in <a href="http://docs.djangoproject.com/en/dev/ref/contrib/syndication/">Django's feed syndication framework</a> and the excellent <a href="http://code.google.com/p/django-tagging/">django-tagging</a>, it's pretty easy to put something like this together. Here's how I did it.</p>
+
+<p>First, in my blog app's feeds.py file:</p>
+
+<pre lang="python">
+# Feeds
+from django.contrib.syndication.feeds import Feed, FeedDoesNotExist
+
+# Models
+from tagging.models import *
+
+# Helpers
+from django.core.exceptions import ObjectDoesNotExist
+
+
+class TagFeed(Feed):
+    """
+    The most recent content with a particular tag.
+    """
+    
+    def get_object(self, bits):
+        """
+        Fetch the Tag object.
+        """
+        if len(bits) != 1:
+            raise ObjectDoesNotExist
+        return Tag.objects.get(name__exact=bits[0])
+        
+    def title(self, obj):
+        """
+        Set the feed title.
+        """
+        return "%s . tags . palewire" % obj.name.lower()
+
+    def description(self, obj):
+        """
+        Set the feed description.
+        """
+        return "the latest tagged %s" % obj.name.lower()
+
+    def link(self, obj):
+        """
+        Set the feed link.
+        """
+        if not obj:
+            raise FeedDoesNotExist
+        return u'/tags/%s/' % obj.name
+        
+    def items(self, obj):
+        """
+        Fetch the latest 10 objects with a particular tag, which is passed as the `obj` argument.
+        """
+        # Pull all the items with that tag.
+        taggeditem_list = obj.items.all()
+        # Loop through the tagged items and return just the items with a pub_date attribute
+        object_list = [i.object for i in taggeditem_list if getattr(i.object, 'pub_date', False)]
+        # Now resort them by the pub_date attribute with the newest coming first
+        object_list.sort(key=lambda x: x.pub_date, reverse=True)
+        # And return the first ten.
+        return object_list[:10]
+        
+    def item_link(self, obj):
+        """
+        Set the URL for each tagged item, using the url attribute we have on each of our models.
+        """
+        if not obj:
+            raise FeedDoesNotExist
+        return obj.url
+</pre>
+
+<p>I then added the new TagFeed class to my feed dictionary in the urls/feeds.py file. You can see it at the bottom there.</p>
+
+<pre lang="python">
+# urls
+from django.conf.urls.defaults import *
+
+# Feeds
+from coltrane.feeds import *
+
+# Feed index page
+urlpatterns = patterns('django.views.generic',
+    (r'^list/$', 'simple.direct_to_template', {'template': 'coltrane/feed_list.html'}),
+)
+
+# RSS feeds mapped to URL slugs
+feeds = {
+    # Bundles
+    'the-full-feed': FullFeed,
+    'less-noise': LessNoise,
+    # Singletons
+    'posts': RecentPosts,
+    'comments': RecentComments,
+    'shouts': RecentShouts,
+    'links': RecentLinks,
+    'photos': RecentPhotos,
+    'tracks': RecentTracks,
+    'books': RecentBooks,
+    'commits': RecentCommits,
+    'tag': TagFeed,
+}
+
+# Feed urlpattern
+urlpatterns += patterns('',
+    url(r'(?P<url>.*)/$', 'django.contrib.syndication.views.feed', {'feed_dict': feeds}, name='coltrane_feeds'),
+)
+</pre>
+
+<p>And finally added the URL to the autodiscovery portion of the head in my tag_detail.html template.</p>
+
+<pre lang="html">
+{% block extrarss %}
+    <link rel="alternate" type="application/rss+xml" title="latest tagged {{ tag }}" href="/feeds/tag/{{ tag }}/"/>
+{% endblock %}
+</pre>
+
+<p>You can find my blog's entire codebase online <a href="http://github.com/palewire/palewire.com/tree/master">here</a>. And I always appreciate a good criticism. So if you see anything wrong, fire away.</p>

--- a/coltrane/content/posts/2009-09-01--django-recipe-remove-newlines-text-block.md
+++ b/coltrane/content/posts/2009-09-01--django-recipe-remove-newlines-text-block.md
@@ -1,0 +1,51 @@
+---
+title: 'Django recipe: Remove newlines from a text block'
+slug: django-recipe-remove-newlines-text-block
+published_at: '2009-09-01T18:01:17-07:00'
+---
+<p>I like to keep a <a href="http://docs.djangoproject.com/en/dev/intro/tutorial01/">Django app</a> called "toolbox" or "utils" in my projects where I store odds and ends. One recent
+addition is this quickie function for removing any newlines characters found in a block of text.</p>
+
+<p>One place I find it useful is when I'm looking to dump scraped or user-submitted data to a spreadsheet or CSV.</p>
+
+<p>Imagine a file like "toolbox/templatetags/misc_tags.py" within a Django project that looks like so:</p>
+
+<pre lang="python">
+from django import template
+from django.utils.safestring import mark_safe
+from django.template.defaultfilters import stringfilter
+from django.utils.text import normalize_newlines
+
+register = template.Library()
+
+def remove_newlines(text):
+    """
+    Removes all newline characters from a block of text.
+    """
+    # First normalize the newlines using Django's nifty utility
+    normalized_text = normalize_newlines(text)
+    # Then simply remove the newlines like so.
+    return mark_safe(normalized_text.replace('\n', ' '))
+remove_newlines.is_safe = True
+remove_newlines = stringfilter(remove_newlines)
+register.filter(remove_newlines)
+</pre>
+
+<p>It then can be called in the template environment...</p>
+
+<pre lang="html">
+{% load misc_tags %}
+
+{{ foo|remove_newlines }}
+</pre>
+
+<p>...or in the shell.</p>
+
+<pre lang="python">
+>>> from toolbox.templatetags.misc_tags import remove_newlines
+>>> text = 'Line one\nLine two\rLine three\r\nLine four'
+>>> remove_newlines(text)
+'Line one Line two Line three Line four'
+</pre>
+
+<p>That's the whole trick. If there's something I screwed up&mdash;a common event&mdash;feel free to let me know.</p>

--- a/coltrane/content/posts/2009-09-01--python-recipe-fetch-all-days-between-two-dates.md
+++ b/coltrane/content/posts/2009-09-01--python-recipe-fetch-all-days-between-two-dates.md
@@ -1,0 +1,52 @@
+---
+title: 'Python recipe: Fetch all the days between two dates'
+slug: python-recipe-fetch-all-days-between-two-dates
+published_at: '2009-09-01T10:32:05-07:00'
+---
+<p>I've added a new function to my <a href="http://github.com/palewire/python-math/tree/master">python-math library</a> that will return a list&mdash;technically a <a href="http://www.wellho.net/mouth/561_Python-s-Generator-functions.html">generator</a>&mdash;of all of the days between two dates.</p>
+
+<p>There might be a more obvious way to do this, but I don't know it. If you do, please let me know.</p>
+
+<pre lang="python">
+import datetime
+
+def date_range(start_date, end_date):
+    """
+    Returns a generator of all the days between two date objects.
+    
+    Results include the start and end dates.
+    
+    Arguments can be either datetime.datetime or date type objects.
+    
+    h3. Example usage
+    
+        >>> import datetime
+        >>> import calculate
+        >>> dr = calculate.date_range(datetime.date(2009,1,1), datetime.date(2009,1,3))
+        >>> dr
+        <generator object at 0x718e90>
+        >>> list(dr)
+        [datetime.date(2009, 1, 1), datetime.date(2009, 1, 2), datetime.date(2009, 1, 3)]
+        
+    """
+    # If a datetime object gets passed in,
+    # change it to a date so we can do comparisons.
+    if isinstance(start_date, datetime.datetime):
+        start_date = start_date.date()
+    if isinstance(end_date, datetime.datetime):
+        end_date = end_date.date()
+    
+    # Verify that the start_date comes after the end_date.
+    if start_date > end_date:
+        raise ValueError('You provided a start_date that comes after the end_date.')
+    
+    # Jump forward from the start_date...
+    while True:
+        yield start_date
+        # ... one day at a time ...
+        start_date = start_date + datetime.timedelta(days=1)
+        # ... until you reach the end date.
+        if start_date > end_date:
+            break
+
+</pre>

--- a/coltrane/content/posts/2009-09-04--django-recipe-pretty-print-objects-and-querysets.md
+++ b/coltrane/content/posts/2009-09-04--django-recipe-pretty-print-objects-and-querysets.md
@@ -1,0 +1,43 @@
+---
+title: 'Django recipe: Pretty print objects and querysets'
+slug: django-recipe-pretty-print-objects-and-querysets
+published_at: '2009-09-04T13:41:03-07:00'
+---
+<p>Below you can find a utility I use across Django projects called dprint. It's a simple addition to the excellent <a href="http://docs.python.org/library/pprint.html">pprint library</a> that will spit your Django objects and querysets out as dictionaries. The result is that the data are a bit easier to browse while debugging. Or at least I think so.</p>
+
+<p>The odds that I screwed something up or there's an easier way to do this are pretty high. Feel free to tell me about it.</p>
+
+<pre lang="python">
+from django.db.models.query import QuerySet
+from pprint import PrettyPrinter
+
+def dprint(object, stream=None, indent=1, width=80, depth=None):
+    """
+    A small addition to pprint that converts any Django model objects to dictionaries so they print prettier.
+
+    h3. Example usage
+
+        >>> from toolbox.dprint import dprint
+        >>> from app.models import Dummy
+        >>> dprint(Dummy.objects.all().latest())
+         {'first_name': u'Ben',
+          'last_name': u'Welsh',
+          'city': u'Los Angeles',
+          'slug': u'ben-welsh',
+    """
+    # Catch any singleton Django model object that might get passed in
+    if getattr(object, '__metaclass__', None):
+        if object.__metaclass__.__name__ == 'ModelBase':
+            # Convert it to a dictionary
+            object = object.__dict__
+    
+    # Catch any Django QuerySets that might get passed in
+    elif isinstance(object, QuerySet):
+        # Convert it to a list of dictionaries
+        object = [i.__dict__ for i in object]
+        
+    # Pass everything through pprint in the typical way
+    printer = PrettyPrinter(stream=stream, indent=indent, width=width, depth=depth)
+    printer.pprint(object)
+</pre>
+

--- a/coltrane/content/posts/2009-10-24--la-county-public-health-should-just-say-no-pdfs.md
+++ b/coltrane/content/posts/2009-10-24--la-county-public-health-should-just-say-no-pdfs.md
@@ -1,0 +1,16 @@
+---
+title: L.A. County should just say no to PDFs
+slug: la-county-public-health-should-just-say-no-pdfs
+published_at: '2009-10-24T10:05:31-07:00'
+---
+<p><a href="http://www.publichealth.lacounty.gov/index.htm">The L.A. County Department of Public Health</a> is publishing its list of the locations where people in high risk groups can receive a <a href="http://www.newscientist.com/article/dn18014-is-the-swine-flu-vaccine-safe.html">swine flu vaccination</a> exclusively in PDF form. Taxpayers deserve better.</p>
+
+<p>In case you don't know, <a href="http://en.wikipedia.org/wiki/Portable_Document_Format">PDFs</a> are those clunky computerized documents that most people can't read in their browsers, don't show up well in search engines, and are often difficult to find on cluttered web pages because they're buried behind a hyperlink, rather than displayed directly in the browser.</p>
+
+<p>Plus they're difficult for bloggers and developers to republish on other sites, because the data aren't easily portable to other platforms.</p>
+
+<p>This makes it needlessly difficult for people to find out about a critical public health issue.</p>
+
+<p>Instead, L.A. government should be publishing the data in more user-friendly formats. A simple <a href="http://www.w3schools.com/html/html_tables.asp">HTML table</a> would be easy for the public to directly access through search engines and web browsers. And an Excel spreadsheet or <a href="http://github.com/palewire/django-swineflu">CSV file</a> would be easier for online news outlets to download and quickly republish.</p>
+
+<p>To show how easy it would be, I spent an hour or two last night grinding out an application here at palewire that does just that, <a href="http://swineflu.palewire.com">swineflu.palewire.com</a>. Check it out. The codebase is open-source and available on <a href="http://github.com/palewire/django-swineflu">Github</a>.</p>

--- a/coltrane/content/posts/2009-10-29--django-recipe-dynamically-load-your-google-maps-api-key.md
+++ b/coltrane/content/posts/2009-10-29--django-recipe-dynamically-load-your-google-maps-api-key.md
@@ -1,0 +1,92 @@
+---
+title: 'Django recipe: Dynamically load a Google Maps API key'
+slug: django-recipe-dynamically-load-your-google-maps-api-key
+published_at: '2009-10-29T18:06:46-07:00'
+---
+<p>So here's the situation. You've got a <a href="http://www.djangoproject.com/">Django</a> app that uses the <a href="http://code.google.com/apis/maps/">Google Maps API</a>. 
+	And you want to deploy the HTML across multiple domains&mdash;like development, staging and production environments.
+	</p>
+
+<p>Typically, you call Google's Mapping API with your registered API key.</p>
+
+<pre lang="html">
+<script src="http://maps.google.com/maps?file=api&amp;v=2&amp;key=ABQIAAAAE7jH76TvSwj2EbGtTFztGBSZQPaKzcJUNBmscSu8lUTMp7T2MxRd9I3aSZGU4Qk1Ibht_Cu0cZYCqQ" type="text/javascript"></script>
+</pre>
+
+<p>But, in this scenario, each of your domains may require a different Google API key. 
+	Which means you can't just paste the key directly into your HTML template and use it
+	across the board, because it will only work for the one domain where it's registered.
+</p>
+
+<p>Here's my workaround. Create a <a href="http://www.b-list.org/weblog/2006/jun/14/django-tips-template-context-processors/">
+	context processor</a> that will dynamically select your API key depending on the domain, and 
+	automatically pump it into your template so it's always ready for you to call. 
+<p>
+	
+<p>So, instead of pasting in the whole key, like we did above. You end up doing something like this.</p>
+
+<pre lang="html">
+<script src="http://maps.google.com/maps?file=api&amp;v=2&amp;key={{ gmaps_api_key }}" type="text/javascript"></script>
+</pre>
+
+<p>How's it done? Well, I created a folder in my utilities folder, called context_processors, where I made a new file
+	named api_keys.py. Here it is.</p>
+
+<pre lang="python">
+def gmaps(request):
+    """
+    Pulls the Google Maps API key depending on the current domain.
+    """
+    domain2key = {
+        'dev.palewire.com': 'ABQIAAAAE7jH76TvSwj2EbGtTFztGBR8UkcbL4-dL61bzErP2SNv1WNIGBQvXvskpcbuLQTIG7VNcEyd_E-oAA',
+        'stage.palewire.com': 'ABQIAAAAE7jH76TvSwj2EbGtTFztGBSO5LlXme5quZiFrf4fQnu-lsRFhBR1f1qhogtXJLk5oZTcBn8Gty3MPQ',
+        'www.palewire.com': 'ABQIAAAAE7jH76TvSwj2EbGtTFztGBSZQPaKzcJUNBmscSu8lUTMp7T2MxRd9I3aSZGU4Qk1Ibht_Cu0cZYCqQ',
+    }
+    try:
+        server_name = request.META['HTTP_HOST']
+        key = domain2key[server_name]
+    except KeyError:
+        key = domain2key['www.palewire.com']
+
+    return {'gmaps_api_key': key }
+</pre>
+
+<p>First I made a dictionary that crosswalks between my domains and their Google API keys.</p>
+
+<p>Then the code pulls the host from the current request (for a full list of attributes in the request object, visit <a href="http://docs.djangoproject.com/en/dev/ref/request-response/#httprequest-objects">the Django docs</a>), and checks the dictionary to see whether there's a key for that domain.</p>
+
+<p>If it finds one, it passes
+	it out in a variable called gmaps_api_key. If it doesn't find a key for the domain, it defaults to the key for
+	the production environment at www.palewire.com.
+</p>
+
+<p>Before it will work, you'll need to add the file to the context processors list in your settings.py. Mine looks like this.</p>
+
+<pre lang="python">
+    TEMPLATE_CONTEXT_PROCESSORS = (
+        'toolbox.context_processors.api_keys.gmaps',
+        'django.core.context_processors.auth',
+        'django.core.context_processors.debug',
+        'django.core.context_processors.i18n',
+        'django.core.context_processors.media',
+        'django.core.context_processors.request',
+    )
+</pre>
+
+<p>And, don't forget this part, you need to make sure that you're using a view that actually uses the context processors. 
+	Generic views will do it by default, but <a href="http://docs.djangoproject.com/en/dev/topics/http/shortcuts/#render-to-response">render_to_response</a> won't.
+</p>
+
+<p>
+	Because of that shortcoming in render_to_response, I've switched to using the <a href="http://docs.djangoproject.com/en/dev/ref/generic-views/#django-views-generic-simple-direct-to-template">direct_to_template</a> 
+	generic view instead. The only additional code necessary is to include the request in your call, like so.
+</p>
+
+<pre lang="python">
+# So start doing this...
+direct_to_template(request, 'my_app/template.html', {'object_list': object_list})
+# And stop doing this...
+render_to_response('my_app/template.html', {'object_list': object_list})
+</pre>
+
+<p>That's the whole trick. Per usual, feel free to tell me where I screwed up in the comments. We'll sort it out.</p>

--- a/coltrane/content/posts/2010-03-10--google-charts-takes-tufte-challenge.md
+++ b/coltrane/content/posts/2010-03-10--google-charts-takes-tufte-challenge.md
@@ -1,0 +1,121 @@
+---
+title: Google Charts takes the Tufte Challenge
+slug: google-charts-takes-tufte-challenge
+published_at: '2010-03-10T13:13:57-08:00'
+---
+			<style type="text/css">
+    .imgduobumper { clear:both; display:block; height:1em; }
+    .imgduowrapper { display:block; }
+    .imgduoleft { width:365px; margin-left:-2.5em; display:inline; float:left;}
+    .imgduoright { float:right; width:365px; margin-right:-4.5em; display:inline;}
+</style>
+<p>They aren't interactive. They won't impress trendy developers. And they can look pretty hideous. They are <a href="http://code.google.com/apis/charttools/docs/choosing.html">Google Charts</a>. And, despite all that, they're kind of awesome.</p>
+
+<div style="width:300px; float:left; margin-right:15px;">
+<img src="http://chart.apis.google.com/chart?cht=p3&amp;chd=t:106,169,73,14&amp;chds=0,169&amp;chs=300x150&amp;chtt=Ocean+Area&amp;chdl=Atlantic|Pacific|Indian|Arctic&amp;chma=0,0,0,0|70&amp;chco=3366CC|DC3912|FF9900|109618&amp;chp=4.7" />
+</div>
+<p>I wouldn't blame you if you looked at this Google Chart, taken from the official documentation, and considered writing them off. The colors are garish. The data values are difficult to judge. The 3D shape muddles your view. The headline looks lame.</p>
+<p>But behind that ugly chart is a powerful application. And if it's used wisely, it can live up to the highest standards.</p>
+<h2>The Tufte Challenge</h2>
+<p>For as long as I've been paying attention, people smarter than me have been talking about a guy named <a href="http://en.wikipedia.org/wiki/Edward_Tufte">Edward Tufte</a>. He's the <a href="http://en.wikipedia.org/wiki/Billy_graham">Billy Graham</a> of information graphics. Tufte travels the country, preaching his gospel to large crowds, encouraging designers to produce economical graphics that present data as clearly as possible.</p>
+<p>In his widely recommended book <a href="http://www.edwardtufte.com/tufte/books_vdqi">The Visual Display of Quantitative Information</a>, Tufte lays out, step-by-step, how the standard bar chart can be tuned to perfection (pp. 126-128).</p>
+
+<p>To prove once and for all that Google Charts need not be hideous, I will now use them to recreate Tufte's carefully crafted charts. And, with the guidance of my ingenious coworker <a href="http://www.google.com/search?q=Thomas+Suh+Lauder+site%3Awww.latimes.com&amp;ie=utf-8&amp;oe=utf-8&amp;aq=t&amp;rls=com.ubuntu:en-US:official&amp;client=firefox-a">Thomas Suh Lauder</a>, I will, just for the hell of it, attempt to surpass the master.</p>
+<p>First, we start with a bar chart that Tufte describes as conventional. A picture from Tufte's book is on the left, and the Google Chart is on the right.</p>
+<div class="imgduobumper"></div>
+<div class="imgduowrapper">
+<div class="imgduoright">
+<img src="http://chart.apis.google.com/chart?chs=365x250&amp;cht=bvg&amp;chbh=15,5,15&amp;chd=t1:8,12,6,7,3,18,13,9,6,12,5,10&amp;chds=0,20&amp;chco=C8C8C8&amp;chxt=x,y,r,t&amp;chxs=0,C8C8C8,0,0,l,C8C8C8%7C1,C8C8C8,0,0,lt,C8C8C8%7C2,C8C8C8,0,0,lt,C8C8C8%7C3,C8C8C8,0,0,l,C8C8C8&amp;chxp=1,25,50,75%7C2,25,50,75&amp;chxtc=1,-5%7C2,-5" />
+</div>
+<div class="imgduoleft">
+<img src="/media/img/tufte1.JPG" />
+</div>
+</div>
+<div class="imgduobumper"></div>
+<p>Since a Google Chart is nothing more than an automatically generated image, you can review the code for each one simply by right-clicking the image and copying out the URL.</p>
+
+<p>Tufte's first move is to cut the ink along the border.</p>
+<div class="imgduobumper"></div>
+<div class="imgduowrapper">
+<div class="imgduoright">
+<img src="http://chart.apis.google.com/chart?chs=365x250&amp;cht=bvg&amp;chbh=15,5,15&amp;chd=t1:8,12,6,7,3,18,13,9,6,12,5,10&amp;chds=0,20&amp;chco=C8C8C8&amp;chxt=x,y&amp;chxs=0,C8C8C8,0,0,l,C8C8C8%7C1,C8C8C8,0,0,lt,C8C8C8&amp;chxp=1,25,50,75&amp;chxtc=1,-5" />
+</div>
+<div class="imgduoleft">
+<img src="/media/img/tufte2.JPG" />
+</div>
+</div>
+<div class="imgduobumper"></div>
+<p>Then he clips the y-axis, leaving the tick marks.</p>
+<div class="imgduobumper"></div>
+<div class="imgduowrapper">
+<div class="imgduoright">
+
+<img src="http://chart.apis.google.com/chart?chs=365x250&amp;cht=bvg&amp;chbh=15,5,15&amp;chd=t1:8,12,6,7,3,18,13,9,6,12,5,10&amp;chds=0,20&amp;chco=C8C8C8&amp;chxt=x,y&amp;chxs=0,C8C8C8,0,0,l,C8C8C8%7C1,ffffff,0,0,t,000000&amp;chxp=1,25,50,75&amp;chxtc=1,-5" />
+</div>
+<div class="imgduoleft">
+<img src="http://www.palewire.com/media/img/tufte3.JPG" />
+</div>
+</div>
+<div class="imgduobumper"></div>
+<p>Tufte raises the ante by inserting white coordinate lines that segment each bar at the y-axis intervals, something I've matched thanks to a hack Tom developed. Tufte also removes the tick marks, replacing them with y-axis labels.</p>
+<div class="imgduobumper"></div>
+<div class="imgduowrapper">
+<div class="imgduoright">
+<img src="http://chart.apis.google.com/chart?chs=450x250&amp;cht=bvg&amp;chbh=15,5,15&amp;chd=t1:0,8,12,6,7,3,18,13,9,6,12,5,10,0|5,5,5,5,5,5,5,5,5,5,5,5,5,5|10,10,10,10,10,10,10,10,10,10,10,10,10,10|15,15,15,15,15,15,15,15,15,15,15,15,15,15&amp;chds=0,20&amp;chco=ffffff|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|ffffff&amp;chxt=x,y&amp;chxs=1,000000,13,0,t|0,ffffff,13,1,lt,ffffff&amp;chxtc=1,0&amp;chm=D,FFFFFF,1,0,1,1|D,FFFFFF,2,0,1,1|D,FFFFFF,3,0,1,15&amp;chxp=1,25,50,75&amp;chxl=1:|5%|10%|15%|0:|" />
+</div>
+<div class="imgduoleft">
+<img src="http://www.palewire.com/media/img/tufte4.JPG" />
+</div>
+
+</div>
+<div class="imgduobumper"></div>
+<p>And, with his final move, Tufte removes the y-axis labels.
+
+<div class="imgduobumper"></div>
+<div class="imgduowrapper">
+<div class="imgduoright">
+<img src="http://chart.apis.google.com/chart?chs=450x250&amp;cht=bvg&amp;chbh=15,5,15&amp;chd=t1:0,8,12,6,7,3,18,13,9,6,12,5,10,0%7C5,5,5,5,5,5,5,5,5,5,5,5,5,5%7C10,10,10,10,10,10,10,10,10,10,10,10,10,10%7C15,15,15,15,15,15,15,15,15,15,15,15,15,15&amp;chds=0,20&amp;chco=ffffff%7CC8C8C8%7CC8C8C8%7CC8C8C8%7CC8C8C8%7CC8C8C8%7CC8C8C8%7CC8C8C8%7CC8C8C8%7CC8C8C8%7CC8C8C8%7CC8C8C8%7CC8C8C8%7Cffffff&amp;chxt=x,y&amp;chxs=0,ffffff,0,0,t,ffffff%7C1,ffffff,13,1,t,ffffff&amp;chxtc=1,0&amp;chm=D,FFFFFF,1,0,1,1%7CD,FFFFFF,2,0,1,1%7CD,FFFFFF,3,0,1,15&amp;chxs=0,C8C8C8,0,0,l,C8C8C8|1,ffffff,0,0,t,000000&amp;chxp=1,25,50,75" />
+</div>
+<div class="imgduoleft">
+<img src="http://www.palewire.com/media/img/tufte5.JPG" />
+</div>
+</div>
+<div class="imgduobumper"></div>
+</p><p>Now, for the fun part. We will defy the master. We will improve the chart.</p>
+<p>First, by adding x-axis labels that indicate the difference between each column. I like to imagine there's one bar for each month.</p>
+
+<div class="imgduobumper"></div>
+<div class="imgduowrapper">
+<div style="margin-left:7em; width:365px; display:inline;">
+<img src="http://chart.apis.google.com/chart?chs=450x250&amp;cht=bvg&amp;chbh=15,5,15&amp;chd=t1:0,8,12,6,7,3,18,13,9,6,12,5,10,0|5,5,5,5,5,5,5,5,5,5,5,5,5,5|10,10,10,10,10,10,10,10,10,10,10,10,10,10|15,15,15,15,15,15,15,15,15,15,15,15,15,15&amp;chds=0,20&amp;chco=ffffff|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|ffffff&amp;chxt=x,y&amp;chxs=1,ffffff,13,0,t|0,000000,13,0,l,000000&amp;chxtc=1,0ffffff&amp;chm=D,FFFFFF,1,0,1,1|D,FFFFFF,2,0,1,1|D,FFFFFF,3,0,1,15&amp;chxp=1,0&amp;chxl=|0:||J|F|M|A|M|J|J|A|S|O|N|D" />
+</div>
+</div>
+<div class="imgduobumper"></div>
+<p>Then we will add the precise y-axis value for each bar, which gives the reader a much higher level of precision than any previous indicator.</p>
+<div class="imgduobumper"></div>
+<div class="imgduowrapper">
+<div style="margin-left:7em; width:365px; display:inline;">
+<img src="http://chart.apis.google.com/chart?chs=450x250&amp;cht=bvg&amp;chbh=15,5,15&amp;chd=t1:0,8,12,6,7,3,18,13,9,6,12,5,10,0|5,5,5,5,5,5,5,5,5,5,5,5,5,5|10,10,10,10,10,10,10,10,10,10,10,10,10,10|15,15,15,15,15,15,15,15,15,15,15,15,15,15&amp;chds=0,20&amp;chco=ffffff|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|C8C8C8|ffffff&amp;chxt=x,y&amp;chxs=1,ffffff,13,0,t|0,000000,13,0,l,000000&amp;chxtc=1,0ffffff&amp;chm=D,FFFFFF,1,0,1,1|D,FFFFFF,2,0,1,1|D,FFFFFF,3,0,1,15|N,000000,0,1,12|N,000000,0,2,12|N,000000,0,3,11|N,000000,0,4,11|N,000000,0,5,11|N,000000,0,6,11|N,000000,0,7,11|N,000000,0,8,11|N,000000,0,9,11|N,000000,0,10,11|N,000000,0,11,11|N,000000,0,12,11&amp;chxp=1,0&amp;chxl=|0:||J|F|M|A|M|J|J|A|S|O|N|D" />
+</div>
+</div>
+<div class="imgduobumper"></div>
+<h2>That's cute, but now what?</h2>
+
+<p>
+    Good question. None of these example make Google Charts any easier to figure out. And, let's be real, those <a href="http://code.google.com/apis/chart/docs/chart_params.html">crazy URL parameters</a> are tough to get your head around.
+</p>
+<p>
+    My hope is this exercise can convince you that Google Charts shouldn't be dismissed. They can look halfway good.
+</p>
+<p>But, beyond appearances, they have a lot going for them on the backend, too.</p>
+<p>If you integrate Google Charts with a database framework like Django,
+    you can scale to the moon. At the Los Angeles Times, we use a branch of Jacob Kaplan-Moss's <a href="http://github.com/jacobian/django-googlecharts">django-googlecharts</a>
+    to automatically generate thousands of charts about Census data in
+    <a href="http://mappingla.com/north-hollywood">L.A. neighborhoods</a> (check out the accordions). We can easily pull off Tom's coordinate line hack using some code I patched to the app. And, thanks to the magic of Python, we do it all without crafting a single crazy URL. 
+
+</p>
+<p><a href="http://projects.latimes.com/hollywood/star-walk/about/#star-types">Elsewhere</a>,
+    we integrate a one-off Google Charts with a little CSS to mimic the style of the newspaper online. That's something you could replicate with the handy <a href="http://dexautomation.com/googlechartgenerator.php">Google Chart Creator</a> and a well-crafted HTML wrapper.
+</p>
+<p>Once you're flying, Google Charts can save you a lot of time. You can make Tufte-approved charts without the help of a Flash developer or outside designer. And since they're nothing more than flat image files, they will immediately work in even <a href="http://en.wikipedia.org/wiki/Internet_Explorer_6">the most difficult environments</a>. What's not to love?</p>
+			

--- a/coltrane/content/posts/2010-03-24--fabric-recipe-delete-pyc-files-runserver-starts.md
+++ b/coltrane/content/posts/2010-03-24--fabric-recipe-delete-pyc-files-runserver-starts.md
@@ -1,0 +1,23 @@
+---
+title: ' Fabric recipe: Delete pyc files before runserver starts'
+slug: fabric-recipe-delete-pyc-files-runserver-starts
+published_at: '2010-03-24T13:19:09-07:00'
+---
+<p>Here's a quick Fabric function that will clean out any pyc files in your Django project before firing up. It's nice to do this when you're building a site on your computer, since lingering pyc files can keep old code alive if you're not careful.</p>
+
+<p>Fabric can also save you a keystroke or two. Heck, you could trim things down even more and name this function something like "rs."</p>
+
+<pre lang="python">
+def runserver(port=8000):
+    """
+    Fire up the Django test server, after cleaning out any .pyc files.
+
+    Example usage:
+    
+        $ fab runserver
+        $ fab runserver:port=8001
+    
+    """
+    local("find . -name '*.pyc' -print0|xargs -0 rm", capture=False)
+    local("./manage.py runserver %s" % port, capture=False)
+</pre>

--- a/coltrane/content/posts/2010-11-07--django-recipe-twitter-style-infinite-scroll.md
+++ b/coltrane/content/posts/2010-11-07--django-recipe-twitter-style-infinite-scroll.md
@@ -1,0 +1,177 @@
+---
+title: 'Django recipe: Twitter-style infinite scroll'
+slug: django-recipe-twitter-style-infinite-scroll
+published_at: '2010-11-07T12:36:59-08:00'
+---
+<p>Twitter added a cool feature. As you scroll down the page, more and more tweets are added to the bottom of the page. It creates an "infinite scroll" where you can read hundreds of tweets without having to click a single button. It's nice.</p>
+
+<p>So, let's say you run a site that features a long list. And, let's say you'd like that list to automatically expand in the same way Twitter does. How would you make it happen?</p>
+
+<p>I can't say I know the best way to do it, but I have a hacked out solution using <a href="http://docs.djangoproject.com/en/dev/topics/pagination/?from=olddocs">Django's pagination system</a> and <a href="http://jquery.com/">jQuery</a> with <a href="/applications/twitter-style-infinite-scroll-with-django-demo/" target="_blank">a demo posted here</a>. Here's what you need:</p>
+
+<h2>01. A view that pulls the first page of data</h2>
+
+<p>Mine passes out the <a href="/tracks/page/1/">latest tracks</a> logged by palewire.com's robot massive.</p>
+
+<pre lang="python">from django.views.generic.simple import direct_to_template
+from django.core.paginator import Paginator, InvalidPage
+from coltrane.models import Track
+
+def newtwitter_pagination_index(request):
+    """
+    An index page where we can lay out how to pull off Twitter style
+    pagination. 
+    
+    Passes out the 100 latest tracks to seed the page.
+    """
+    # Pull the data
+    object_list = Track.objects.all()
+    
+    # Grab the first page of 100 items
+    paginator = Paginator(object_list, 100)
+    page_obj = paginator.page(1)
+    
+    # Pass out the data
+    context = {
+        "object_list": page_obj.object_list,
+        "page": page_obj,
+    }
+    template = 'newtwitter_pagination/index.html'
+    return direct_to_template(request, template, context)</pre>
+
+<h2>02. An HTML template that lays out the list</h2>
+
+<p>Here's the part where I place the object_list pulled above. Notice how it has that anchor div at the end. We'll use that later.</p>
+
+<pre lang="html"><ul class="newtwitter">
+    {% for object in object_list %}
+    <li>
+        <a href="{{ object.url }}">
+        {{ object.pub_date|date:"U" }}:&nbsp;&nbsp;&nbsp;{{ object|truncatewords:10 }}
+        </a> 
+    </li>
+    {% endfor %}
+    <div id="newtwitter-anchor"></div>
+</ul>
+</pre>
+
+<h2>03. A view that pulls any page and serves it as JSON</h2>
+
+<p>My view looks like this:</p>
+
+<pre lang="python">def newtwitter_pagination_json(request, page):
+    """
+    A JSON feed to feed updates to the index page as the user
+    scrolls down the page. 
+    
+    Passes out pages of Track objects based on the `page` kwarg.
+    """
+    # Pull the data
+    object_list = Track.objects.all()
+    
+    # Pull the proper items for this page
+    paginator = Paginator(object_list, 100)
+    try:
+        page_obj = paginator.page(page)
+    except InvalidPage:
+        # Return 404 if the page doesn't exist
+        raise Http404
+    
+    # Pass out the data
+    context = {
+        "object_list": page_obj.object_list,
+        "page": page_obj,
+    }
+    template = 'newtwitter_pagination/tracks.json'
+    return direct_to_template(request, template, context, 'text/javascript')</pre>
+
+<p>It hooks up to the JSON template like this. Don't worry about the special templatetags. All they do is help clip the string.</p>
+
+<pre lang="javascript">{{% load coltrane_tags %}
+    "page": {{ page.number }},
+    "hasNext": {{ page.has_next|lower }},
+    "itemList": [{% for obj in page.object_list %}
+        {"string": "{{ obj.pub_date|date:"U" }}:&nbsp;&nbsp;&nbsp;{{ obj|truncatewords:10|escapejs }}", "url": "{{ obj.url }}"}{% if not forloop.last %},{% endif %}{% endfor %}
+    ]
+}</pre>
+
+<p>The two views are wired to urls that look like this.</p>
+
+<pre lang="python">from django.conf.urls.defaults import *
+from coltrane import views
+
+urlpatterns = patterns('',
+    
+    # newtwitter style autopagination with django
+    url(r'^twitter-style-infinite-scroll-with-django-demo/$',
+        views.newtwitter_pagination_index,
+        name='coltrane_app_newtwitter_index'),
+    
+    url(r'^twitter-style-infinite-scroll-with-django-demo/json/(?P<page>[0-9]+)/',
+        views.newtwitter_pagination_json,
+        name='coltrane_app_newtwitter_json')
+)</pre>
+
+<h2>04. JavaScript that loads JSON, is hooked to scroll event</h2>
+
+<p>There's a function in the head of <a href="/applications/twitter-style-infinite-scroll-with-django-demo/">the demo</a> that hits the JSON view and loads the data as list items just above our anchor div. It's called loadItems below.</p>
+
+<p>It's hooked to the scroller using jQuery's $(window).bind() function. The decision on when to trigger an update is handled in that loadOnScroll function which checks the current position of the scroller against the cutoff I've put in.</p>
+
+<p>You can adjust where that is by increasing or decreasing the number 3 I tossed in there. That works okay for this site, which has a small footer, but you might want a bigger or smaller one depending on your site's design.</p>
+
+<p>The scroll handler is wired up in the $(document).ready() bit at the end there.</p>
+
+<pre lang="javascript">// Scroll globals
+var pageNum = {{ page.number }}; // The latest page loaded
+var hasNextPage = {{ page.has_next|lower }}; // Indicates whether to expect another page after this one
+var baseUrl = '{% url coltrane_app_newtwitter_index %}'; // The root for the JSON calls
+
+// loadOnScroll handler
+var loadOnScroll = function() {
+   // If the current scroll position is past out cutoff point...
+    if ($(window).scrollTop() > $(document).height() - ($(window).height()*3)) {
+        // temporarily unhook the scroll event watcher so we don't call a bunch of times in a row
+        $(window).unbind();
+        // execute the load function below that will visit the JSON feed and stuff data into the HTML
+        loadItems();
+    }
+};
+
+var loadItems = function() {
+    // If the next page doesn't exist, just quit now 
+    if (hasNextPage === false) {
+        return false
+    }
+    // Update the page number
+    pageNum = pageNum + 1;
+    // Configure the url we're about to hit
+    var url = baseUrl + "json/" + pageNum + '/';
+    $.ajax({
+        url: url, 
+        dataType: 'json',
+        success: function(data) {
+            // Update global next page variable
+            hasNextPage = data.hasNext;
+            // Loop through all items
+            var html = [];
+            $.each(data.itemList, function(index, item){
+                /* Format the item in our HTML style */
+                html.push('<li><a href="', item.url, '">', item.string, '</a></li>')
+            });
+            // Pop all our items out into the page
+            $("#newtwitter-anchor").before(html.join(""));
+        },
+        complete: function(data, textStatus){
+            // Turn the scroll monitor back on
+            $(window).bind('scroll', loadOnScroll);
+        }
+    });
+};
+
+$(document).ready(function(){     
+   $(window).bind('scroll', loadOnScroll);
+});
+</pre>
+
+<p>And that's pretty much all the moving parts. Obviously, not rocket science. And hardly innovative on my part. There are much more sophisticated implementations <a href="http://code.google.com/p/django-endless-pagination/">here</a> and <a href="http://www.infinite-scroll.com/">here</a> that I glanced at before deciding to hack out what's above. The loadOnScroll handler is my perversion of what I found open-sourced in <a href="http://code.google.com/p/django-endless-pagination/">django-endless-pagination</a>. If you see anything that sucks, let me know in the comments below.</p>

--- a/coltrane/content/posts/2010-11-10--zain-memon-tells-how-tendermaps-works.md
+++ b/coltrane/content/posts/2010-11-10--zain-memon-tells-how-tendermaps-works.md
@@ -1,0 +1,46 @@
+---
+title: 'Q&A: Zain Memon tells how Tendermaps works'
+slug: zain-memon-tells-how-tendermaps-works
+published_at: '2010-11-10T07:53:40-08:00'
+---
+<img style="width:600px; border:3px solid #E5E5E5" src="/media/img/tendermaps-hand-600x448.png">
+
+<p>Last weekend, San Francisco developers converged at <a href="http://www.gaffta.org/2010/11/09/the-great-urban-hack-re-cap/">The Great Urban Hack</a> to crank out some civically-minded sites. The focus was on the city's famous <a href="http://en.wikipedia.org/wiki/Tenderloin,_San_Francisco">Tenderloin neighborhood</a>. (Don't know it? Think <a href="http://en.wikipedia.org/wiki/Stonewall_riots">Stonewall</a> or <a href="http://en.wikipedia.org/wiki/The_Maltese_Falcon_(novel)">The Maltese Falcon</a>.)
+
+<p>The one that caught my eye was <a href="http://tendermaps.com/">Tendermaps</a>. It's an interactive map of the neighborhood, but it's not drawn by the city government or <a href="http://projects.latimes.com/mapping-la/neighborhoods/">self-appointed journalists</a>. No, it's a collage of boundaries and landmarks drawn&mdash; by hand, <a href="http://www.sharpie.com/">with Sharpies</a>&mdash;by people who live and work in the area. <a href="http://tendermaps.com/">Check it out</a>.</p>
+
+<p>To learn how it got online, I conducted an email interview with one of the developers, <a href="http://twitter.com/zainy">Zain Memon</a>. Here's what he said.</p>
+
+<div id="detailborderbumper" class="thin"></div>
+
+<p>How did you get the Sharpie drawings onto an online map?  I see you wrote they were "scanned, and the handmade mark-ups extracted, georectified, and superimposed," but I'm hoping you can be specific (a.k.a geeky) about the process. How is each one of those steps accomplished?</p>
+
+<blockquote><p>We used <a href="http://walking-papers.org/">walking-papers.org</a> to generate paper map prints of the tenderloin. We printed these out in grayscale and had people mark them up with colored sharpies. Here's <a href="http://c0848462.cdn.cloudfiles.rackspacecloud.com/d18e50bd35a8ebc5861ff309bccc064e.png">a picture</a> of one of them.</p>
+
+<p>We scanned all of the maps into JPEGs and then used the <a href="http://www.pythonware.com/products/pil/">Python Imaging Library</a> to lift drawings off them. The coolest part was separating the drawings from the map itself &mdash; we basically checked each pixel's color, threw away the grayscale, and antialiased the rest.  By reading the <a href="http://en.wikipedia.org/wiki/QR_Code">QR code</a> in the bottom right corner, we gathered the bounding box of the map, and from there we could easily slice up the drawing into georectified tiles: one tile layer for each map.</p></blockquote>
+
+<p>Is any of the python code available online?</p>
+
+<blockquote><p>Not at the moment, no. But the walking-papers code is available at <a href="https://github.com/migurski/paperwalking">https://github.com/migurski/paperwalking</a> (written by the venerable <a href="http://mike.teczno.com/">Mike Migurski</a> of <a href="http://stamen.com/">Stamen</a>). We'll clean up our decoder and throw it on github at some point too.</p></blockquote>
+
+<p>If someone wanted to learn how to use PIL and other python tools to digitize printed data, how would you suggest they go about doing it?</p>
+
+<blockquote><p>I learned everything I know by playing with the tools available out there. It seems daunting at first, but once you start on a project, you suddenly find all these amazing libraries that make the impossible become possible and the difficult become easy. The <a href="http://www.pythonware.com/library/pil/handbook/index.htm">PIL tutorial and handbook</a> is a great place to start, as is the documentation for libraries like <a href="http://opencv.willowgarage.com/wiki/">OpenCV</a>, <a href="http://cairographics.org/pycairo/">pycairo</a>, and <a href="http://www.imagemagick.org/script/index.php">ImageMagick</a>.</p></blockquote>
+
+<p>After you've collected a set of geospatial survey data, like you did here, what options do you have for aggregating it for analysis?</p>
+
+<p>Correct me where I'm wrong, but it seems to me that tendermaps mainly tosses everything on the map and then allows users to filter it down using a set of browser knobs. I'm curious what other options there might be for mashing all the entries together and coming out with a finished product.</p>
+
+<blockquote><p>That's a great question. We chose to throw everything onto the map is because it really showed the order within the chaos of two dozen handwritten maps on the same screen.</p>
+
+<p>It would've been really cool to have different views into the people behind the data too. For example, we heard a great suggestion asking for a map of the paths that young women take through the tenderloin, because those paths are presumably safer. It would be really interesting to see maps diving into those sorts of verticals.</p></blockquote>
+
+<p>Did you use <a href="http://geodjango.org/">GeoDjango</a> for this project? If so, how? If not, why not?</p>
+
+<blockquote><p>Nope &mdash; the webserver backend is written with <a href="http://flask.pocoo.org/">Flask</a>. We georectified the tiles when saving them so we didn't need a geospatial database.</p></blockquote>
+
+<p>Who all worked on the project, what role did they play, and how much time did they put in?</p>
+
+<blockquote>I did all the back-end Python coding. <a href="http://twitter.com/#!/shashashasha">Sha Hwang</a> did all of the front-end (html/css/javascript). <a href="http://twitter.com/#!/the_hip_hapa">Jen Phillips</a> and <a href="http://twitter.com/#!/almostsci">Alan Rorie</a> went around the tenderloin and interviewed all the people who gave us maps. We were all at <a href="http://www.gaffta.org/">GAFFTA</a> working on tendermaps from Saturday morning to late Sunday afternoon.</blockquote>
+
+<p>That's all I asked. If you have any more questions, drop them in the comments and maybe we can get Zain to answer them below.</p>

--- a/coltrane/content/posts/2010-12-16--introducing-pluggable-maps-geodjango.md
+++ b/coltrane/content/posts/2010-12-16--introducing-pluggable-maps-geodjango.md
@@ -1,0 +1,21 @@
+---
+title: Introducing Pluggable Maps for GeoDjango
+slug: introducing-pluggable-maps-geodjango
+published_at: '2010-12-16T15:59:50-08:00'
+---
+<iframe src="https://docs.google.com/present/embed?id=ddw9cxb8_36ct9n7kcc&size=m" frameborder="0" width="555" height="451"></iframe>
+
+<p>Tonight in Pasadena I will be speaking at the Hacks/Hackers event <a href="http://meetupla.hackshackers.com/calendar/15624221/">
+Data Visualization: An Open Brainstorm</a>. There I will babble on a bit while flipping through the slideshow above.</p>
+
+<p>The idea is pretty simple: GeoDjango apps should aim to be just as reusable as any other Django app. And, when they are, they can open
+up some fun possiblities.</p>
+
+<p>To try and prove the point, I'm introducing <a href="https://github.com/datadesk/latimes-pluggablemaps-uscounties">
+latimes-pluggablemaps-uscounties</a>, which attempts to set a template for redistributing a common GIS dataset. I'm also releasing
+<a href="https://github.com/datadesk/hackshackers-dec2010">hackhackers-dec2010</a>, an example GeoDjango project that plugs it into a 
+living, breathing news app.</p>
+
+<p>Most importantly, I'll be closing my talk with a call for intern applications. If you want to work at <a href="http://latimes.com">
+@latimes</a> with the Data Desk, give <a href="mailto:ben.welsh@latimes.com">me</a> a shout or contact my boss, <a href="mailto:daniel.gaines.@latimes.com">
+Daniel Gaines</a>.

--- a/coltrane/content/posts/2011-02-24--postgis-is-your-new-bicycle.md
+++ b/coltrane/content/posts/2011-02-24--postgis-is-your-new-bicycle.md
@@ -1,0 +1,10 @@
+---
+title: PostGIS is your new bicycle
+slug: postgis-is-your-new-bicycle
+published_at: '2011-02-24T14:36:19-08:00'
+---
+<iframe src="https://docs.google.com/present/embed?id=ddw9cxb8_92g39cvqd9&size=m" frameborder="0" width="555" height="451"></iframe>
+
+<p>Today, <a href="http://twitter.com/mikejcorey">Mike Corey</a> and I gave a brief talk on <a href="http://www.postgis.org/">PostGIS</a> at the <a href="http://www.ire.org/training/conference/CAR11/">NICAR 2011 conference</a>. We tried to sell the news geeks on it, and you can see the slides above.</p>
+
+<p>Your questions can go below.</p>

--- a/coltrane/content/posts/2011-02-26--break-news-on-google-app-engine.md
+++ b/coltrane/content/posts/2011-02-26--break-news-on-google-app-engine.md
@@ -1,0 +1,16 @@
+---
+title: How to break news on Google App Engine
+slug: break-news-on-google-app-engine
+published_at: '2011-02-26T05:08:47-08:00'
+---
+<iframe src="https://docs.google.com/present/embed?id=ddw9cxb8_105d7gddvcw&size=m" frameborder="0" width="555" height="451"></iframe>
+
+<p>Yesterday, I gave a five-minute lightning talk at the <a href="http://www.ire.org/training/conference/CAR11/">NICAR</a> conference in Raleigh, North Carolina. I talked briefly about how our team at <a href="http://latimes.com">latimes.com</a> has used Google App Engine to host some simple Django applications. You can see the slides above.</p>
+
+<p>We also took the opportunity to announce a few open-source releases related to App Engine. They are:</p>
+
+<ul>
+ <li><a href="https://github.com/datadesk/latimes-appengine-template">latimes-appengine-template</a>: A simple library for bootstrapping a Google App Engine project with Django and the other goodies we like already installed.</li>
+ <li><a href="https://github.com/datadesk/latimes-table-stacker">latimes-table-stacker</a>: A white-label App Engine app that will publish spreadsheets as interactive tables. It plays off great libraries by <a href="https://github.com/thejefflarson">Jeff Larson</a> and <a href="https://github.com/eyeseast">Chris Amico</a>. You can see the demo <a href="http://table-stacker.appspot.com/">here</a> and our version at <a href="http://spreadsheets.latimes.com/">spreadsheets.latimes.com</a>.</li>
+ <li><a href="https://github.com/datadesk/latimes-document-stacker">latimes-document-stacker</a>: A white label version of our <a href="http://documentcloud.org">DocumentCloud</a> repository at <a href="http://documents.latimes.com/">documents.latimes.com</a>, which is also hosted on App Engine. It's inspired by some great code by <a href="https://github.com/JoeGermuska">Joe Germuska</a>.</li>
+</ul>

--- a/coltrane/content/posts/2011-08-14--brian-boyer-on-panda.md
+++ b/coltrane/content/posts/2011-08-14--brian-boyer-on-panda.md
@@ -1,0 +1,126 @@
+---
+title: 'Q&A: Brian Boyer on the plan for PANDA'
+slug: brian-boyer-on-panda
+published_at: '2011-08-14T22:51:05-07:00'
+---
+<p>This summer, the Chicago Tribune won <a href="http://www.knightfoundation.org/grants/20110152/">a $150,000 grant</a> through the Knight News Challenge to create PANDA, a software tool aimed at helping reporters clean up data. To find out more about it, I conducted an email interview with the project's leader, <a href="http://hackerjournalist.net/">Brian Boyer</a>.</p>
+
+<p>You can read the entire transcript below, but here are the quick takeaways I had:</p>
+
+<ul>
+    <li>PANDA is conceived as an online warehouse where newsrooms can store data sets.</li>
+    <li>To me, it sounds like some combination of Google Refine and Google Fusion Tables tailored to suit newsroom needs.</li>
+    <li>Any newsroom will be allowed to use it, and they shouldn't need a full-time geek to make it work.</li>
+    <li>All of the code will be open on <a href="http://github.com">Github</a> "from day one" under an <a href="http://en.wikipedia.org/wiki/MIT_License">MIT license</a>.</li>
+</ul>
+
+<p>It must be said, I'm biased. Brian and I work for <a href="http://www.tribune.com/">the same parent company</a> and I'm rooting for him to succeed. So if you think I'm letting him off the hook, fire away in the comments and we'll see if we can keep him answering.</p>
+
+<div id="detailborderbumper" class="thin"></div>
+
+<p>In <a href="http://www.knightfoundation.org/grants/20110152/">a video about PANDA</a> on the Knight News Challenge's website, you describe it as a "newsroom data appliance." What is that?</p>
+
+<blockquote><p>PANDA will be a place for folks in the newsroom to stash their data,
+and a tool for helping reporters search and compare data sets. It will
+not be a publishing tool, and is not intended to address the needs of
+readers. It will be an appliance in the same way Google sells
+appliances for your intranet -- it will be a cloud-hosted system,
+provisioned for each newsroom that signs up. Each newsroom will pay
+their own hosting costs, which we will try to keep very low.</p></blockquote>
+
+<p>How will it be different from something like <a href="http://en.wikipedia.org/wiki/Google_Fusion_Tables">Google Fusion Tables?</a></p>
+
+<blockquote><p>We envision Google Fusion Tables as one of many ways you can further
+explore or present your data, after it's been run through PANDA. Alex
+Howard wrote up a good piece the other day about an idea that Jonathan
+Stray and I were talking about: <a href="http://radar.oreilly.com/2011/07/data-journalism-tools-newsroom-stack.html">the newsroom stack</a>.</p>
+
+<p>The stack would be your kit of tools you use to deal with data, and
+each tool helps with a different layer of abstraction.</p>
+
+<p>So for example, you write a FOIA and they send you a group of
+100-column Excel files. (Each numbered step is sort of a concept, each
+tool is, in my mind, a layer of the stack. This may be better as an
+infographic with arrows and icons.)</p>
+
+<p>1. Prepare the data<br>
+Excel: Save each file to CSV<br>
+CSVKit: Join the files into one, and cut out the columns you don't care for<br>
+Refine: Normalize the hand-entered values in the columns<br></p>
+
+<p>2. Find stuff<br>
+Refine + PANDA: Compare your dataset to other datasets you've got in PANDA<br>
+PANDA: Upload the dataset (and original docs, for archival purposes)<br>
+so you can search through it quickly, and so that your peers can see
+it easily</p>
+
+<p>3. Explore in other tools and/or publish<br>
+Google Fusion Tables: Export the dataset (or a subset) to FT to see it on a map<br>
+Overview (Mr. Stray's project): Export to do fancy semantic stuff<br>
+TileMill: Export to make sweet slippy maps<br>
+PostGIS/QGIS: Export to a database to do proper GIS analysis</p></blockquote>
+
+<p>So you see PANDA as integrating with <a href="http://code.google.com/p/google-refine/">Google's Refine?</a> How would that work?</p>
+
+<blockquote><p>Refine was originally created as a tool to tidy up data on it's way
+into Freebase. One of it's fancier features is to compare one of your
+columns with data in Freebase. So for instance, your dataset is a list
+of all the dogs registered in your county.</p>
+
+<p>The first thing you'd do is clean up the column of the dogs' breeds.
+Refine gives you great tools to find clusters of similar values
+(Golden Retriever, Golden Retreiver, Golden Retr, etc.) and replace
+them with a single proper value.</p>
+
+<p>But let's say that you want to know the popularity of the breeds.
+Well, you can instruct Refine to join to tables in Freebase, and carry
+over columns of data. So, you can match up your newly-tidy breed
+column to the list of dog breeds in Freebase, and add the Kennel Club
+Ranking column from Freebase to your dataset.</p>
+
+<p>So, back to PANDA... re-read the above example, but replace "dogs"
+with "campaign donors", "breeds" with "companies a person works for",
+"Kennel Club Ranking" with "payments for services rendered to city
+agencies".</p>
+
+<p>Or something. I don't have a perfect example because if I did, we'd
+have written the story, or I wouldn't be writing about it. I'm hoping
+that reporters will find interesting ways to join up data sets that we
+haven't yet thought of -- it will be a somewhat open-ended tool.</p></blockquote>
+
+<p>Will you be incorporating code from Refine, or mimicking it?</p>
+
+<blockquote><p>Refine has a plugin architecture. The plan is that folks would use
+Refine, with a PANDA plugin.</p></blockquote>
+
+<p>Existing sites like Google Fusion Tables have incredible features, but tend to bog down on large datasets. Will PANDA be able to work with datasets that contain tens of thousands &mdash; or, for that matter, hundreds of thousands &mdash; of records?</p>
+
+<blockquote><p>We were just discussing multi-million row datasets (like voter
+registration lists) and the consensus was yes, we absolutely must
+handle data that big.</p></blockquote>
+
+<p>What's the development plan? Who will be building what? And will any of the code or tickets or anything be online before the initial release?</p>
+
+<blockquote><p>All the code and tickets will be on GitHub from day one. We don't have
+a detailed development plan yet -- when we get our first check from
+Knight, we'll start working on the project in earnest. We'll have a
+full-time developer on staff for the length of the grant (one year)
+and part-time/contract help for design and UX work.</p></blockquote>
+
+<p>Who will be allowed to use PANDA? Will be limited to news organizations you approve, like DocumentCloud, or will anyone be able to create an account?</p>
+
+<blockquote><p>We plan to make PANDA freely available to anybody who finds a use for
+it. That said, PANDA will be built with news organizations in mind, so
+if folks want a general-purpose data appliance (instead of a newsroom
+data appliance), they're welcome to fork the code and modify it for
+their own use.</p></blockquote>
+
+<p>Will a newsroom need a developer, like the people on your team, to participate? Or will they be able to sign up and throw reporters at it?</p>
+
+<blockquote><p>The goal is to create a system that a newsroom can fire up with no
+technical people on-hand. You'll likely get more out of PANDA if
+you've got data manipulation skills, but that won't be a requirement.</p></blockquote>
+
+<p>Finally, what software license will you release under? And how was that worked out with Knight?</p>
+
+<blockquote><p>MIT. I don't think we really worked it out. But that's the plan!</p></blockquote>

--- a/coltrane/content/posts/2011-09-26--miranda-mulligan-responsive-design.md
+++ b/coltrane/content/posts/2011-09-26--miranda-mulligan-responsive-design.md
@@ -1,0 +1,63 @@
+---
+title: 'Q&A: Miranda Mulligan dishes on responsive design'
+slug: miranda-mulligan-responsive-design
+published_at: '2011-09-26T18:37:55-07:00'
+---
+<p>The <a href="http://www.alistapart.com/articles/responsive-web-design/">"responsive design"</a> of the new <a href="http://bostonglobe.com">bostonglobe.com</a> is one of the most talked about newspaper.com events of the year. Built using a system that tailors the page's design to the user's device, it sizes down for mobile phones and sizes up for desktop monitors.</p>
+
+<p>To learn more about how it happened, I conducted an email interview with <a href="http://www.linkedin.com/in/mirandamulligan">Miranda Mulligan</a>, the Globe's digital design director.</p>
+
+<p>You can read the entire transcript below, but here are my quick takeaways:</p>
+
+<ul>
+    <li>The new bostonglobe.com took a year "from inception to launch."</li>
+    <li>Mulligan thinks the technology's cross-platform potential makes it "not a terribly hard sell" to the business side.</li>
+    <li>The new frontend is rolling out with a new CMS backend and "everyone's jobs changed."</li>
+    <li>Mulligan underscores that boston.com and bostonglobe.com are "two different products."</li>
+    <li>Mulligan is with the legion of developers who think making sites "comp to code needs a rethink."</li>
+    <li>Existing open-source kits for responsive design don't cut it.</li>
+    <li>Getting display ads to work across devices is difficult and still needs work.</li>
+</ul>
+
+<div class="detailborderbreak"></div>
+
+<p>How long did this take, from beginning to launch?</p>
+
+<blockquote><p><a href="https://twitter.com/#!/jeffmoriarty">Jeff Moriarty</a>, our VP of Product and Development had started working on defining the new site (<a href="http://bostonglobe.com">BostonGlobe.com</a>) in late summer of last year. He and <a href="http://www.linkedin.com/pub/dan-zedek/3/b96/872">Dan Zedek</a> had conceived some of the early prototypes and when I joined the Globe (in September), I joined the party. We found a great partner for the visual design of the site in <a href="http://upstatement.com/">Upstatement</a> and <a href="http://www.filamentgroup.com/">Filament Group</a> and <a href="http://unstoppablerobotninja.com/about/">Ethan Marcotte</a> joined us in the end of the year. So, I'd say it took a little over a year from inception to launch. However, we began a deep dive on the design and build of this site -- from scratch -- at the beginning of this year.</p></blockquote>
+
+<p>How does a geek concept like responsive design germinate inside a newspaper company like the Boston Globe? Print media executives are reputed to be totally out of it. So how was the idea sold internally?</p>
+
+<blockquote><p>When defining the news site, Jeff had become obsessed with idea of having it available at any entry point: desktop, tablet and mobile. It is easy to become overwhelmed by the ever-increasing range of devices in the market and it is not realistic to try and design for everything. In the fall, we met <a href="http://www.linkedin.com/in/toddparker">Todd Parker</a> and <a href="http://www.linkedin.com/profile/view?id=1401177">Patty Toland</a> at The Filament Group in Boston, whose team had popularized the concept of <a href="http://en.wikipedia.org/wiki/Progressive_enhancement">progressive enhancement</a>. (In fact, my second week of working at the Globe, Jeff walked by my desk, dropped off a copy of <a href="http://www.filamentgroup.com/dwpe/">their book</a> and said "Weekend homework.") As we talked to them about our project, they thought to reach out to Ethan to see if he was interested in joining the party. By the time we were all gathering for an official kickoff, it was really exciting that we were on the same page and the next step was to figure out if we could do it.</p>
+
+<p>Also, I think the other half of your question is getting at the idea that it takes a lot of internal stakeholder buy-in to turn a large ship, correct?:</p>
+
+<p>Well, when you think of what we were trying to do from 30,000 feet, it was not a terribly hard sell. At its root, this design approach takes full advantage of the most popular app on any device – the Web browser. So, we are not even asking users to go download something to read our content. Also, it should be understood, BostonGlobe.com is a new product. There is no legacy. The Globe content has always been digitally published to <a href="http://boston.com">Boston.com</a>, with a primary entry point of "Today's Globe" section of Boston.com. We also have an Adobe Air-based paid app called <a href="http://boston.com/bostonglobe/reader/">GlobeReader</a> that’s been available for the past several years. After much research, there seemed to be an argument to be made there was an audience for a long-form, immersive reading experience like the one we have tried to create for BostonGlobe.com. It really has been an incredible year to work for The Boston Globe.</p>
+
+<p>Also, I am not sure that it is fair to dump all large, 'old media' news organizations into the same 'Print media executives are reputed to be totally out of it' bucket. I balk at the idea that you have to go the journalism-start-up route in order to try something fresh. In my experience, the are some really awesome, smart people in the trenches as well as at the executive table.</p></blockquote>
+
+<p>The cosmetic changes between boston.com and bostonglobe.com look drastic. Is the same true for the backend? How does the new site integrate with your preexisting CMS? How has it changed the staffing and workflow (i.e. photo cropping, CMS jockeying) necessary to publish each day?</p>
+
+<blockquote><p>Actually we are currently implementing a new CMS and BostonGlobe.com is the first of the publishing points to go on it. Next will be the print edition of The Boston Globe and we will be moving Boston.com into it next year. The new CMS meant everyone's jobs changed: i.e. how reporters filed their stories, how budgets were managed, how picture editors attached photos to stories, copy editors, artists, designers etc. The managing editor likes to joke that we have changed everything that we could possibly change digitally in 2011 including our email client.</p>
+
+<p>Also, it should be understood, Boston.com and BostonGlobe.com are two different products, intended for two different audiences.</p></blockquote>
+
+<p>How does a design system like this adjust to the demands of a newspaper site? I noticed that the second column tends to jump to the top on smaller devices. Why did you do that? And what other things are baked in that are different from an off the shelf responsive-design kit?</p>
+
+<blockquote><p>In short, there isn't really an "off-the-shelf responsive design kit" In fact, we talk about the design process being heavily reliant on a highly collaborative, design-development cycle. It involves rapid prototyping and designing, mostly, in the browser. Web design has two buckets, right? Visual design and interaction design. Therefore, the traditional process of going from comp to code needs a rethink, especially when designing a responsive site.</p>
+
+<p>So, really, the way the content reflows at different breakpoints is on purpose. We tried to maintain the content hierarchy as much as possible not take away any content just because the user is on a phone, for example. (And, yes, we have some display bugs that we are working out still, but hey, it's about constant refinement, right?) Basically, we were fighting the adage that 'mobile | desktop' have become synonyms for 'less | more'.</p></blockquote>
+
+<p>There are some ready-to-serve sets like <a href="http://getskeleton.com/">getskeleton.com</a> and <a href="http://cssgrid.net/">cssgrid.net</a> that claim to be a quick-and-dirty framework for making it happen. How would you distinguish your system from those sorts of things?</p>
+
+<blockquote><p>I balk at the idea that there is a 'responsive design' button that can be pushed... Those sets are fine but do not automatically include some of the patches that came out of this project  such as the responsive images solution which deals with the size of images being served depending on the breakpoints. Thinking about page weight is especially important in responsive design.</p>
+
+<p>So, sure, those examples are fine starting points so long as the end result has a fluid foundation, has flexible images and media, and utilizes media queries from the CSS3 specification.</p></blockquote>
+
+<p>In <a href="http://www.readwriteweb.com/mobile/2011/09/how-the-boston-globe-pulled-ofp2.php">an interview with ReadWriteWeb</a>, a Globe staffer said that the "ugly" JavaScript code commonly found in online advertisements created an "unresolved" issue for your team. Another said interstitials and takeovers simple can't be done. How does this problem get resolved?</p>
+
+<blockquote><p>These are not Globe employees. These are our contractors. But to answer your question:
+We are working with our advertisers and constantly refining the ad serving solution. It has definitely been one of the major challenges.</p></blockquote>
+
+<p>Finally, how does a design like this turn up the volume for big news? If the Red Sox win the World Series in a few weeks, how do you blow it out?</p>
+
+<blockquote><p>We designed out several views for the homepage given different news presentation scenarios... Just like we have always done. </p></blockquote>

--- a/coltrane/content/posts/2011-12-05--q-matt-waite-founding-drone-journalism-lab.md
+++ b/coltrane/content/posts/2011-12-05--q-matt-waite-founding-drone-journalism-lab.md
@@ -1,0 +1,67 @@
+---
+title: 'Q&A: Matt Waite on the founding of the Drone Journalism Lab'
+slug: q-matt-waite-founding-drone-journalism-lab
+published_at: '2011-12-05T08:35:49-08:00'
+---
+<p>Last week, Prof. Matt Waite of the University of Nebraska-Lincoln announced the founding of the <a href="http://dronejournalism.tumblr.com/about">Drone Journalism Lab</a>, dedicated to exploring the use of unmanned aircraft to do journalism.</p>
+
+<p>Waite used to work at the St. Petersburg Times, where he used technology to cover environmental issues and developed the Pulitzer Prize winning website, <a href="http://www.politifact.com/">Politifact</a>.</p>
+
+<p>I conducted an email interview with Waite to learn more about the project. You can read the transcript below, but here are my quick takeaways:</p>
+
+<ul style="margin-bottom:1em;">
+    <li>Waite believes drones already present an affordable way to cover disasters and other stories, but the go-to technology and the rules of the road have not been worked out yet.</li>
+    <li>The lab is in its infant stages, and is still determining exactly what it will do and how it will be financed.</li>
+    <li>But the work could involve building drones, teaching students to use drones and writing and speaking about the ethics of the whole enterprise.</li>
+    <li>Waite says its "foolish to believe" drones won't be misused, and says thinking about legal and ethical constraints is one of his top priorities.</li>
+    <li>Waite says he can't rule out government or military involvement, but promises transparency.</li>
+    <li>A survey of the Platte River is penciled in as the lab's first classroom experiment.</li>
+</ul>
+
+<p>It must be said: I know Matt. We belong to the <a href="http://ire.org/">same professional organization</a>. In many ways, I've modeled my work on his. I root for him to succeed. In short, I'm biased. So, if you think I'm in the bag and went soft here, feel free to toss in a comment or question below and we'll try to keep him hopping.</p>
+
+<div class="detailborderbreak"></div>
+
+<p>What is the goal of the drone journalism lab?</p>
+
+<blockquote><p>The goals of the lab are split in two: First, how can journalists use drones and aerial platforms to do reporting? What drones? What stories? What are the possibilities? Second, and I think this is really important, how can journalists use them responsibly? What are the ethics? What are the legalities? Safety? My hunch is that traditional ideas of ethics are going to apply -- you don't use long lenses to take pictures of people in their houses, so why would you fly a drone up to their window? But I think there are interesting questions of balancing the public's right to know versus government claims of security and safety. Where do those lines fall? The sooner we start having these conversations and the sooner we start thinking about it, the sooner we can have a voice in regulatory discussions and have answers for critics who may have the wrong idea of what drone journalism is really about.</p></blockquote>
+
+<p>I know about Predator drones. And I know about the crappy remote control helicopter the guy in my office buzzes around. But you must be aiming for something in between. How close is the technology?</p>
+
+<blockquote><p>The tech is at a tantalizing point where it's in some respects there and in some respects right on the cusp of being there. On the lower ends, the first drone we're going to get is a <a href="http://ardrone.parrot.com/parrot-ar-drone/usa/">Parrot AR Drone</a>, a quadricopter that you can control with your smart phone. I'm going to mod it to hold a <a href="http://gopro.com/products/?gclid=CMbUvNqn66wCFacEQAodAFN7KA">GoPro HD camera</a> and we're in business with a drone mounted camera. There's loads of videos on YouTube of hobbyists doing this and the results they're getting are amazing. A Parrot drone and a Go Pro camera will run you right around $600. That's cheap. And it's about the size of a large backpack. And, given that you can control it with a smart phone, an ideal rig for a reporter to take out to a town blown apart by a tornado or hurricane.</p>
+
+<p>But it's limited. It's really just a photo/video platform. On the higher end, I've got my eye on a drone I saw at the ESRI Users Conference in San Diego this past June called the <a href="http://www.gatewing.com/gatewingX100">Gatewing X100</a>. It's fully autonomous. You tell it, via a tablet device, where you are taking off from, where you want it to land, and the area you want photographed and it takes off and does it. When it returns, you pop out the storage card, plug it into the tablet and it stitches the images together into a geo-rectified orthophoto. In short, with this drone, you could do on demand imagery of an area. Again, think of a town blown apart by a tornado. You could get high resolution imagery of the ground quickly that you could then layer with property records or on the ground reports. That drone runs about $65,000 and the FAA hasn't issued rules yet on how, when or where something like this is legal. But, <a href="http://articles.latimes.com/print/2011/nov/27/business/la-fi-drones-for-profit-20111127">the LA Times reported</a> this past weekend that the agency is going to in the new year, so the doors are opening as we speak.</p></blockquote>
+
+<p>What kind of response did you get from the crowd when you spoke this past weekend at the News Foo conference?</p>
+
+<blockquote><p>Interestingly, I think the reaction from the News Foo audience was an interesting gauge on what I can expect from the public. Because it was a tech-heavy audience, everyone saw the potential -- I don't think anyone said that this is a dumb/bad/misguided idea with no potential. But News Foo had a number of tech people very interested in and sensitive to privacy issues and they were quite wary. They immediately went to TMZ+Lindsay Lohan as an example of how drones could be misused.</p>
+
+<p>So when I started thinking about this idea, I immediately thought that people would rightfully be wary of this and that the sooner we started talking about ethics and laws, the sooner we could have answers for criticisms and guidelines to balance the public's right to know and people's expectations of privacy. And, more importantly, I think we'll be able to identify what's a good use and what isn't. I think it's foolish to believe that drones in civilian life won't be misused. A court is going to throw out a criminal case because of an overzealous police drone operator some day. It's going to happen. Every tool law enforcement has ever been given has been misused by someone in some way. The same could be said for people in general. And as predictable as that is, so is some news organization landing in the Poynter/CJR/Nieman/media criticism crosshairs for misusing drones.</p>
+
+<p>What I'm trying to do now, before we can even push this very far forward, is set up some guidelines or a framework for decisions on when to use drones or not use drones. We'll look at the past, at other industries, at how we've handled other leaps in technology to do journalism and try to port those over to drones for reporting. I can't stop someone from misusing a drone. It's foolish to think I can. But I can get as much information out there on how to do this right as I can. And I think seeing and hearing the News Foo crowd's concerns was great -- it told me we're on the right track thinking about these ethical and legal issues even before we start flying aircraft around.</p></blockquote>
+
+<p>Why are you taking this on and what will be your role?</p>
+
+<blockquote><p>I'm taking this on because I'm fascinated by the use of remote sensing data in journalism. I think I'm the first journalist to ever use satellite imagery analysis techniques to do a story, and I was among the first in the late 90s to be using GPS devices to gather data for journalism. This is just an extension of that. Covering tornadoes and hurricanes in my career, I was frustrated by my inability to gather data on such a vast spatial extent.</p>
+
+<p>I think drones -- small, cheap, easy to use vehicles that can fit in a small bag and carried into the field by a reporter -- offer a major opportunity to improve certain kinds of reporting. My role is whatever it needs to be. I'm founding the lab, trying to raise funds, I'll be doing research and I'll be incorporating this into classes in the very near future. So the answer to what is my role is yes.</p></blockquote>
+
+<p>How is your lab financed? What's the size of the staff, and the budget?</p>
+
+<blockquote><p>We're just getting started - I mean like hours old just getting started. The staff is me and the budget is a small startup grant of $1,000. We're actively looking for funders and other people interested in this and I think you'll see some things  happen very quickly. Given how things are happening quickly with civilian drones now, I wanted to get started, funds or no, staff or no. We'll build and grow and change as we can and as opportunities allow. I've already received three emails from people interested in collaborating and helping since I tweeted about it this morning, so things are happening fast.</p></blockquote>
+
+<p>Will you solicit or accept funding from the military or other arms of the government?</p>
+
+<blockquote><p>I've had some conversations with the National Science Foundation about this but just conversations. Funding at research universities is a Byzantine business, and collaborations across departments are common. It would be easy for me to say we'd never solicit funds from the military, but there is a drone lab on campus now working on military drones. Should we not work with them or get help from them or have coffee with them sometime? It's not that easy. Obviously, as a journalism school, we're sensitive to the funding issues and we're going to tread very lightly. For now, we're seeking support elsewhere, but given the nature of university grant funding, I can't say never. I can say we'll be very clear and public about all of it.</p></blockquote>
+
+<p>What, if any, classroom component will there be?</p>
+
+<blockquote><p>Over the summer, I will be developing an environmental journalism/data visualization class that will involve this really ambitious project to photograph the Platte River over time. We're planning to incorporate drones into that class -- when it will be offered has yet to be determined. I'm sure I'll find ways to sneak this into other classes too and who knows what the future holds. Is there an entire class to be had on drone journalism? I'm on the fence, to be honest. On the one hand, there's very cool opportunities to do all kinds of new things with drones for reporting. On the other, it's just a tool for reporting. So is it a whole class or is it a module in an existing reporting class? I don't know. It's an interesting question.</p></blockquote>
+
+<p>Why the Platte River?</p>
+
+<blockquote><p>There's an existing grant program in place about the Platte and it's health. We're piggybacking on their data.</p></blockquote>
+
+<p>What news organizations, if any, are doing drone journalism now, and what are the best examples of work in the field?</p>
+
+<blockquote><p>News Corp's The Daily did <a href="http://www.thedaily.com/page/2011/05/02/news-severe-weather-5a-10/">some drone video</a> in Tuscaloosa, Ala. that was just amazing. It's an ideal example of what's possible with very little expense or effort.</p></blockquote>

--- a/coltrane/content/posts/2012-02-25--nicar-2012-things-i-said.md
+++ b/coltrane/content/posts/2012-02-25--nicar-2012-things-i-said.md
@@ -1,0 +1,24 @@
+---
+title: 'NICAR 2012: Things I said'
+slug: nicar-2012-things-i-said
+published_at: '2012-02-25T00:01:17-08:00'
+---
+<p>Here is a collection of the talks I gave this year at the <a href="http://ire.org/conferences/nicar-2012/">2012 conference</a> of the National Institute for Computer-Assisted Reporting.</p>
+
+<h2>Locating the story: The latest in online maps</h2>
+
+<iframe src="https://docs.google.com/presentation/embed?id=11_6sSd31mEy7VkQdG-YY_mQtlktKPt0ZuuaFwFy6H3w&start=false&loop=false&delayms=3000" frameborder="0" width="480" height="389" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+
+<h2>Making friends with map projections</h2>
+
+<p>This talk was conceived and primarily written by <a href="http://www.mikejcorey.com/wordpress/">Michael Corey</a>.</p>
+
+<iframe src="https://docs.google.com/present/embed?id=df2gtfhr_14f6km6gft" frameborder="0" width="410" height="342"></iframe>
+
+<h2>Human-assisted reporting: How to create robot reporters in your own image</h2>
+
+<iframe src="https://docs.google.com/presentation/embed?id=1sW3iLUDXs7NTdo7EUUxD7X3vnIWYo7G8orMf5FT05Zk&start=false&loop=false&delayms=3000" frameborder="0" width="480" height="389" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+
+<h2>How I learned to stop worrying and love flat files</h2>
+
+<iframe src="https://docs.google.com/presentation/embed?id=1IybYcc0eVL-Rchm7lEQNwrM-AHRfr_M8ewfGYYNjeu8&start=false&loop=false&delayms=3000" frameborder="0" width="480" height="389" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>

--- a/coltrane/content/posts/2012-03-26--leaflet-recipe-hover-events-features-and-polygons.md
+++ b/coltrane/content/posts/2012-03-26--leaflet-recipe-hover-events-features-and-polygons.md
@@ -1,0 +1,153 @@
+---
+title: 'Leaflet recipe: Hover events on features and polygons'
+slug: leaflet-recipe-hover-events-features-and-polygons
+published_at: '2012-03-26T13:47:10-07:00'
+---
+<p>Leaflet is an exciting tool for making interactive maps. It's free. It's simple. It's easy to write. It isn't tied to any one set of background tiles. It works in all the major browsers. It's under <a href="https://github.com/CloudMade/Leaflet">active development</a>.</p>
+
+<p>It even has <a href="http://leaflet.cloudmade.com/examples.html">good documentation</a>. But one thing it doesn't show you how to create is hover effects. Say you've got some shapes or points on your map and you want something to happen when the user rolls her mouse over them. After getting <a href="https://github.com/CloudMade/Leaflet/issues/60">some help from GitHubber patmisch</a>, here's how I made it work.</p>
+
+<h2>Getting started</h2>
+
+<p>The city of Los Angeles recently redrew its City Council districts. Below is a Leaflet map displaying the boundaries from the redistricting commission's final recommendation. I downloaded the lines as a <a href="http://en.wikipedia.org/wiki/Shapefile">shapefile</a> from <a href="http://redistricting2011.lacity.org/LACITY/proposedFinalMap.html">the commission's Web site</a> and converted them into <a href="http://en.wikipedia.org/wiki/GeoJSON">GeoJSON</a> format using <a href="http://en.wikipedia.org/wiki/Qgis">Quantum GIS</a>.</p>
+
+<iframe src="http://s3-us-west-1.amazonaws.com/palewire/leaflet-hover/before.html" frameborder=0 scrolling=no width=100% height=350px></iframe>
+
+<p style="margin-top:10px">This kind of map can be accomplished by following the <a href="http://leaflet.cloudmade.com/examples/geojson.html">GeoJSON instructions</a> Leaflet already provides. One hundred percent of the code is below. I've annotated it to provide some clues to what's happening, but this is the baseline for making a static map run and I'm going to assume you get how it works. If you get stuck up, fire off a question in the comments or spend some time with <a href="http://leaflet.cloudmade.com/index.html">Leaflet's tutorial for beginners</a>.</p>
+
+<pre lang="html">
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Leaflet GeoJSON example</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- All the stuff you need to install from Leaflet -->
+    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.4/leaflet.css" />
+    <!--[if lte IE 8]><link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.4/leaflet.ie.css" /><![endif]-->
+    <script src="http://cdn.leafletjs.com/leaflet-0.4/leaflet.js"></script>
+    <!-- My external GeoJSON file with the City Council boundaries in it -->
+    <script src="http://s3-us-west-1.amazonaws.com/palewire/leaflet-hover/citycouncil.geojson"></script>
+</head>
+<body style="margin:0; padding:0;">
+    <!-- The <div> where we're put the map -->
+    <div id="map" style="width: 100%; height: 350px;"></div>
+    <script type="text/javascript">
+        // Initialize the map object
+        var map = new L.Map('map', {
+            // Some basic options to keep the map still and prevent 
+            // the user from zooming and such.
+            scrollWheelZoom: false,
+            touchZoom: false,
+            doubleClickZoom: false,
+            zoomControl: false,
+            dragging: false
+        });
+        // Prep the background tile layer graciously provided by stamen.com
+        var stamenUrl = 'http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png';
+        var stamenAttribution = 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.';
+        var stamenLayer = new L.TileLayer(stamenUrl, {maxZoom: 18, attribution: stamenAttribution});
+        // Set the center on our city of angels
+        var center = new L.LatLng(34.0, -118.4);
+        map.setView(center, 9);
+        // Load the background tiles
+        map.addLayer(stamenLayer);
+        // Create an empty layer where we will load the polygons
+        var featureLayer = new L.GeoJSON();
+        // Set a default style for out the polygons will appear
+        var defaultStyle = {
+            color: "#2262CC",
+            weight: 2,
+            opacity: 0.6,
+            fillOpacity: 0.1,
+            fillColor: "#2262CC"
+        };
+        // Define what happens to each polygon just before it is loaded on to
+        // the map. This is Leaflet's special way of goofing around with your
+        // data, setting styles and regulating user interactions.
+        var onEachFeature = function(feature, layer) {
+            // All we're doing for now is loading the default style. 
+            // But stay tuned.
+            layer.setStyle(defaultStyle);
+        };
+        // Add the GeoJSON to the layer. `boundaries` is defined in the external
+        // GeoJSON file that I've loaded in the <head> of this HTML document.
+        var featureLayer = L.geoJson(boundaries, {
+            // And link up the function to run when loading each feature
+            onEachFeature: onEachFeature
+        });
+        // Finally, add the layer to the map.
+        map.addLayer(featureLayer);
+    </script>
+</body>
+</html>
+</pre>
+
+<h2>Hooking up hovers</h2>
+
+<p>Our goal is to make the same map as above, except with polygons that light up on hover and a popup that appears with metadata about the selected council district. Something like this.</p>
+
+<iframe src="http://s3-us-west-1.amazonaws.com/palewire/leaflet-hover/after.html" frameborder=0 scrolling=no width=100% height=350px></iframe>
+
+<p style="margin-top:10px;">First add jQuery to the head of the page, so we can easily make the popup when the time comes.</p>
+
+<pre lang="html"><script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+</pre>
+
+<p>Then create a second style set that describes how to brighten up the polygon.</p>
+
+<pre lang="javascript">var highlightStyle = {
+    color: '#2262CC', 
+    weight: 3,
+    opacity: 0.6,
+    fillOpacity: 0.65,
+    fillColor: '#2262CC'
+};</pre>
+
+<p>Now the real work. Look back at how we used the "featureparse" event above to assign the default style to each polygon. You can assign events in the same way, turning them on one at a time as Leaflet loops through your GeoJSON features and adds them to the layer. The only trick is to bind your events using a <a href="http://www.hunlock.com/blogs/Functional_Javascript#quickIDX5">self-invoking function</a> that gets the scope right and lines things up as they loop by.</p>
+
+<p>Watch as it happens below. The wrapper function passes in the layer and JSON metadata, which are then assigned as the function is executed before each step of the loop is complete.</p>
+
+<pre lang="javascript">var onEachFeature = function(feature, layer) {
+    // Load the default style. 
+    layer.setStyle(defaultStyle);
+    // Create a self-invoking function that passes in the layer
+    // and the properties associated with this particular record.
+    (function(layer, properties) {
+      // Create a mouseover event
+      layer.on("mouseover", function (e) {
+        // Change the style to the highlighted version
+        layer.setStyle(highlightStyle);
+        // Create a popup with a unique ID linked to this record
+        var popup = $("<div></div>", {
+            id: "popup-" + properties.DISTRICT,
+            css: {
+                position: "absolute",
+                bottom: "85px",
+                left: "50px",
+                zIndex: 1002,
+                backgroundColor: "white",
+                padding: "8px",
+                border: "1px solid #ccc"
+            }
+        });
+        // Insert a headline into that popup
+        var hed = $("<div></div>", {
+            text: "District " + properties.DISTRICT + ": " + properties.REPRESENTATIVE,
+            css: {fontSize: "16px", marginBottom: "3px"}
+        }).appendTo(popup);
+        // Add the popup to the map
+        popup.appendTo("#map");
+      });
+      // Create a mouseout event that undoes the mouseover changes
+      layer.on("mouseout", function (e) {
+        // Start by reverting the style back
+        layer.setStyle(defaultStyle); 
+        // And then destroying the popup
+        $("#popup-" + properties.DISTRICT).remove();
+      });
+      // Close the "anonymous" wrapper function, and call it while passing
+      // in the variables necessary to make the events work the way we want.
+    })(layer, feature.properties);
+};</pre>
+
+<p>That's it. If this doesn't make sense, or I've made a mistake, please leave a comment below. You can find the source code for the complete working demo <a href="http://s3-us-west-1.amazonaws.com/palewire/leaflet-hover/after.html">here</a>.</p>

--- a/coltrane/content/posts/2013-07-08--where-will-downtown-la-regional-connector-run.md
+++ b/coltrane/content/posts/2013-07-08--where-will-downtown-la-regional-connector-run.md
@@ -1,0 +1,14 @@
+---
+title: Where will Downtown L.A.'s Regional Connector run?
+slug: where-will-downtown-la-regional-connector-run
+published_at: '2013-07-08T22:08:43-07:00'
+---
+<iframe src="/regional-connector/" width="100%" height=400 scrolling=no frameborder=0></iframe>
+
+<p>Perhaps, like me, you live in Downtown Los Angeles. And perhaps, like me, you have wondered, "Where exactly is <a href="https://en.wikipedia.org/wiki/Los_Angeles_County_Metropolitan_Transportation_Authority">L.A. Metro</a> going to build its weirdly named 'Regional Connector' rail line?"</p>
+
+<p>If so, the dotted black line above, which runs up 2nd Street and then turns south on Flower Street, is your answer.</p>
+
+<p>The Regional Connector is <a href="http://www.metro.net/projects/connector/">touted as</a> 1.9 miles of underground light rail that will better link the existing lines that now terminate at Union Station and Metro Center. It is scheduled to open in 2020 and estimated to cost nearly $1.4 billion, partially funded by the half-cent sales tax city <a href="https://en.wikipedia.org/wiki/Measure_R">voters approved in 2008</a>.</p>
+
+<p>The only maps on Metro's website I could find were in the <a href="http://www.metro.net/projects_studies/connector/images/map_corridor_regconn_eng.pdf">painful PDF</a> format. So I traced an electronic version in the handier <a href="https://en.wikipedia.org/wiki/GeoJSON">GeoJSON</a> format using <a href="http://macwright.org/edit-geojson/">Tom MacWright's brilliant tool</a> and <a href="https://github.com/datadesk/lametro-maps/blob/master/planned-regional-connector-line.geojson">open sourced the result</a> over on GitHub, <a href="https://github.com/datadesk/lametro-maps">along with</a> all the other GIS data that Metro publishes online. Enjoy!</p>

--- a/coltrane/content/posts/2013-07-18--why-develop-in-the-newsroom.md
+++ b/coltrane/content/posts/2013-07-18--why-develop-in-the-newsroom.md
@@ -1,0 +1,24 @@
+---
+title: Why develop in the newsroom
+slug: why-develop-in-the-newsroom
+published_at: '2013-07-18T23:53:54-07:00'
+---
+<p>The Knight-Mozilla OpenNews project has <a href="http://dansinker.com/post/55724537132/opennews-why-develop-in-the-newsroom-part-1">posed a question</a>: Why should talented computer programmers decide to work in a newsroom?</p>
+
+<p>I can’t say it as <a href="http://thescoop.org/archives/2013/07/16/why-develop-in-the-newsroom/">roundly</a> as Derek Willis, as <a href="https://www.propublica.org/nerds/item/why-develop-in-the-newsroom">encyclopedically</a> as ProPublica’s crew or as <a href="http://michelleminkoff.com/2013/07/17/why-i-develop-in-the-newsroom/">big sisterly</a> as Michelle Minkoff. But, if the World Wide Web would welcome yet another humble opinion into congregation, let me lift up for a minute.</p>
+
+<p>Why develop in the newsroom?</p>
+
+<p>Because data are used to tell stories. And we need independent storytellers.</p>
+
+<p>This is not news. But, more and more each day, the government, special interests, and wealthy corporations are using data, as a tool, to tell stories tailored to advance their goals.</p>
+
+<p>You may have heard them say things like: <a href="http://www.nbcchicago.com/news/local/School-Board-Votes-to-close-49-schools-208547131.html">We must close dozens of public schools to improve education</a>; <a href="http://www.nytimes.com/2012/06/11/nyregion/at-black-church-in-brooklyn-bloomberg-defends-stop-and-frisk-policy.html">Aggressively frisking people makes our city a better place</a>; Or, a personal favorite of mine, <a href="https://www.youtube.com/watch?v=Ei5OrV-CmHg">a balloon-payment mortgage with no money down is the bank doing you a favor</a>.</p>
+
+<p>Our society needs independent voices that can understand, vet and &mdash; if necessary &mdash; challenge the claims underpinning such stories, where powerful forces use facts and figures to justify their actions.</p>
+
+<p>I’m proud to say, my colleagues in the media have often <a href="http://articles.chicagotribune.com/2013-03-06/news/ct-met-cps-school-closing-class-size-20130306_1_class-size-state-records-high-schools">answered</a> <a href="http://www.wnyc.org/articles/wnyc-news/2011/apr/26/marijuana-arrests/">the</a> <a href="http://www.nytimes.com/2006/12/06/business/06mortgage.html?ex=1166072400&en=61cb6768da408d68&ei=5070&emc=eta1">call</a>. But we need help. We need people with the skill to analyze the deluge of data swamping our society, and the courage to step up to a megaphone and share the truths the data tell.</p>
+
+<p>Computer programmers, I believe you have it in you. You’re a curious, inventive, free-thinking lot. And there’s a way you can apply yourself that is more morally ambitious than a ridiculously violent video game or an <a href="https://en.wikipedia.org/wiki/High-frequency_trading">empty money chase</a>.</p>
+
+<p>That is speaking truth to power. And it’s a career path that, with your skills, is so open to you today it might be shocking. Click <a href="http://mozillaopennews.org/fellowships/apply.html">here</a> or <a href="http://www.newsnerdjobs.com/">here</a> or <a href="http://www.ire.org/nicar/">here</a> and you'll see what I mean.</p>

--- a/coltrane/content/posts/2014-07-25--django-recipe-base-management-command-running-custom-sql.md
+++ b/coltrane/content/posts/2014-07-25--django-recipe-base-management-command-running-custom-sql.md
@@ -1,0 +1,74 @@
+---
+title: 'Django recipe: Base management command for running custom SQL'
+slug: django-recipe-base-management-command-running-custom-sql
+published_at: '2014-07-25T12:02:15-07:00'
+---
+<p>Here is a simple <a href="https://docs.djangoproject.com/en/dev/howto/custom-management-commands/">Django management command</a> I use when I want to quickly execute custom SQL in the database.</p>
+
+<p>For me, it comes in handy in cases working with large data sets where <a href="https://docs.djangoproject.com/en/dev/topics/db/queries/">Django's tools for interacting with the database</a> can take more time to craft and execute than a well-tailored <code><a href="http://www.w3schools.com/sql/sql_insert.asp">INSERT</a></code> command.</p>
+
+<p>Here's the command. Paste it wherever you'd like in your project.</p>
+
+<pre lang="python">from django.db import transaction, connection
+from django.core.management.base import BaseCommand, CommandError
+
+
+class SimpleSQLCommand(BaseCommand):
+    help = "A base class for packaging simple SQL operations as a command"
+    # Overriding these attributes is what you will need to do when subclassing
+    # this command for use.
+    flush = None  # An optional Django database model to be flushed
+    sql = ""  # The SQL command to be run
+
+    def handle(self, *args, **options):
+        # Validate
+        if not self.sql:
+            raise CommandError("'sql' attribute must be set")
+
+        # Flush model if it is provided
+        if self.flush:
+            if options.get("verbosity") >= 1:
+                self.stdout.write("- Flushing %s" % self.flush.__name__)
+            self.flush_model(self.flush)
+
+        # Run custom sql
+        if options.get("verbosity") >= 1:
+            self.stdout.write("- Running custom SQL")
+        self.execute_sql(self.sql)
+
+    @transaction.atomic
+    def flush_model(self, model):
+        """
+        Flushes the provided model using the lower-level TRUNCATE SQL command.
+        """
+        cursor = connection.cursor()
+        cursor.execute("TRUNCATE %s CASCADE;" % (model._meta.db_table))
+
+    @transaction.atomic
+    def execute_sql(self, sql):
+        """
+        Executes the provided SQL command.
+        """
+        cursor = connection.cursor()
+        cursor.execute(sql)</pre>
+
+<p>Then simply import it into wherever you're putting your new custom command and provide the <code>sql</code> attribute. If you want to flush a model prior to running the command, as I often do, you can also provide it to the optional <code>model</code> attribute.</p>
+
+<pre lang="python">from myapp import models
+from mytoolbox import SimpleSQLCommand
+
+
+class Command(SimpleSQLCommand):
+    flush = models.MyModel
+    # I might typically have more JOINs and other SQL crap going on
+    # but let's keep it simple for this example
+    sql = """
+        INSERT INTO myapp_mymodel ("group","count")
+        SELECT group, COUNT(*)
+        FROM myapp_myothermodel
+        GROUP BY group
+        """</pre>
+
+<p>Then, provided you've put your new command <a href="https://docs.djangoproject.com/en/dev/howto/custom-management-commands/#module-django.core.management">in the right spot</a>, running it should be as simple as this.</p>
+
+<pre lang="bash">$ python manage.py mynewcommand</pre>

--- a/coltrane/content/posts/2015-02-11--first-news-app-second-time-around.md
+++ b/coltrane/content/posts/2015-02-11--first-news-app-second-time-around.md
@@ -1,0 +1,10 @@
+---
+title: '"First News App," a second time around'
+slug: first-news-app-second-time-around
+published_at: '2015-02-11T12:00:00-08:00'
+---
+<p>We've overhauled the First News App class that debuted at last year's NICAR conference based on feedback from our students.</p>
+
+<p>The plan is to work through the new materials with a sold-out class next month at the 2015 conference in Atlanta.</p>
+
+<p>But, if it interests you, visit <a href="http://first-news-app.readthedocs.org/en/latest/">first-news-app.readthedocs.org</a> and try out the latest draft on your own any time. If you give it a spin, let me know what you think. I'd love to hear your feedback so we can make it stronger.</p>

--- a/coltrane/content/posts/2015-04-14--california-civic-data-coalition-advances-knight-news-challenge.md
+++ b/coltrane/content/posts/2015-04-14--california-civic-data-coalition-advances-knight-news-challenge.md
@@ -1,0 +1,10 @@
+---
+title: California Civic Data Coalition advances in Knight News Challenge
+slug: california-civic-data-coalition-advances-knight-news-challenge
+published_at: '2015-04-14T12:00:00-07:00'
+---
+<p>Good news. <a href="https://www.newschallenge.org/challenge/elections/refinement/this-is-a-test">Our open-source effort</a> to decode California's campaign cash database advanced to the second round of the Knight News Challenge. We are one of 45 semifinalists selected from a pool of more than 1,000 applicants.</p>
+
+<p>Next we expand our proposal and if the Knight Foundation likes it we win funding to hire a computer programmer to push things forward. If you're interested, give our application a read and let me know below how you think it could be improved.</p>
+
+<p>If you have any thoughts you'd like to share privately you can email me at ben.welsh@gmail.com. And if you think you are the coder we should hire if we get the money, definitely reach out.</p>

--- a/coltrane/content/posts/2015-04-16--join-2015-cal-access-challenge.md
+++ b/coltrane/content/posts/2015-04-16--join-2015-cal-access-challenge.md
@@ -1,0 +1,8 @@
+---
+title: Join the 2015 CAL-ACCESS challenge
+slug: join-2015-cal-access-challenge
+published_at: '2015-04-16T12:00:00-07:00'
+---
+<p>I'm on my way to Palo Alto where the Stanford brain trust is hosting <a href="http://events.stanford.edu/events/501/50185/">a symposium</a> on better detecting political corruption. I'm bringing with me this pile of problems from California's database of campaign spending and lobbying activity.</p>
+
+<p>If you're interested in helping our open-source effort to decode the millions of dollars that oil the Sacramento statehouse, <a href="http://www.californiacivicdata.org/2015/04/16/calaccess-challenge/">learn about the CAL-ACCESS challenge</a>. Even if you can't attend the conference, you can still make a difference.</p>

--- a/coltrane/content/posts/2015-05-12--introducing-django-memento-framework.md
+++ b/coltrane/content/posts/2015-05-12--introducing-django-memento-framework.md
@@ -1,0 +1,10 @@
+---
+title: Introducing django-memento-framework
+slug: introducing-django-memento-framework
+published_at: '2015-05-12T12:00:00-07:00'
+---
+<p>Today I'm at the Dodging the Memory Hole conference on better archiving digital news held in Charlotte.</p>
+
+<p>I'm also releasing this new open-source library that makes it easy for Django developers to implement the Memento framework for time-based web requests. Check it out.</p>
+
+<p><a href="http://bit.ly/django-memento">http://bit.ly/django-memento</a></p>

--- a/coltrane/content/posts/2015-07-22--california-civic-data-coalition-named-winner-knight-news-challenge.md
+++ b/coltrane/content/posts/2015-07-22--california-civic-data-coalition-named-winner-knight-news-challenge.md
@@ -1,0 +1,12 @@
+---
+title: California Civic Data Coalition named winner of Knight News Challenge
+slug: california-civic-data-coalition-named-winner-knight-news-challenge
+published_at: '2015-07-22T12:00:00-07:00'
+---
+<p>Good news! Our effort to unlock California's crazy money in politics database is one of the 2015 Knight News Challenge winners!</p>
+
+<p>That means we are hiring.</p>
+
+<p>If you are passionate about campaign finance data and want to get involved please let me know!</p>
+
+<p>To learn more check out <a href="http://www.californiacivicdata.org/2015/07/22/knight-news-challenge/">our announcement</a>.</p>

--- a/coltrane/content/posts/2015-09-28--introducing-memento-wordpress.md
+++ b/coltrane/content/posts/2015-09-28--introducing-memento-wordpress.md
@@ -1,0 +1,15 @@
+---
+title: Introducing Memento for Wordpress
+slug: introducing-memento-wordpress
+published_at: '2015-09-28T12:00:00-07:00'
+---
+<p>This weekend at the Online News Association conference in LA I released <a href="http://pastpages.github.io/wordpress-memento-plugin/">a new Wordpress plugin</a> to enable any news blog to become a living, breathing Internet archive.</p>
+
+<p>It's done via the cutting-edge Memento framework that accepts time-based web requests and returns past versions of archived URLs.</p>
+
+<p>Learn more about the system in <a href="https://docs.google.com/presentation/d/1Ng3Q1O7IirK2VtpCj8-IHSc9qd19u6CU0sXVhOjMKTw/pub?start=false&loop=false&delayms=3000#slide=id.gbc8dc8ef9_1_25">the slides here</a>.</p>
+
+<p>The project is still on-going and sponsored by the Reynolds Journalism Institute at the Missouri School of Journalism.</p>
+
+<p>If you run a Wordpress site and are interested in becoming one of our beta testers please let me know. Please!</p>
+

--- a/coltrane/content/posts/2015-09-29--l-times-liveblog-now-nationwide.md
+++ b/coltrane/content/posts/2015-09-29--l-times-liveblog-now-nationwide.md
@@ -1,0 +1,14 @@
+---
+title: L.A. Times liveblog now nationwide
+slug: l-times-liveblog-now-nationwide
+published_at: '2015-09-29T12:00:00-07:00'
+---
+<p>Today marks a small landmark for the custom liveblog our team built to help the Los Angeles Times cover the 2016 campaign.</p>
+
+<p>After starting out as a hacktastic kludge on latimes.com, it's now <a href="http://www.latimes.com/nation/politics/trailguide/la-na-trailguide-09292015-htmlstory.html">all growed up</a> and live across the network of Tribune newspapers, from <a href="http://l.facebook.com/l.php?u=http%3A%2F%2Fwww.chicagotribune.com%2Fla-na-trailguide-09292015-htmlstory.html&h=QAQFOe6Fy">Chicago</a> to <a href="http://l.facebook.com/l.php?u=http%3A%2F%2Fwww.baltimoresun.com%2Fla-na-trailguide-09292015-htmlstory.html&h=YAQGVt6Gk">Baltimore</a> to <a href="http://l.facebook.com/l.php?u=http%3A%2F%2Fwww.sun-sentinel.com%2Fla-na-trailguide-09292015-htmlstory.html&h=JAQG7HKpj">South Florida</a>.</p>
+
+<p>It ain't no Da Vinci, but it works and it shows that when equipped with the proper skills and authority the newsroom can build better tools for itself.</p>
+
+<p>Praise due to a lot of hard work and ingenuity by Honest Charley Bodkin, Lily Mazet, Evan Wagstaff and Julie Westfall.</p>
+
+<p>And of course it's still a work in progress. So if something sucks I expect you to tell me about it.</p>

--- a/coltrane/content/posts/2015-10-15--unexpected-award.md
+++ b/coltrane/content/posts/2015-10-15--unexpected-award.md
@@ -1,0 +1,26 @@
+---
+title: An unexpected award
+slug: unexpected-award
+published_at: '2015-10-15T12:00:00-07:00'
+---
+<p>On a Fourth of July weekend a few years ago I did something I'm sure hundreds of other nerds are doing tonight. I built <a href="http://www.pastpages.org/">a stupid web site</a>.</p>
+
+<p>I didn't expect anything to come of it. And, in some ways, not much did.</p>
+
+<p>But it brought on one of the great pleasures in my life over past few years: An unexpected welcome from digital librarians across the country who are struggling to change their profession to meet the challenges of our newly wired world.</p>
+
+<p>What I learned is that librarians have a lot in common with my tribe, the nerds in the newsroom fighting a similar battle.</p>
+
+<p>I learned we're natural allies trying to build a more literate, more intelligent Internet that has a chance to outlive us.</p>
+
+<p>And I learned that, like journalists, librarians enjoy giving each other awards.</p>
+
+<p>Linked <a href="http://blogs.loc.gov/digitalpreservation/2015/10/announcing-the-2015-innovation-award-winners/">here</a> is one I received today from the Library of Congress that I don't deserve. But I'd like to use it as an opportunity to call on anyone who has bothered to read this far to do more to ensure the digital work they do is preserved.</p>
+
+<p>Our legacy is in jeopardy and unless we improve how we publish information online most of what you're reading and writing today will be lost in a matter of years. Don't believe me? <a href="http://www.theatlantic.com/&#8230;/raiders-of-the-lost-web/409210/">Read this</a>.</p>
+
+<p>If you work at a news outlet that uses Wordpress let me know today.</p>
+
+<p>I've hooked up with a crew of library people way smarter than me. We're pushing now on <a href="http://palewi.re/posts/2015/09/28/introducing-memento-wordpress/">an open-source effort</a> to build tools that we hope will be a showcase for how news sites can be both self-preserving and archive ready.</p>
+
+<p>And we want you to be our guinea pig.</p>

--- a/coltrane/content/posts/2015-11-12--estado-de-las-artes.md
+++ b/coltrane/content/posts/2015-11-12--estado-de-las-artes.md
@@ -1,0 +1,10 @@
+---
+title: Estado de las artes
+slug: estado-de-las-artes
+published_at: '2015-11-12T12:00:00-08:00'
+---
+<p>It took more than 100 years, but today the Los Angeles Times published <a href="http://schools.latimes.com/es/grading-the-arts/">its first ever Spanish-language database.</a></p>
+
+<p>It's a translation of the arts education report cards we published last week for more than 700 schools in the L.A. Unified School District. Check the links below.</p>
+
+<p>Credit is due to Ryan Menezes, Zahira Torres, Angelica Quintero and the whole Hoy Los Angeles team for making it happen. It took some work, but my hope is that we can smooth the path and make it a routine thing in the future.</p>

--- a/coltrane/content/posts/2015-12-03--who-they-were.md
+++ b/coltrane/content/posts/2015-12-03--who-they-were.md
@@ -1,0 +1,10 @@
+---
+title: Who they were
+slug: who-they-were
+published_at: '2015-12-03T12:00:00-08:00'
+---
+<p>One of the best features of working on our specialized Los Angeles Times nerd squad is the opportunity to partner with talented people from all across the newsroom.</p>
+
+<p>Today that feeling is hitting harder than usual as we team with a small army of journalists to assemble <a href="http://www.latimes.com/local/lanow/la-me-ln-san-bernardino-shooting-victims-htmlstory.html?foo=UTY6K266MW">the names and stories</a> of those killed and injured in yesterday's San Bernardino shooting.</p>
+
+<p>The data is still developing, but check back at the link below throughout the day to keep up with the latest, as we learn it.</p>

--- a/coltrane/content/posts/2016-03-06--first-news-app-ride-again-nicar-2016.md
+++ b/coltrane/content/posts/2016-03-06--first-news-app-ride-again-nicar-2016.md
@@ -1,0 +1,16 @@
+---
+title: '"First News App" rides again at NICAR 2016'
+slug: first-news-app-ride-again-nicar-2016
+published_at: '2016-03-06T12:00:00-08:00'
+---
+<p>This week at the annual Investigative Reporters and Editors (IRE and NICAR) conference in Denver, Derek Willis and I will again be teaching our six-hour course &quot;First News App.&quot;</p>
+
+<p>Students will get hands-on experience in every stage of the web development process, writing Python, HTML and JavaScript that is recorded in Git&rsquo;s version control system.</p>
+
+<p>They will start with a spreadsheet. By the end they will have published an interactive database on the World Wide Web.</p>
+
+<p>In the open spirit of the NICAR conference, the entire script for the class is available online at <a href="<a href="http://first-news-app.readthedocs.org/en/latest/">">this link</a>.</p>
+
+<p>I've expanded it this year to include an extra section that improves the appearance of the application and introduces concepts of responsive design.</p>
+
+<p>So whether you're going to the conference or not our course is waiting for you. If you give it a shot and have any problems please let me know.</p>

--- a/coltrane/content/posts/2016-04-18--pulitzer-pride.md
+++ b/coltrane/content/posts/2016-04-18--pulitzer-pride.md
@@ -1,0 +1,18 @@
+---
+title: Pulitzer pride
+slug: pulitzer-pride
+published_at: '2016-04-18T12:00:00-07:00'
+---
+<p>I'm proud to report that our Los Angeles Times team was <a href="http://www.latimes.com/local/california/la-me-pulitzer-san-bernardino-20160418-story.html">honored today</a> with a Pulitzer Prize for our coverage of the San Bernardino shooting last year.</p>
+
+<p>Cliche as it is to say, this truly was a team effort with significant contributions from every corner of the newsroom.</p>
+
+<p>But I'm especially proud of our Data Desk crew. The official entry included:</p>
+
+<p>* Our custom liveblog software that powered <a href="http://www.latimes.com/local/lanow/la-me-ln-san-bernardino-shooting-live-updates-htmlstory.html">the initial coverage</a>, developed over the previous year by Julie Westfall and Charley Bodkin.</p>
+
+<p>* Our <a href="http://www.latimes.com/local/lanow/la-me-ln-san-bernardino-shooting-victims-htmlstory.html">victims database</a> that reporters used to provide the earliest and most authoritative accounting of the dead, an approach modeled on years of similar work done by Maloy Moore and Megan Garvey.</p>
+
+<p>* The <a href="http://graphics.latimes.com/san-bernardino-shooting/">custom web designs</a> for the &quot;lead-all&quot; stories that wrapped up each day's coverage crafted with care by Lily Mazet and Evan Wagstaff.</p>
+
+<p>* The <a href="http://www.latimes.com/local/crime/la-me-1209-sb-paramedic-20151209-story.html">rapid recounting</a> of how emergency medical workers responded to the deadly attack, which I couldn't have contributed to if I hadn't learned so much about the field from Robert Lopez.</p>

--- a/coltrane/content/posts/2017-09-09--what-i-learned.md
+++ b/coltrane/content/posts/2017-09-09--what-i-learned.md
@@ -1,0 +1,104 @@
+---
+title: What I learned
+slug: what-i-learned
+published_at: '2017-09-09T20:00:00-07:00'
+---
+<p>
+This past April I returned to my alma mater, DePaul University. It was a thrill to see the school's new <a href="https://communication.depaul.edu/initiatives/cjie/Pages/default.aspx">Center for Journalism Integrity and Excellence</a>, which was recently established by veteran journalists <a href="https://communication.depaul.edu/faculty-and-staff/faculty/Pages/marin.aspx">Carol Marin</a> and <a href="https://communication.depaul.edu/faculty-and-staff/faculty/Pages/moseley.aspx">Don Moseley</a>.</p>
+
+<p>I got my start in journalism thanks to Carol and Don at an internship program they started at DePaul.</p>
+
+<p>As part of the trip, I was honored alongside Lester Holt of NBC News in <a href="http://www.depaulnewsline.com/features/depaul-presents-inaugural-journalism-awards-lester-holt-and-ben-welsh">the center's inaugural round of journalism awards</a>.</p>
+
+<p>I was asked to give a brief speech during the ceremony at the Union Club of Chicago.
+I figured I'd never have another chance, so I uncorked an unauthorized commencement address for the students in the audience.</p>
+
+<p>Here it is. I start a little bit after the 6:30 mark.</p>
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; margin-bottom: 25px;} .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://player.vimeo.com/video/214875675?title=0&byline=0&portrait=0&autoplay=0' frameborder='0' webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div>
+
+<blockquote>
+
+<p>Thank you, Don. Thank you so much. I am so honored to receive this award. </p>
+
+<p>And I am happy to have a chance to come back to Chicago, the place where I felt like I grew up and a lot of great things happened for me. I’m always eager to come back, as long as it's not winter. </p>
+
+<p>I’m especially glad on this trip to have met the bright young students at DePaul’s new Center for Journalism Integrity and Excellence, where I see the things I want talk about becoming part of DePaul as an institution and something so many others can benefit from.</p>
+
+<p>On this occasion I also recognize there is no religious institution that’s properly run – as DePaul is – that could ever responsibly invite me to deliver a commencement address and risk tainting their valuable young minds.</p>
+
+<p>So I’m just going to take my shot right now. Brace yourselves, I’m going to give you kids some advice.</p>
+
+<p>Like all fables force fed to the young by their elders, this one starts with a boring piece of autobiography. Sorry, that’s how it goes. You’ll understand one day.</p>
+
+<p>Here comes your advice from Uncle Ben. </p>
+
+<p>My story starts about 15 years ago on the Lincoln Park campus when I was working on the top floor of the Schmitt Academic Center (SAC) in what was then the Department of Communication office. I was earning some extra money as a student there by answering the phones and doing odd jobs around the office. </p>
+
+<p>One of the many important responsibilities I was trusted with was putting up fliers on the department's bulletin board. One day there was a new posting that announced an opening for an intern to work with two journalists who were taking up residence at DePaul: Carol and Don.</p>
+
+<p>And, oh, by the way, their new office was only three floors below where I was standing. I just needed to take the elevator down.</p>
+
+<p>As I was pinning that notice to the board, a thought popped into my head: “I don’t know what this job is but it’s probably a hell of a lot more interesting that pinning fliers on a bulletin board.”</p>
+
+<p>So I jumped in the elevator. Because I was the first one to see the listing I was probably the first one to apply. Somehow I lucked into that internship.</p>
+
+<p>I didn’t know it at the time but it was probably one of the luckiest days of my life.</p>
+
+<p>I soon started. I had no idea what I was doing, I’ll confess now.</p>
+
+<p>I soon learned the luckiest thing for me was simply to see Carol and Don work. I was inspired by their sense of purpose, by their dedication to finding and telling stories that matter – stories that otherwise wouldn’t be told, or be told to the standards that they expected. </p>
+
+<p>Once I got past the fear that I would screw everything up and they would fire me – and, let’s be honest, the fear was pretty well founded – I started to wonder if I could ever take a stab myself.</p>
+
+<p>I got my chance one day when Carol and Don received a tip that a local law firm was milking money from a Chicago suburb (you know the ones) by over billing the city for legal work. </p>
+
+<p>It sounded like a good story of local corruption. Even I knew that this was the kind of thing that should be on the news. </p>
+
+<p>But where to begin?</p>
+
+<p>If it was true there would be evidence in the city’s financial books, which are public records, Don told me. Then he challenged me to sit down and write a public records request, something I’d never done before, so we could get to the bottom of it.</p>
+
+<p>And then for weeks he egged me on, again and again, when a shady city official tried to delay, skirt the law and discourage me from pursuing this request. Because Don kept pushing me, I kept pushing the city.</p>
+
+<p>Weeks went by. A lot of sternly written letters went back and forth. Then one day a package arrived. Inside was the data we asked for.</p>
+
+<p>There was only one problem. The city had sent it as a massive printout of paper, a scroll over 10 or 20 feet in length that was connected like paper from those old 1980s printers with the holes and tearsheets.</p>
+
+<p>There was no total cost of the legal fees and the pages were in inconsistent order and an odd format.</p>
+
+<p>To make sense of it all, we would need to puzzle through this scroll page by page and add up all the numbers. Tedious, unglamorous work.</p>
+
+<p>Not the kind of thing you imagine important journalists on television spending their time doing, right?</p>
+
+<p>Wrong.</p>
+
+<p>With Carol and Don’s encouragement, I built my first spreadsheet in Microsoft Excel and hammered in all the figures line by line. Hours later we had enough support for a story that exposed the exorbitant legal fees being charged to the city. </p>
+
+<p>Carol read the big numbers I had added up on camera and even dropped the hilarious, long piece of paper from the top of a ladder to illustrate its size.</p>
+
+<p>That was a moment for me where it clicked, where I saw, where I learned. All the slow frustrating work I had put in made sense. It wasn’t just worthwhile, it was essential.</p>
+
+<p>I learned that what separates reporters who get the story – the Carols and Dons of the world – from the ones who don’t isn’t all that complicated. It’s hard work. It’s persistence. It’s a willingness to take on tedious tasks others haven’t or won’t. Most of all it is a determination to finish the job. </p>
+
+<p>Despite all the changes I’ve seen in our industry since I got started way back in SAC, that truth is still standing.</p>
+
+<p>It’s true if you work on a traditional old school city corruption story like that. It’s true if you’re experimenting with new story forms online to try to reach an audience that we’ve lost. It’s true if you’re doing something weird like me and trying to become a computer programmer but still be a journalist at the same time.</p>
+
+<p>If you do the work and you do it the right way, like Carol and Don can teach you, you too can move the needle.</p>
+
+<p>But if that’s something you really want to do, you have to start now. You start by picking up that phone, getting outside your comfort zone, filing that public records request, not giving up, digging into that ugly database, asking questions that haven’t been asked before and banging on those doors. </p>
+
+<p>If whatever happens next frustrates you, you have to keep trying. You’re probably onto something. It’s only by pushing that you’re ever going to get there. </p>
+
+<p>And the really good stories – the ones that are worth telling – they don’t come easy. You have to nail them down. </p>
+
+<p>The best kept secret of all, the one I think we ought to advertise, is that when you are on the trail of something good there’s no better feeling. Or at least not one we can talk about in front of Father Holtschneider. </p>
+
+<p>Carol once told me it’s like breathing different air when we were out on assignment, and she could tell I was feeling it. She was right. As soon as I got my taste I was hooked.</p>
+
+<p>But like any good journalist, you shouldn’t take my word for it. You should go check it out yourself. You won’t be disappointed.</p>
+
+<p>Thank you.</p>
+
+</blockquote>

--- a/coltrane/content/posts/2018-04-14--my-times.md
+++ b/coltrane/content/posts/2018-04-14--my-times.md
@@ -1,0 +1,547 @@
+---
+title: My Times
+slug: my-times
+published_at: '2018-04-14T10:00:00-07:00'
+repr_image: //palewire.s3.amazonaws.com/latimes-tour/121.jpg
+---
+<p>The new owner of the Los Angeles Times is <a href="http://www.latimes.com/business/hollywood/la-fi-ct-la-times-el-segundo-20180413-story.html">moving</a> the newsroom from its historic headquarters to El Segundo, a small suburb next to the airport.</p>
+
+<p>I've been lucky to inhabit and explore the interlocking buildings at 1st and Spring for over a decade.</p>
+
+<p>I'd like to share them with you. It's a beautiful day in downtown L.A. Shall we take a wander?</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/1.jpg"></figure>
+
+<p>The buildings were built by the Chandler Family.</p>
+
+<p>The different sections of the block have different cornerstones set by succeeding generations.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/2.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/stone.jpg"></figure>
+
+<p>Here's the lobby at 2nd and Spring, with its beautiful fixtures. They include -30-, the traditional newspaper code for a story's end, hung over the exit.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/4.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/5.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/6.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/7.jpg"></figure>
+
+<p>That lobby is also home to some more recently minted iconography. It tends to be a little less ... subtle?</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/8.jpg"></figure>
+
+<p>Once you're past the gate, things get less glamorous. And fast.</p>
+
+<p>A blood pressure monitor and scale next to the vending machines. Sure. Why not?</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/9.jpg"></figure>
+
+<p>The other public entrance, on 1st, is called the Globe Lobby. Here's why. </p>
+
+<p>Believe it or not. This thing rotates. When it's not broken.</p>
+
+<p>It is now broken.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/10.jpg"></figure>
+
+<p>The Globe Lobby is effectively the Chandlers' museum for themselves. It features busts of the male heirs, who in their time ran the paper.</p>
+
+<p>First, Gen. Harrison Gray Otis.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/11.jpg"></figure>
+
+<p>Then, Harry Chandler.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/12.jpg"></figure>
+
+<p>Then, Norman Chandler.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/13.jpg"></figure>
+
+<p>And, finally, the most celebrated heir, Otis Chandler.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/14.jpg"></figure>
+
+<p>The lobby is also home to a 360-degree mural by <a href="https://en.wikipedia.org/wiki/Hugo_Ballin">Hugo Ballin</a>. It's a tribute to the settlers of California and the nobility of press workers.</p>
+
+<p>There's a longer story about why that's the dominant theme, and why this building even exists. We'll get to it later.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/15.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/16.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/17.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/18.jpg"></figure>
+
+<p>There's also a tribute to four Los Angeles Times reporters who died on duty.</p>
+
+<p>One, <a href="https://en.wikipedia.org/wiki/Ruben_Salazar">Ruben Salazar</a>, has become a legend on L.A.'s Eastside, and a symbol of Chicano professionalism. He's even on a stamp.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/salazar.jpg"></figure>
+
+<p>Here's an old Linotype machine.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/20.jpg"></figure>
+
+<p>Well. My phone died. So I'm going to brew a pot of coffee up in the newsroom while it charges at my desk. </p>
+
+<p>Here's my desk by the way. </p>
+
+<p>Everybody makes fun of the monitors I've scrounged through the years. But I'll be honest. I've never seen too much Linux.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/21.jpg"></figure>
+
+<p>While we are here, let me introduce you to my own personal Globe Lobby. I call it "The Windowsill of the Weird."</p>
+
+<p>It's the Los Angeles Times Data Desk's museum, I suppose. When people leave The Times, I make them leave me a memento.</p>
+
+<p>There's also just a lot of my crap too.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/22.jpg"></figure>
+
+<p>RIP Yasiel Twig.</p>
+
+<p>(Pronounced "<a href="https://www.youtube.com/watch?v=iOCT8B9WyKw">Tweeg</a>", of course)</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/23.jpg"></figure>
+
+<p>It contains such treasures as the "office Crocs" of <a href="https://twitter.com/dgainesla?lang=en">Dan Gaines</a>.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/24.jpg"></figure>
+
+<p><a href="https://twitter.com/mazet">Lily Mihalik's</a> turkey cap.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/25.jpg"></figure>
+
+<p>The infamous "ghost tie." (Hint: those aren't ghosts.)</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/26.jpg"></figure>
+
+<p>And, my favorite, the "first annual" Tronc innovation award.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/27.jpg"></figure>
+
+<p>I guess I can let all this spill now. Below the sill is our secret cache of abandoned computers, monitors, cords and parts scavenged during the uncountable layoffs and reorgs.</p>
+
+<p>You know the Data Desk likes you if we made sure you scored a second monitor from here.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/28.jpg"></figure>
+
+<p>My coffee was brewed in a newsroom nook financed by prize money from an ONA award. </p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/29.jpg"></figure>
+
+<p>The beans are supplied by our Data Desk coffee club. (<a href="https://twitter.com/maloym?lang=en">Maloy Moore</a> collects the bills. <a href="https://twitter.com/anthonyjpesce">Anthony Pesce</a> secures the reup.)</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/30.jpg"></figure>
+
+<p>The sludge is served in <a href="https://twitter.com/hfuhrmann">Henry Fuhrmann's</a> custom-designed copy desk mug.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/31.jpg"></figure>
+
+<p>I'm not the only amateur curator in the newsroom.</p>
+
+<p>Here is the Business Section's "Museum of Defunct Technology."</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/32.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/33.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/34.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/35.jpg"></figure>
+
+<p>Here is <a href="https://twitter.com/latdoug?lang=fr">Doug Smith's</a> private collection. It includes the typewriter of legendary reporter <a href="http://articles.latimes.com/print/2010/jul/29/local/la-me-eric-malnic-20100729">Eric Malnic</a> and old 9-track tapes from the true innovator of data analysis at The Times: Dick O'Reilly.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/36.jpg"></figure>
+
+<p>I can't take you there, because it's already gone, but Dick O'Reilly's server room of 9-track tape readers lasted until April 2017.</p>
+
+<p>Before it closed up, I took some video. The Cipher 9's still ran!</p>
+
+<figure class="latimes-tour video">
+ <video playsinline poster="//palewire.s3.amazonaws.com/latimes-tour/9track.jpg" controls>
+  <source src="//palewire.s3.amazonaws.com/latimes-tour/9track.mp4" type="video/mp4">
+ </video>
+</figure>
+
+<p>Alright my phone is charged and we're back in the Globe Lobby.</p>
+
+<p>It displays some of the most famous work from Times history.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/37.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/38.jpg"></figure>
+
+<p>My favorites are the hand-drawn World War 2 maps of <a href="https://onlinelibrary.wiley.com/doi/abs/10.1111/j.1467-8306.2005.00465.x">Charles Owens</a>, who is shown working below.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/39.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/40.jpg"></figure>
+
+<p>The lobby used to have a board featuring the digital work of latimes.com.</p>
+
+<p>It has been removed and replaced with old photos. The grooves in the upper left here once held lettering spelling out "INTERACTIVE."</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/41.jpg"></figure>
+
+<p>The exterior of the Globe Lobby, out on 1st Street, is engraved with several messages from the Chandlers.</p>
+
+<p>One, which once appeared on the paper's masthead, praises "the cause of true industrial freedom."</p>
+
+<p>I'm told that was an anti-union slogan of their time.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/freedom.jpg"></figure>
+
+<p>Also on the exterior is this message, which our new owner might consider somehow updating on whatever building The Times inhabits next.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/symbol.jpg"></figure>
+
+<p>Back inside on the floor you can find plates commemorating the three previous homes of The Times, one of which was dynamited by union activists.</p>
+
+<p>That event shaped the Chandlers' politics for generations and is embedded in much of the art and rhetoric we see here.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/44.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/45.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/46.jpg"></figure>
+
+<p>Just above the plates you find the eagle statue that stood atop the previous headquarters and survived the bombing.</p>
+
+<p>It is the true centerpiece of the symbolry here, which is why it made such a powerful logo for the Los Angeles Times Guild's <a href="http://www.latimes.com/business/la-fi-times-guild-vote-20180119-story.html">recent push</a> to change the course of the organization's history.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/47.jpg"></figure>
+
+<p>To the eagle's left, there's an old phone booth.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/longdist.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/phone.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/nickel.jpg"></figure>
+
+<p>If you look at Ballin's mural again with history in mind, you see that it encodes some less-than-subtle reactions to the unionist bombing.</p>
+
+<p>It also offers some smaller gifts. Like, this, the car of the future. (Note: It's a bus.)</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/car.jpg"></figure>
+
+<p>And a set of intricately drawn hands, all grasping for a paper fresh off the press.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/hands.jpg"></figure>
+
+<p>Before we leave, let's admire a few more artsy doodads from this beautiful room.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/pull.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/48.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/49.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/50.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/51.jpg"></figure>
+
+<p>Outside, above the entrance, there is a wonderful, and often overlooked, grid of 12 plates celebrating the aspects of life and culture covered by The Times.</p>
+
+<p>My favorite is the position of respect of given to the game of Bridge.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/52.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/53.jpg"></figure>
+
+<p>On the floor above the globe is an exhibit of all of The Times' Pulitzer Prize winners.</p>
+
+<p>See which current and former staff you can spot.</p>
+
+<p>(Sorry for the low quality of these photos. I am obviously a bad photographer and I'm now venturing into poorly lit parts of the building.)</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/54.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/55.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/56.jpg"></figure>
+
+<p>Next door is the suite of offices reserved for the publisher and the editorial board.</p>
+
+<p>The most recent occupants were <a href="https://en.wikipedia.org/wiki/Ross_Levinsohn">Ross Levinsohn</a> and the so-called <a href="https://www.huffingtonpost.com/entry/los-angeles-times-scab-fears_us_5a6a09bbe4b06e2532657c66">"shadow newsroom"</a> being developed by Tronc.</p>
+
+<p>The space is now vacant.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/57.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/58.jpg"></figure>
+
+<p>Not far away is the library, home to a vast archive of microfiche and microfilm.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/59.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/60.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/61.jpg"></figure>
+
+<p>That includes the machines necessary to read it.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/62.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/63.jpg"></figure>
+
+<p>My favorite here is the Kardex Series 80 Lektriever, a still-functioning carousel of alphabetized packets of print  clips organized by topic.</p>
+
+<p>Watch it go.</p>
+
+<figure class="latimes-tour video">
+ <video playsinline poster="//palewire.s3.amazonaws.com/latimes-tour/kardex.jpg" controls>
+  <source src="//palewire.s3.amazonaws.com/latimes-tour/kardex.mp4" type="video/mp4">
+ </video>
+</figure>
+
+<p>Each envelope of clips carries a warning.</p>
+
+<p>Its message is something we'd probably all do well to heed before retweeting.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/64.jpg"></figure>
+
+<p>Some odds and ends from the offices of our Spanish language publications, which now sit where the Data Desk did in prior years.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/65.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/66.jpg"></figure>
+
+<p>Nearby is a popular stop on any tour: The test kitchen where all our recipes are prepared and photographed.</p>
+
+<p>This is one of the places I can't get in with my badge. But that won't stop us from trying. Let's keep moving.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/67.jpg"></figure>
+
+<p>A couple steps away is <a href="http://www.adamtschorn.com/">Adam Tschorn's</a> arsenal of hats and wigs.</p>
+
+<p>That arm belongs to <a href="https://www.kirkmckoyphotography.com/">Kirk McCoy</a>. This is likely the most poorly composed series of photographs he's ever been involved in.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/68.jpg"></figure>
+
+<p>I'll be honest. I don't know what this one is.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/69.jpg"></figure>
+
+<p>Don't worry. The GTI MiniMatcher is still plugged in.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/70.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/71.jpg"></figure>
+
+<p>Here's the mail chute down to those ornate boxes we saw earlier.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/72.jpg"></figure>
+
+<p>I followed it back up to the third floor and the main newsroom.</p>
+
+<p>Here's one for your dad: The set where <a href="https://twitter.com/BillPlaschke">Bill Plaschke</a> tapes his "Around the Horn" segments on ESPN.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/73.jpg"></figure>
+
+<p>A big chunk of the newsroom runs along the length of Spring Street.</p>
+
+<p>It starts with the Data Desk. Mostly Metro section reporters past that.</p>
+
+<p>Because it extends like a tail from the core of offices behind me, this strip is know as "Baja Metro." The area beyond: "Cabo."</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/74.jpg"></figure>
+
+<p>Facing the other way you see a donut-shaped area with an elevator to the Globe Lobby at the center.</p>
+
+<p>The inner ring is known as "The Glass Offices."</p>
+
+<p>The term is code for upper management and is often used as a collective noun, as in "The Glass Offices haven't weighed in yet."</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/75.jpg"></figure>
+
+<p>The largest of these corner offices has traditionally belonged to the editor-in-chief.</p>
+
+<p>It is currently vacant, and has been since our previous editor was <a href="http://money.cnn.com/2017/08/21/media/los-angeles-times-shakeup/index.html">fired</a>.</p>
+
+<p>Most recently it has served as a war room for Washington Post programmers during deployments to overhaul our content-management system, what we call our "CMS."</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/76.jpg"></figure>
+
+<p>This office is renowned for having its own private bathroom.</p>
+
+<p>Since I'll probably never have another chance, let's check it out.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/77.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/78.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/80.jpg"></figure>
+
+<p>Here's one of the section signs from prior to the most recent remodel, with some minor modifications.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/81.jpg"></figure>
+
+<p>Now the "A1" conference room where committees of editors meet to plan news coverage. Its windows look out on 1st Street.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/82.jpg"></figure>
+
+<p>The view of City Hall from <a href="https://twitter.com/ChrisLKellerLAT">Chris Keller's</a> desk in our Graphics Department.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/83.jpg"></figure>
+
+<p>Alright. Enough normal stuff. Let's get weird.</p>
+
+<figure class="latimes-tour video">
+ <video playsinline autoplay loop poster="//palewire.s3.amazonaws.com/latimes-tour/button.jpg">
+  <source src="//palewire.s3.amazonaws.com/latimes-tour/button.mp4" type="video/mp4">
+ </video>
+</figure>
+
+<p>So you just started your new job here at The Times. Someone you don't know sent you an Outlook calendar invitation to attend a mandatory CMS training session in the basement.</p>
+
+<p>This is not a drill. Welcome to the Los Angeles Times Training Center.</p>
+
+<p>Just keep following the arrows, the email said. What could go wrong?</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/84.jpg"></figure>
+
+<p>Everything is totally okay. Just keep walking.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/85.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/86.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/87.jpg"></figure>
+
+<p>This seems like a bad idea.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/88.jpg"></figure>
+
+<p>What. You again? Did you follow me from the library?</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/89.jpg"></figure>
+
+<p>Again? No. No thank you.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/90.jpg"></figure>
+
+<p>This probably shouldn't be here.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/pedestal.jpg"></figure>
+
+<p>Why is this beeping?</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/91.jpg"></figure>
+
+<p>No. Really. I'm good.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/92.jpg"></figure>
+
+<p>This can't be the right way. Can it?</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/93.jpg"></figure>
+
+<p><a href="https://en.wikipedia.org/wiki/Phillip_Jeffries">Phillip Jeffries</a>, is that you? Can you tell me what happened to <a href="https://en.wikipedia.org/wiki/Laura_Palmer">Laura Palmer</a>?</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/twinpeaks.jpg"></figure>
+
+<p>I guess I just keep going?</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/94.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/95.jpg"></figure>
+
+<p>Oh no. How do I get back?</p>
+
+<figure class="latimes-tour video">
+ <video playsinline autoplay loop poster="//palewire.s3.amazonaws.com/latimes-tour/handle.jpg">
+  <source src="//palewire.s3.amazonaws.com/latimes-tour/handle.mp4" type="video/mp4">
+ </video>
+</figure>
+
+<p>Okay. I guess I have to go back upstairs. Yeah. Let's do that.</p>
+
+<p>Wait. Where am I?!</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/96.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/97.jpg"></figure>
+
+<p>Thus ends my stupid play.</p>
+
+<p>The basements of the Los Angeles Times building hold some of its most exquisite joys.</p>
+
+<p>There was once a "music room" down here where staff were encouraged to hold band practice.</p>
+
+<p>You found it, and I'm not kidding, by following emoji painted on the walls.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/98.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/99.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/100.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/101.jpg"></figure>
+
+<p>What's down there now, you ask. Oh, nothing. Just a full-length basketball court with concrete pillars in play.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/102.jpg"></figure>
+
+<p>I don't know which Times reporter would be best suited as a "Street Fighter II" character, but I think this would have to be the backdrop for their battles.</p>
+
+<p>(Who am I kidding? The answer is obviously <a href="https://twitter.com/JamesQueallyLAT?">James Queally</a>.)</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/103.jpg"></figure>
+
+<p>For my final trick of the day, we scale to the top of the old factory building to explore the Chandler Family's inner sanctum.</p>
+
+<p>Ready? Let's hope I don't get locked in.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/104.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/105.jpg"></figure>
+
+<p>The Harry Chandler Auditorium, where both <a href="https://en.wikipedia.org/wiki/Sam_Zell">Sam Zell</a> and <a href="https://en.wikipedia.org/wiki/Patrick_Soon-Shiong">Patrick Soon-Shiong</a> introduced themselves as owners.</p>
+
+<p>Now a coworking space. Locked.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/106.jpg"></figure>
+
+<p>The fifth floor "bullpen" where I joined <a href="https://en.wikipedia.org/wiki/Meredith_Artley">Meredith Artley</a>, <a href="http://ulken.com/">Eric Ulken</a> and latimes.com  in 2007? City office space. Locked.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/107.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/108.jpg"></figure>
+
+<p>The downtown L.A. skyline and top of The Times' Mirror Building from the executive parking garage's roof. This is the 2nd and Broadway corner.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/109.jpg"></figure>
+
+<p>Another floor up: An atrium surrounded by what I'm told were the Chandlers' private offices.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/111.jpg"></figure>
+
+<p>Nearby: A massive boardroom worthy of <a href="https://en.wikipedia.org/wiki/Illuminati">The Illuminati</a>.</p> 
+
+<p>I'm sorry to report its beautiful, circular table appears to already be gone.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/112.jpg"></figure>
+
+<p>Underneath where it once sat is the logo of the defunct Times-Mirror company.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/113.jpg"></figure>
+
+Here's the latest picture of the table I have, <a href="https://twitter.com/palewire/status/943955813369966592">taken</a> during a recent visit with <a href="https://twitter.com/irisslee">Iris Lee</a>.
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/table.jpg"></figure>
+
+<p>There's a big corner office.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/corner-office.jpg"></figure>
+
+<p>This one has a shower.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/shower-door.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/shower.jpg"></figure>
+
+<p>Nearby you can find the "Ladies Lounge."</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/ladies-door.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/ladies-lounge.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/chandelier.jpg"></figure>
+
+<p>Definitely not haunted.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/115.jpg"></figure>
+
+<p>You probably can't see in very well but it's the darkened and long-abandoned executive cafeteria. It once displayed works by Picasso. Locked.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/116.jpg"></figure>
+
+</p>Nevermind. Where there's a will there's a way. I'm in.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/117.jpg"></figure>
+
+<p>Looks like there's a kitchen back here. Locked.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/118.jpg"></figure>
+
+<p>Outside, the coat room.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/119.jpg"></figure>
+
+<p>And, finally, another favorite spot. The glass-encased salon at the corner of 1st and Spring with a sweeping view of City Hall that is even better at night. It looks down on the spot where I started our tour.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/corner.jpg"></figure>
+
+<p>It offers a back door to a catwalk on the roof, which I'll take back down to the newsroom.</p>
+
+<p>That's the end of today's adventure. Thank you for joining me.</p>
+
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/121.jpg"></figure>
+<figure class="latimes-tour"><img src="//palewire.s3.amazonaws.com/latimes-tour/122.jpg"></figure>
+
+<p><em style="font-style:italic;">This story originally appeared as a series of posts <a href="https://twitter.com/palewire/status/985179795771211776">on Twitter</a>. It has been lightly edited for clarity. A small number of photos have been added to expand the original tour.</em></p>

--- a/coltrane/content/posts/2020-03-21--flash-mooc-first-python-notebook.md
+++ b/coltrane/content/posts/2020-03-21--flash-mooc-first-python-notebook.md
@@ -1,0 +1,26 @@
+---
+title: 'Flash MOOC: First Python Notebook'
+slug: flash-mooc-first-python-notebook
+published_at: '2020-03-21T18:09:31-07:00'
+---
+<p>In response to an <a href="https://twitter.com/palewire/status/1241370106262745089">outpouring on social media</a>, I plan to host an impromptu live stream of "<a href="http://www.firstpythonnotebook.org/">First Python Notebook</a>," a computer-programming class that teaches the fundamentals of computerized data analysis for news.</p>
+
+<h2>How it will work</h2>
+
+<p>The class is tentatively scheduled for 9 a.m. Pacific on Saturday, March 28.</p>
+
+<p>If you're interested in participating, <a href="https://forms.gle/bHws6jWSHgz5YKEn6">fill out this form</a>. The class is free. All are welcome. Class size may need to be limited.</p>
+
+<p>You are expected to have your own computer and to do some configuration of its programming tools before class. You will also need to connect to an online meeting using a program like <a href="https://zoom.us/">Zoom</a>. If you sign up, I'll be in touch soon about the specifics.</p>
+
+<h2>About the class</h2>
+
+<p>The six-hour hands-on class will guide students through an investigation of money in politics. The entire tutorial is already scripted out at <a href="http://www.firstpythonnotebook.org/">www.firstpythonnotebook.org</a>. First developed in 2017 as a <a href="https://knightcenter.utexas.edu/blog/00-18396-sign-now-our-new-online-course-data-journalism-python-data-journalists-analyzing-money">massive open online course</a>, "First Python Notebook" has been taught at numerous journalism conferences and in university classrooms around the world.</p>
+
+<p>If you join, you will learn just enough of the <a href='https://www.python.org/">Python</a> computer programming language to work with the <a href="http://pandas.pydata.org/">pandas</a> library, a popular open-source tool for analyzing data. The course will teach you how to read, filter, join, group, aggregate and rank structured data.</p>
+
+<p>You will also learn how to record, remix and republish your analysis using the <a href="http://jupyter.org/">Jupyter notebook</a>, a browser-based application for writing code that is emerging as the standard for sharing reproducible research.</p>
+
+<p>You will also learn how to plot and chart your data inside the notebook using the <a href="https://altair-viz.github.io/">Altair</a> data visualization library, a cutting-edge tool that offers a simple, structured grammar for generating graphics.</p>
+
+<p>We will work through the standard materials, and, depending on our pace, take several breaks throughout the day.</p>

--- a/coltrane/content/posts/2021-02-23--nicar21-after-party-first-python-notebook.md
+++ b/coltrane/content/posts/2021-02-23--nicar21-after-party-first-python-notebook.md
@@ -1,0 +1,36 @@
+---
+title: '#NICAR21 After Party'
+slug: nicar21-after-party-first-python-notebook
+published_at: '2021-02-23T19:20:22-08:00'
+---
+<p>Due to the continued scourge of the coronavirus, the annual conference of National Institute for Computer-Assisted Reporting <a href="https://www.ire.org/nicar21-virtual-conference/">is being held online</a>.</p>
+
+<p>One sad result is that the virtual event will not offer the lengthy hands-on training sessions where attendees typically dive into computer programming.</p>
+
+<p>They are my favorite part of the conference. And I'm not ready to let them go.</p>
+
+<p>So, after the conference wraps up, I plan to host an impromptu live stream of "<a href="http://www.firstpythonnotebook.org/">First Python Notebook</a>," a six-hour class that teaches the fundamentals of data analysis for news. It's been taught the last four years and we're going to keep the streak alive.</p>
+
+<h2>How it will work</h2>
+
+<p>The class is tentatively scheduled for 9 a.m. Pacific on Saturday, March 6.</p>
+
+<p>If you're interested in participating, <a href="https://forms.gle/YbJD4ExdrsGnPKYG6">fill out this form</a>. The class is free. You do not have to be registered for the conference. You don't even need to be a journalist. All are welcome.</p>
+
+<p>You are expected to have your own computer and to do some configuration of its programming tools before class. You will also need to connect to an online meeting using <a href="https://zoom.us/">Zoom</a>. If you sign up, I'll be in touch soon about the specifics.</p>
+
+<h2>About the class</h2>
+
+<p>The six-hour hands-on class will guide students through an investigation of money in politics. The entire tutorial is already scripted out at <a href="http://www.firstpythonnotebook.org/">firstpythonnotebook.org</a>.</p>
+
+<p>First developed in 2017 as a <a href="https://knightcenter.utexas.edu/blog/00-18396-sign-now-our-new-online-course-data-journalism-python-data-journalists-analyzing-money">massive open online course</a>, "First Python Notebook" has been taught at numerous journalism conferences and in university classrooms around the world. A similar online class was <a href ="https://palewi.re/posts/2020/03/21/flash-mooc-first-python-notebook/">taught last year</a>, in the early days of the pandemic.</p>
+
+<p>This time, I'll be joined by <a href="http://irisslee.com/">Iris Lee</a> and <a href="https://andreasuozzo.com/">Andrea Suozzo</a>, who will each teach a section of the class. <a href="http://thescoop.org/">Derek Willis</a>, <a href="https://en.wikipedia.org/wiki/Cheryl_Phillips">Cheryl Phillips</a> and others will be on hand to assist students.</p>
+
+<p>If you join, you will learn just enough of the <a href="https://www.python.org/">Python</a> computer programming language to work with the <a href="http://pandas.pydata.org/">pandas</a> library, a popular open-source tool for analyzing data. The course will teach you how to read, filter, join, group, aggregate and rank structured data.</p>
+
+<p>You will also learn how to record, remix and republish your analysis using the <a href="http://jupyter.org/">Jupyter notebook</a>, a browser-based application for writing code that is emerging as the standard for sharing reproducible research.</p>
+
+<p>You will also learn how to plot and chart your data inside the notebook using the <a href="https://altair-viz.github.io/">Altair</a> data visualization library, a cutting-edge tool that offers a simple, structured grammar for generating graphics.</p>
+
+<p>We will work through the standard materials, and, depending on our pace, take several breaks throughout the day.</p>

--- a/coltrane/content/posts/2021-05-02--ee-cummings-archive.md
+++ b/coltrane/content/posts/2021-05-02--ee-cummings-archive.md
@@ -1,0 +1,42 @@
+---
+title: Introducing the e.e. cummings free poetry archive
+slug: ee-cummings-archive
+published_at: '2021-05-02T18:46:06-07:00'
+---
+<figure>
+ <a href="https://cummings.ee">
+  <img src="https://palewi.re/static/img/cummings-intro.gif" alt="the e.e. cummings free poetry archive">
+</a>
+</figure>
+
+<p>Today marks the launch of <a href="https://cummings.ee">cummings.ee</a>, a  digital archive of the poetry of Edward Estlin Cummings.</p>
+
+<p>The website aims to republish all of the author’s work as it gradually enters the public domain. Built using <a href="https://github.com/ee-cummings-archive/cummings.ee">open-source software</a> and structured data, it also offers publishers, academics, analysts, fans and artists free and easy access to the poet's body of work.</p>
+
+<p><a href="https://en.wikipedia.org/wiki/E._E._Cummings">Edward Estlin Cummings</a>, better known by the pen name E. E. Cummings, was a 20th century American author who distinguished himself among the <a href="https://en.wikipedia.org/wiki/Modernism">modernists</a> with his playful syntax and sensual subject matter. His poems, often delivered in lower case spellings, continue to enjoy a large following.</p>
+
+<p>Due to the way U.S. law works, <a href="https://web.law.duke.edu/cspd/publicdomainday/2021/">each January 1</a> the copyright on another year of past literature expires, making it free for others to use and build from. In the last few years, protections have expired on books published in the mid-1920's, including Cummings’s first three volumes of verse.</p>
+
+<p>The author's first book of poetry, “<a href="https://cummings.ee/">Tulips and Chimneys,</a>” has already been republished by the archive in full, perhaps for the first time ever online. Transcription of the books that followed — “<a href="https://cummings.ee/book/and/">&</a>” and “<a href="https://cummings.ee/book/xli-poems/">XLI Poems</a>” — is underway.</p>
+
+<p>Volunteers interested in helping with the keypunching effort can participate via <a href="https://github.com/ee-cummings-archive/cummings.ee">the project's GitHub repository</a>, where all of the code that powers the site, including the database of transcriptions, is stored. Instructions on how to contribute are <a href="https://github.com/ee-cummings-archive/cummings.ee/blob/master/CONTRIBUTING.md">available there</a>. Any errors in the digital copies can be addressed via GitHub as well.</p>
+
+<p>Cummings’s fourth book, “<a href="https://cummings.ee/book/is-5/">is 5</a>,” will free up in 2022, along with all other American works published in 1926. It will be added to the archive soon after.</p>
+
+<p>The site was designed to emulate the typography and layout of books put out in the 1920's by <a href="https://en.wikipedia.org/wiki/Thomas_Seltzer_(translator)">Thomas Seltzer</a> and <a href="https://en.wikipedia.org/wiki/Boni_%26_Liveright">Boni & Liveright</a>, two of Cummings's earliest publishers. The font is <a href="https://fonts.google.com/specimen/Newsreader">Newsreader</a>, a free letter-set created by <a href="https://www.productiontype.com/">Production Type</a>.</p>
+
+<p>Accommodations have been made to honor Cummings’s unconventional use of punctuation and white space. For instance, when accessing the site via a mobile phone the text is not allowed to wrap to a new line when it would mar the author's intended effect. While this violates the <a href="https://en.wikipedia.org/wiki/Responsive_web_design">dominant conventions</a> in web design, it better preserves the integrity of the original work.</p>
+
+<p>The complete database of poems is <a href="https://cummings.ee/downloads/">available for bulk download</a> in machine-readable formats. This should allow anyone seeking to study or republish the work to port transcriptions to a system of their choosing. It will update as new material is added.</p>
+
+<p>My hope is that this will result in the poems being syndicated by popular free libraries, like <a href="https://www.gutenberg.org/">Project Gutenberg</a>, as well as other creative forms of reuse. I am particularly interested in exploring the potential for studying the corpus using the computational methods of <a href="https://en.wikipedia.org/wiki/Digital_humanities">digital humanities</a> scholars.</p>
+
+<p>The data are now free for anyone to repurpose. Those interested in a partnership effort should contact me at <a href="mailto:b@palewi.re">b@palewi.re</a>.</p>
+
+<p>While the site is far from finished, and I welcome ideas on how it could improve, I would not have gotten this far without the valuable feedback I've received from a group of advisors. Thank you to <a href="https://aaronmoe.com/">Aaron Moe</a>, <a href="https://english.tau.ac.il/profile/tartako">Roi Tartakovsky</a>, <a href="https://www.latimes.com/people/alex-tatusian">Alex Tatusian</a> and <a href="https://gvsu.academia.edu/MichaelWebster/CurriculumVitae">Michael Webster</a>, who each helped improve the effort.</p>
+
+<p>The work here, cobbled together in odd hours and on weekends, is dedicated to my wife, Amanda, the most passionate Cummings fan in our family.</p>
+
+<p>It's been tempting to think of this pandemic year as a long-running parenthetical. One that, if we wait long enough, will close and return the flow of our lives to normal, to what it was before.</p>
+
+<p>Taking a page from <a href="https://dailypoetry.me/e-e-cummings/since-feeling-is-first/">one of the poet’s best works</a>, she has reminded me to instead focus on the here and now, to not pay too much attention to “the syntax of things.” My mind may not know better, but my blood approves.</p>

--- a/coltrane/content/posts/2021-05-09--public-art-on-la-light-rail-line.md
+++ b/coltrane/content/posts/2021-05-09--public-art-on-la-light-rail-line.md
@@ -1,0 +1,352 @@
+---
+title: Liberating the public art on L.A.’s light rail lines
+slug: public-art-on-la-light-rail-line
+published_at: '2021-05-09T16:52:30-07:00'
+---
+<img style="margin-bottom:15px;" src="https://palewi.re/static/img/regional-connector/backgrounds.gif" alt="Regional Connector art">
+
+<p><a href="https://en.wikipedia.org/wiki/Freedom_of_information_laws_by_country">Public records laws</a> are powerful. They allow lawyers, journalists, activists and any old citizen to pry loose information from their government.</p>
+
+<p>They are also broad. Most laws assume all government records are open, unless they qualify for a small number of exemptions, like those protecting law enforcement investigations or personal medical records.</p>
+
+<p>One avenue that often goes unexplored is public art. When the government uses taxpayer dollars to commission an artist to adorn a public venue, the work should be accessible via a records request like any other official document.</p>
+
+<p>In our digital era, with many artists using computers to design their work, that also means many creations can be released in an <a href="https://en.wikipedia.org/wiki/Open_format">open format</a> that is easily remixed and reproduced.</p>
+
+<p>To test this principle, I used <a href="https://www.muckrock.com/">MuckRock</a> to issue a series of requests under the <a href="https://en.wikipedia.org/wiki/California_Public_Records_Act">California Public Records Act</a> to the <a href="https://en.wikipedia.org/wiki/Los_Angeles_County_Metropolitan_Transportation_Authority">Metropolitan Transportation Authority</a> of Los Angeles County.</p>
+
+<p>This local body is now in the process of building three new light-rail stops in downtown Los Angeles, part of an extension known as the <a href="https://en.wikipedia.org/wiki/Regional_Connector">Regional Connector</a>. The project is paid for, in large part, by <a href="https://en.wikipedia.org/wiki/Measure_R">new taxes</a> levied on the area. Among other things, the funding has been used to hire local artists.
+</p>
+
+<p>The agency honored my request by releasing <a href="https://en.wikipedia.org/wiki/PDF">PDF documents</a> with digital reproductions of the art that will soon appear on station walls. I've posted them all below. I was blown away by the work and I'm excited to share it with you here.</p>
+
+<p>The original files are available on <a href="https://github.com/palewire/regional-connector-art">GitHub</a>.</p>
+
+<h2>Little Tokyo/Arts District</h2>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/little-tokyo-elevations.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/little-tokyo-elevations.png">
+  <img src="/static/img/regional-connector/little-tokyo-elevations.png" alt="Little Tokyo">
+</picture>
+
+<p>The Little Tokyo/Arts District station at First Street and Central Avenue will serve as a new juncture between today's <a href="https://en.wikipedia.org/wiki/L_Line_(Los_Angeles_Metro)">L Line</a> and other trains that run south and west.</p>
+
+<p>Architectural plans released by Metro show how panels by <a href="http://kavigupta.com/artist/clare-rojas/">Clare Rojas</a> will adorn many of the walls.</p>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/little-tokyo-rojas-1.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/little-tokyo-rojas-1.png">
+  <img src="/static/img/regional-connector/little-tokyo-rojas-1.png" alt="Little Tokyo">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/little-tokyo-rojas-2.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/little-tokyo-rojas-2.png">
+  <img src="/static/img/regional-connector/little-tokyo-rojas-2.png" alt="Little Tokyo">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/little-tokyo-rojas-3.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/little-tokyo-rojas-3.png">
+  <img src="/static/img/regional-connector/little-tokyo-rojas-3.png" alt="Little Tokyo">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/little-tokyo-rojas-4.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/little-tokyo-rojas-4.png">
+  <img style="margin-bottom: 15px;" src="/static/img/regional-connector/little-tokyo-rojas-4.png" alt="Little Tokyo">
+</picture>
+
+<p><a href="https://www.audreychan.net/">Audrey Chan</a> crafted 14 panels of porcelain enamel steel to flank the platform. Chan calls the piece, "Will Power Allegory." It celebrates characters from the area’s history, including the local residents who overcame the <a href="https://en.wikipedia.org/wiki/Internment_of_Japanese_Americans">internment of Japanese Americans</a> during World War II.</p>
+
+<p><a href="https://audreychan.net/will-power-allegory">She told</a> Metro, "This is the first time I worked on a piece that could be considered permanent, so it made me think, 'What is worth committing to history?'"</p>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/little-tokyo-chan-1.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/little-tokyo-chan-min-1.png">
+  <img src="/static/img/regional-connector/little-tokyo-chan-min-1.png" alt="Little Tokyo">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/little-tokyo-chan-2.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/little-tokyo-chan-min-2.png">
+  <img src="/static/img/regional-connector/little-tokyo-chan-min-2.png" alt="Little Tokyo">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/little-tokyo-chan-3.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/little-tokyo-chan-min-3.png">
+  <img src="/static/img/regional-connector/little-tokyo-chan-min-3.png" alt="Little Tokyo">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/little-tokyo-chan-4.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/little-tokyo-chan-min-4.png">
+  <img src="/static/img/regional-connector/little-tokyo-chan-min-4.png" alt="Little Tokyo">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/little-tokyo-chan-5.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/little-tokyo-chan-min-5.png">
+  <img src="/static/img/regional-connector/little-tokyo-chan-min-5.png" alt="Little Tokyo">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/little-tokyo-chan-6.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/little-tokyo-chan-min-6.png">
+  <img src="/static/img/regional-connector/little-tokyo-chan-min-6.png" alt="Little Tokyo">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/little-tokyo-chan-7.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/little-tokyo-chan-min-7.png">
+  <img style="margin-bottom: 15px;"  src="/static/img/regional-connector/little-tokyo-chan-min-7.png" alt="Little Tokyo">
+</picture>
+
+<p>Chan also includes portraits of <a href="https://en.wikipedia.org/wiki/Biddy_Mason">Biddy Mason</a>, an African-American nurse and early entrepreneur of downtown L.A., the <a href="https://en.wikipedia.org/wiki/Tongva">Tongva</a> natives who first settled the region, the Skid Row community of homeless people,  as well as more recent cultural and activist movements in the area.</p>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/little-tokyo-chan-8.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/little-tokyo-chan-min-8.png">
+  <img src="/static/img/regional-connector/little-tokyo-chan-min-8.png" alt="Little Tokyo">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/little-tokyo-chan-9.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/little-tokyo-chan-min-9.png">
+  <img src="/static/img/regional-connector/little-tokyo-chan-min-9.png" alt="Little Tokyo">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/little-tokyo-chan-10.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/little-tokyo-chan-min-10.png">
+  <img src="/static/img/regional-connector/little-tokyo-chan-min-10.png" alt="Little Tokyo">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/little-tokyo-chan-11.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/little-tokyo-chan-min-11.png">
+  <img src="/static/img/regional-connector/little-tokyo-chan-min-11.png" alt="Little Tokyo">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/little-tokyo-chan-12.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/little-tokyo-chan-min-12.png">
+  <img src="/static/img/regional-connector/little-tokyo-chan-min-12.png" alt="Little Tokyo">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/little-tokyo-chan-13.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/little-tokyo-chan-min-13.png">
+  <img src="/static/img/regional-connector/little-tokyo-chan-min-13.png" alt="Little Tokyo">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/little-tokyo-chan-14.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/little-tokyo-chan-min-14.png">
+  <img src="/static/img/regional-connector/little-tokyo-chan-min-14.png" alt="Little Tokyo">
+</picture>
+
+<h2>Historic Broadway</h2>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-elevations.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-elevations.png">
+  <img src="/static/img/regional-connector/broadway-elevations.png" alt="Historic Broadway">
+</picture>
+
+<p>The station at 2nd Street and Broadway sits at the heart of the city’s <a href="https://en.wikipedia.org/wiki/Civic_Center,_Los_Angeles">Civic Center</a>, next to City Hall and the Los Angeles Police Department’s headquarters.</p>
+
+<p><a href="https://www.otis.edu/faculty/andrea-bowers">Andrea Bowers</a>, an instructor at the Otis College of Art and Design, prepared a potent message for any politicos who take the train.</p>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-bowers-1.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-bowers-1.png">
+  <img src="/static/img/regional-connector/broadway-bowers-1.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-bowers-2.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-bowers-2.png">
+  <img src="/static/img/regional-connector/broadway-bowers-2.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-bowers-3.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-bowers-3.png">
+  <img src="/static/img/regional-connector/broadway-bowers-3.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-bowers-4.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-bowers-4.png">
+  <img style="margin-bottom: 15px;" src="/static/img/regional-connector/broadway-bowers-4.png" alt="Historic Broadway">
+</picture>
+
+<p>The photography of Clarence Williams will also be featured. Black and white photographs of people displaced by Hurricane Katrina are interspersed with images of immigrants and placed alongside a stark work of poetry.</p>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-willims-1a.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-willims-1a.png">
+  <img src="/static/img/regional-connector/broadway-willims-1a.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-willims-1b.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-willims-1b.png">
+  <img src="/static/img/regional-connector/broadway-willims-1b.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-willims-1c.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-willims-1c.png">
+  <img src="/static/img/regional-connector/broadway-willims-1c.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-willims-2a.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-willims-2a.png">
+  <img src="/static/img/regional-connector/broadway-willims-2a.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-willims-2b.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-willims-2b.png">
+  <img src="/static/img/regional-connector/broadway-willims-2b.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-willims-2c.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-willims-2c.png">
+  <img src="/static/img/regional-connector/broadway-willims-2c.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-willims-3a.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-willims-3a.png">
+  <img src="/static/img/regional-connector/broadway-willims-3a.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-willims-3b.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-willims-3b.png">
+  <img src="/static/img/regional-connector/broadway-willims-3b.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-willims-3c.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-willims-3c.png">
+  <img src="/static/img/regional-connector/broadway-willims-3c.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-willims-4a.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-willims-4a.png">
+  <img src="/static/img/regional-connector/broadway-willims-4a.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-willims-4b.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-willims-4b.png">
+  <img src="/static/img/regional-connector/broadway-willims-4b.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-willims-5a.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-willims-5a.png">
+  <img src="/static/img/regional-connector/broadway-willims-5a.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-willims-5b.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-willims-5b.png">
+  <img src="/static/img/regional-connector/broadway-willims-5b.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-willims-5c.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-willims-5c.png">
+  <img src="/static/img/regional-connector/broadway-willims-5c.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-willims-6a.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-willims-6a.png">
+  <img src="/static/img/regional-connector/broadway-willims-6a.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-willims-6b.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-willims-6b.png">
+  <img src="/static/img/regional-connector/broadway-willims-6b.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-willims-6c.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-willims-6c.png">
+  <img src="/static/img/regional-connector/broadway-willims-6c.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-willims-7a.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-willims-7a.png">
+  <img src="/static/img/regional-connector/broadway-willims-7a.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-willims-7b.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-willims-7b.png">
+  <img src="/static/img/regional-connector/broadway-willims-7b.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-willims-7c.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-willims-7c.png">
+  <img src="/static/img/regional-connector/broadway-willims-7c.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-willims-8a.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-willims-8a.png">
+  <img src="/static/img/regional-connector/broadway-willims-8a.png" alt="Historic Broadway">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/broadway-willims-8b.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/broadway-willims-8b.png">
+  <img src="/static/img/regional-connector/broadway-willims-8b.png" alt="Historic Broadway">
+</picture>
+
+<h2>Grand Av Arts/Bunker Hill</h2>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/grand-logos.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/grand-logos.png">
+  <img src="/static/img/regional-connector/grand-logos.png" alt="Grand Ave Arts/Bunker Hill">
+</picture>
+
+<p>This stop at 2nd Place and Hope Street is at the city’s epicenter for the fine arts, next to the opera, philharmonic, several theaters and  numerous arts museums.</p>
+
+<p>The underground train platform will be decorated by two <a href="https://mungothomson.com/">Mungo Thomson</a> images, which were created by inverting photographs of the <a href="Andromeda (M31) galaxy">Andromeda galaxy</a> taken by the <a href="https://en.wikipedia.org/wiki/Hubble_Space_Telescope">Hubble Space Telescope</a>.</p>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/grand-thomson-blue.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/grand-thomson-blue.png">
+  <img src="/static/img/regional-connector/grand-thomson-blue.png" alt="Grand Ave Arts/Bunker Hill">
+</picture>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/grand-thomson-white.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/grand-thomson-white.png">
+  <img style="margin-bottom: 15px;" src="/static/img/regional-connector/grand-thomson-white.png" alt="Grand Ave Arts/Bunker Hill">
+</picture>
+
+<p>The stop will be the lone portal in the L.A. system accessible only via elevator. Also on display will be this lengthy mural by <a href="https://www.pearlchsiung.com/">Pearl C. Hsiung</a>. It's unclear to me where it will appear, but I like to imagine it will engage elevator riders as they descend down from the street.
+</p>
+
+<picture>
+  <source type="image/webp" srcset="/static/img/regional-connector/grand-hsiung.webp">
+  <source type="image/png" srcset="/static/img/regional-connector/grand-hsiung-min.png">
+  <img src="/static/img/regional-connector/grand-hsiung-min.png" alt="Grand Ave Arts/Bunker Hill">
+</picture>

--- a/coltrane/content/posts/2024-10-30--data-journalism-delivery.md
+++ b/coltrane/content/posts/2024-10-30--data-journalism-delivery.md
@@ -1,0 +1,19 @@
+---
+title: Introducing a new delivery system for data journalism
+slug: data-journalism-delivery
+published_at: '2024-10-30T12:00:00-07:00'
+repr_image: https://palewi.re/static/img/reuters-dashboard.gif
+---
+<img style="margin-bottom:15px;" src="https://palewi.re/static/img/reuters-dashboard.gif" alt="The Magnificent Seven Monitor">
+
+<p>Data dashboards are now one of the standard storytelling templates at <a href="http://reuters.com">reuters.com</a>, joining the familiar journalistic arsenal of text articles, photo galleries and blogs. Going forward, publishing a live-updating collection of charts, maps and tables will require nothing more than a few points and clicks.</p>
+
+<p>First through the gate is "<a href="https://www.reuters.com/data/magnificent-seven-monitor-2024-10-30/">The Magnificent Seven Monitor</a>,"  which tracks the ongoing performance of the heavyweight U.S. technology stocks that dominate the market.</p>
+
+<p>Anyone who has toiled in the vineyards of news knows it's hard to integrate custom designs like this into the rigid, cookie-cutter "content-management systems" that power most media sites. As a result, many data projects and long-form investigations are published off-the-reservation using shadow technology.</p>
+
+<p>While there are advantages to working outside your core platform, there are downsides, too. Every new publishing tool must tackle how to integrate with your site design, your homepage, your recirculation system, your ads, your analytics, your paywall, and the workflow of your colleagues. That's a lot.</p>
+
+<p>At Reuters, we aim to bridge the divide once and for all. That requires treating the innovative story forms pioneered over the last twenty years—multimedia stories, interactive visuals, live-updating data—like the other widgets we manufacture in our "CMS."</p>
+
+<p>Today's release is a modest first step in that direction. Now that we have the technology issues sorted out, we'll do more and better in the months ahead.</p>

--- a/coltrane/content/posts/2024-11-19--reuters-cuny-internship-2025.md
+++ b/coltrane/content/posts/2024-11-19--reuters-cuny-internship-2025.md
@@ -1,0 +1,46 @@
+---
+title: CUNY students, we want you
+slug: reuters-cuny-internship-2025
+published_at: '2024-11-19T06:00:00-08:00'
+repr_image: https://palewi.re/static/img/reuters-building.jpg
+---
+<p>
+Applications are <a href="https://forms.office.com/r/7z96wmkzab">now being accepted</a> for the CUNY News Applications Internship, which will welcome a student journalist to the Reuters newsroom at 3 Times Square in the summer of 2025.
+</p>
+
+<p>
+The 12-week paid position is open to any current student at the City University of New York’s <a href="https://www.journalism.cuny.edu/">Craig Newmark Graduate School of Journalism</a>. 
+</p>
+
+<p>
+The apprentice reporter will join the News Applications Desk, an editorial team focused on creating dashboards, databases and automated systems that benefit clients, inform readers, empower reporters and serve the public interest. The initiative aims to publish timely, trustworthy resources that lead to a greater understanding of the world’s most pressing issues.
+</p>
+
+<p>
+The intern will develop software that gathers, refines, enriches and publishes data for a professional audience. That could include the creation of:
+</p>
+
+<ul>
+
+<li>A collection of charts, maps and tables that presents a comprehensive, high-level, real-time view of a single topic.</li>
+
+<li>A tailored website that allows readers to explore a newsworthy database.</li>
+
+<li>A data pipeline that monitors data feeds, discovers tips and drafts templated content.</li>
+</ul>
+
+<p>
+They will find opportunities to partner with Reuters editors and reporters worldwide. That will include working with members of the newsroom’s other data journalism groups, such as its award-winning analysis team and its globe-spanning graphics desk.
+</p>
+
+<p>
+This work requires blending skills from journalism, computer programming and product design. Ideal participants bring interest in more than one of those areas. The strongest applicants will be able to demonstrate experience creating data-driven applications for the general public.
+</p>
+
+<p>
+The partnership between Reuters and CUNY, America’s largest urban public university, began in the summer of 2024. The first student to fill the position developed a templated chart that hits the wire seconds after each month’s US jobs report, wrote a web scraper to fuel a plot of the partisan split in consumer sentiment surveys and drafted the design for our automated hurricane maps.
+</p>
+
+<p>
+Next year’s intern will start work on June 16 and report to me. Applications, which can be submitted <a href="https://forms.office.com/r/7z96wmkzab">via this form</a>, are due by December 15.
+</p>

--- a/coltrane/content/posts/2025-03-11--new-at-nicar25.md
+++ b/coltrane/content/posts/2025-03-11--new-at-nicar25.md
@@ -1,0 +1,18 @@
+---
+title: New at NICAR25
+slug: new-at-nicar25
+published_at: '2025-03-11T00:00:00-07:00'
+---
+<p>Over the weekend, I debuted three new hands-on classes at the <a href="https://www.ire.org/training/conferences/nicar-2025/">latest edition of NICAR</a>, the annual data journalism conference organized by <a href="https://www.ire.org/">Investigative Reporters and Editors</a>.</p>
+
+<p>Today, I'm happy to release all three as online textbooks where anyone can work through the material for free. Loaded up with screenshots, code snippets and hyperlinks, the documentation sites include everything we covered in person.</p>
+
+<img src="https://palewi.re/static/img/new-at-nicar25.gif" alt="Screenshots of our new NICAR classes">
+
+<p>🏷️ <a href="https://palewi.re/docs/first-llm-classifier/"><strong>First LLM Classifier</strong></a>, developed with <a href="https://thescoop.org/about/">Derek Willis</a>, will teach you how journalists can use large-language models to organize and analyze massive datasets. Machine learning has never been easier.</p>
+
+<p>❓ <b><a href="https://palewi.re/docs/first-athena-query/">First Athena Query</a></b>, developed with <a href="https://www.linkedin.com/in/katalo/">Katlyn Alo</a>, will teach you how to analyze millions of records in seconds with Amazon Web Services (AWS) and SQL. Today's release <a href="https://palewi.re/docs/first-athena-query/python.html">includes</a> a set of flexible Python functions for automation we developed at Reuters, which are being made public for the first time.</p>
+
+<p>🦾 <b><a href="https://palewi.re/docs/go-big-with-github-actions/">Go big with GitHub Actions</a></b>, developed with <a href="https://irisslee.com/">Iris Lee</a> and <a href="https://dana.computer/">Dana Chiueh</a>, will teach you how to scale up your data pipelines using GitHub’s powerful Actions framework. It demonstrates advanced automation patterns that will empower you to collect, process and publish gigantic datasets with ease.</p>
+
+<p>I hope these materials are helpful to someone out there. The IRE community has given so much to me in my career that it's an honor to give something, however modest, back.</p>

--- a/coltrane/content/posts/2025-05-21--ire-podcast-transcript.md
+++ b/coltrane/content/posts/2025-05-21--ire-podcast-transcript.md
@@ -1,0 +1,120 @@
+---
+title: IRE and me
+slug: ire-podcast-transcript
+published_at: '2025-05-21T09:30:00-07:00'
+---
+<iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/2099172090&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe><div style="font-size: 10px; color: #cccccc;line-break: anywhere;word-break: normal;overflow: hidden;white-space: nowrap;text-overflow: ellipsis; font-family: Interstate,Lucida Grande,Lucida Sans Unicode,Lucida Sans,Garuda,Verdana,Tahoma,sans-serif;font-weight: 100;"><a href="https://soundcloud.com/ire-nicar" title="IRE Radio" target="_blank" style="color: #cccccc; text-decoration: none;">IRE Radio</a> · <a href="https://soundcloud.com/ire-nicar/a-conversation-with-ben-welsh" title="A conversation with Ben Welsh" target="_blank" style="color: #cccccc; text-decoration: none;">A conversation with Ben Welsh</a></div>
+
+<p style="margin-top: 40px;">I'm the guest this week on <a href="https://soundcloud.com/ire-nicar/a-conversation-with-ben-welsh">the podcast</a> published by <a href="https://www.ire.org/">Investigative Reporters and Editors</a>, the non-profit organization where I started out.</p>
+
+<p>Tune in to hear <a href="https://www.linkedin.com/in/nakylah-carter-24204519a">Nakylah Carter</a> ask me about my accidental induction into the press corps, my first FOIA, the enduring appeal of Good Internet, the industrialization of data journalism, the economic advantages of being a nerd, homework as soulcraft, my reluctant respect for R and the transcendent moments when statistics and shoe leather coalesce.</p>
+
+<p>Below you can find a transcript of our conversation, which I have lightly edited for clarity and concision.</p>
+
+<p><b>When did you know journalism was your thing? And then how did you nurture it to be the person you are today?</b></p>
+
+<p>Oh man, we can go way back with this. I'm getting old.</p>
+
+<p>I never set out to be a journalist. It wasn't something I did much in high school or a career goal I went into college with. I was an undergraduate at DePaul University in Chicago, Illinois, after growing up in Eastern Iowa, and I stumbled into journalism accidentally.</p>
+
+<p>I had a job answering phones in the communication department as part of one of these work-study programs, to make a little money while I was in school. And in that job, I was entrusted with some very important responsibilities. One of them was pinning up flyers on the bulletin boards around campus about upcoming events the department was running.</p>
+
+<p>So, I was often the first person to see the notice of new things happening. One day, I was pinning up a flyer and noticed that it was an advertisement for an internship with two journalists taking up residency at the university, Carol Marin and Don Moseley. They were looking for a student to join them.</p>
+
+<p>While I was pinning it up, I thought, hey, that sounds cool. It sounds a lot cooler than this job pinning up flyers on bulletin boards. And because I was the first person to see the flyer, I suspect I was the first person to apply.</p>
+
+<p>I never asked how many other people applied, but I ended up getting that internship despite being ridiculously unqualified and began my journalism career as the grunt assistant to this producer and correspondent team, who were doing weekly television pieces and newspaper columns and some long-form documentaries. So I got into journalism by accident and quickly saw it was a lot of fun. It was a great way to engage with the world and learn about it. It was also a challenge and, maybe, something I could do.</p>
+
+<p><b>I think that's amazing because I think it's important to understand that everybody's path into journalism is completely different. Can you talk about how you got into the data journalism realm?</b></p>
+
+<p>Data and the work I do today quickly found me in a public records request.</p>
+
+<p>We got a tip that a local suburb of the city had been rigging legal contracts to rack up money for a local alderman and his allies. To check it out, we filed a public records request asking for a list of every legal contract or fee paid out by the city to this law firm. It was my first FOIA ever.</p>
+
+<p>After a few weeks or months, I can't remember exactly, in the mail came a big, long printout, a computer printout. This was a 1990s or '80s style one where it's an accordion sheet of paper, dozens of pages connected by the little tear strips on the outside. It was all the legal fees, but they were spread out in this dot matrix style across a lot of paper.</p>
+
+<p>We initially had the question, how the heck are we going to make sense of this? I don't remember where I got the idea, but I thought, hey, what if I type it all into a spreadsheet?</p>
+
+<p>So I sat down and did it. It took me a day or two to go through it all and double and triple-check it. But we arrived at a pretty big number, a big enough number to justify the story being on the news. And we got our little scoop, our investigative piece, out of the tip, the FOIA, and the data entry.</p>
+
+<p>With that, I was hooked. One, I saw that data was a shortcut to getting to work on really cool stories, more than just run-of-the-mill stuff, things I found exciting. And as the guy who could sit down and figure out the tech, it might be a niche for me or a place for me to fill that gap and help make those stories happen.</p>
+
+<p>Those two things got me going. I wanted to go further down that road. So I went to the University of Missouri and was a graduate assistant at IRE/NICAR, where I got to focus on not just faking it, but actually learning these skills, learning how to code, learning what real analysis was, getting a lot more practice. That set me off onto the path I still am on today, now more than 20 years later.</p>
+
+<p><b>You grow so much as a data journalist by practical experience, but also by talking to peers and collaboration and learning other people's tips and tricks. So, I have to talk about your website, <a href="https://palewi.re/">palewi.re</a>, because I was like, this is amazing. I wish I'd seen this last year.</b></p>
+
+<p><b>What made you want to compile all that information? Because it's not something that you're required to do, but it's amazingly helpful.</b></p>
+
+<p>It's nothing that happened overnight. It's the accumulation of years and years of chipping stuff together.</p>
+
+<p>For me, the annual IRE/NICAR conference is an opportunity to challenge myself and for all of us in our community to come together to say, what do we want to teach each other? What's important? What have we learned in the last year that's worth passing on to other people, that we're excited about, or want to share?</p>
+
+<p>I look at every year's conference as a moment of opportunity and try to drum up new stuff. I've been doing it long enough that I have a playbook for it, a little routine, and I've just been adding incrementally more and more lessons that I've put together, with other people who help me, by the way, of course. And it's become, over time, <a href="https://palewi.re/docs/">this collection</a>.</p>
+
+<p><b>Do you have any favorites or any talks that you have that you look forward to? Because I know some of them you repeat and some of them you tweak. Is there ever one where you wish something like this existed when you first started?</b></p>
+
+<p>I don't know if I have a favorite child, so to speak. To me, there are a lot of great things about it.</p>
+
+<p>I love coming together with peers and people I respect to help create the classes and that formative experience of us collaborating to take an idea or a technique that hasn't been fully fleshed out and trying to put it on paper and get it across. That creative process is really stimulating and always rewarding to me, and that keeps me doing it.</p>
+
+<p>Then the conference itself is a great experience, but, maybe most of all, is the thing that comes out of putting it on the web and having a little bit of faith in the world. I am often stunned to hear from people on the other side of the planet, who I've never met and never will, who will reach out and say they learned this or that based on a resource we put on the web, not knowing what would happen with it. There's something magical to that, a hit I keep chasing or that I just love.</p>
+
+<p>It reminds me of my own formative experiences on the internet as a teenager in the '90s. I'm old enough to remember life before the web. As a kid in rural Iowa, its arrival was a big deal. The internet was my gateway to the world and such an exciting, stimulating place to learn and connect. To still have experiences like that 30 years later with people in Ukraine or Brazil or wherever else is the magic of technology that I find so rewarding.</p>
+
+<p><b>You went from not knowing that journalism was something you were interested in to creating a new news desk. How did you know that that is something that the newsroom needed, and how do you operate in that position?</b></p>
+
+<p>Without sounding too grandiose or self-assured, I think we are entering a new era of data journalism in the commercial media, which is, I think, one of industrialization and specialization.</p>
+
+<p>When I started out at the Los Angeles Times in 2007, the whole idea of putting data on the internet on a newspaper website was still a pretty new one. We weren't the first to do it, for sure, but in our context it was definitely new.</p>
+
+<p>I think a lot of what was going on then, even at the leading news organizations, was experimental. You had small teams of people goofing around, trying to make things happen on the web, often totally separate from their mainline newsrooms.</p>
+
+<p>It's good to remember that the 2008 election was the first one where you had widespread live election results on newspaper and news organization websites, when Obama was first elected. There were examples of that before, but the really kind of first widespread publication of it was that time.</p>
+
+<p>It was an experiment that was then wildly successful. Since then, there have been many other examples running up to coronavirus trackers. You can go down the list of all these different ways of taking data directly to the audience in the form of dashboards and databases and visualizations that aren't traditional stories.</p>
+
+<p>That has gone from an experiment to a widget or a product that we want to manufacture inside the metaphorical factory of the newsroom. It's my view that as we go from experiment to mass production, we need to institutionalize, specialize, and ramp up how we're organized to create these widgets. In my view, that means making a news desk, which is its own little assembly line in the factory, that focuses not on battleship investigative reporting projects, not on one-off graphics to accompany traditional text stories, but instead on these data products, whatever you want to call them, that are incredibly popular with audiences and could also be capital J journalism.</p>
+
+<p>This news applications desk is our attempt to name something that does that. I don't know if I love the name. If you have a better name, I'd love to hear it. But that's what we mean. That's what we're trying to do here at Reuters. We're trying to create a group of people who focus on making that type of thing.</p>
+
+<p><b>We're moving towards a time where people almost expect data to be in the story. It's become way more normal. So I think it's amazing that you guys are thinking about this.</b></p>
+
+<p>We can't forget that. Data journalism grew out of the investigative reporting tradition, or at least a large part of it did — there are many streams and strands — but the IRE/NICAR tradition is one that stems back to investigative reporting, which is what I was trained in and what I love and respect.</p>
+
+<p>I've done a lot of it in my career. But the justification for that type of work, for the investment, for the dollars to be spent to fund it, is typically one that's based on prestige and public service, which are two of the very high callings of our profession. But in a time of decreasing resources and brutal disruption to the economic model that supports journalism, it can be difficult to justify jobs and investment in data journalism if it's strictly seen as a prestige project.</p>
+
+<p>So that's bad news, maybe. But the good news is, and I think we often undersell this good news, is that these data products I'm talking about, your live election result or your coronavirus tracker, yes, these are public service and, yes, they ought to be seen as prestigious. They've won some of the highest awards, but they are also popular.</p>
+
+<p>Last year at <a href="https://reuters.com/">reuters.com</a>, the most popular thing all year was <a href="https://www.reuters.com/graphics/USA-ELECTION/RESULTS/zjpqnemxwvx/">the live election results</a> done by our team in London, led by <a href="https://www.reuters.com/authors/jon-mcclure/">Jon McClure</a>. The most popular thing in the history of the Los Angeles Times, where I used to work, the most read piece of journalism in the one hundred and whatever year history of the L.A. Times, was its coronavirus tracker. And I suspect the same is true for The New York Times and many other news organizations. We shouldn't sell ourselves short. We're making things people want.</p>
+
+<p><b>A lot of people say journalists and math don't go together. A lot of journalists aren't set up naturally to do data. What is your advice for someone who wants to get into that realm? It's a hot commodity right now.</b></p>
+
+<p>That's your advantage. If other people are avoiding it and you're willing to take it on, that's going to give you the edge. That's going to give you the front foot.</p>
+
+<p>I think you should not listen to people discouraging you from going down this road if it's where you want to go. Because we know it's where things are headed and it's valuable. So, don't be afraid to have the confidence to do it. Surround yourself with people who agree with you, and find mentors and role models who'll help you move down that path. It's a lane that's wide open.</p>
+
+<p>I don't know if I can rewind. What would I tell younger me? Study harder in high school? I don't have any regrets or any big things like that. There's the reassurance I think we all need when we're young, that I needed like everyone else, which is that if you work hard, it will pay off.</p>
+
+<p>I've seen that in my own life, and I've seen it in many others. I encourage people to, I almost said, lean in. I won't say lean in. I'll say work hard and be a good person, and it'll work out. So that's what I would tell myself because I was a nervous young country kid in the city.</p>
+
+<p>As far as the work, you have got to have high standards for yourself, and you can't cut corners. You have got to do the work.  I think that means coming in every day like you have something to prove, not being afraid of challenges, and realizing that it's by pushing through them that you're going to do something you're proud of. Don't be lazy. It's the same message, maybe, but what I believe. I think it's all about progress and push and not giving up.</p>
+
+<p><b>So I have to ask some things. Do you prefer Python or R?</b></p>
+
+<p>I'm definitely a Python person, but I respect R and, really, it's about the results. So, I think there's a lot of great and talented people who work in R, but Python's obviously superior.</p>
+
+<p><b>I agree. I wholeheartedly agree. And then I wanted to ask, what is your favorite data journalism memory? A story, or maybe an interview, or something that happened where you thought this is the career for me.</b></p>
+
+<p>There's that first story I told you earlier, where the light bulb went on that this could be something for me.</p>
+
+<p>The most powerful moments are often, and maybe it does go back to investigative pieces, when statistics and data lead me to someone's doorstep and help both me, the journalist who's trying to figure out the story, and more important in the moment, and maybe in the cosmic sense, the person who lived the story, better understand what the heck happened to them in life, particularly if it was something bad.</p>
+
+<p>I did a series of stories about the local 911 system in Los Angeles, where we uncovered a lot of systemic flaws in how emergency care is delivered, in how the fire department is run. Some of the most powerful memories I have are where the statistics would tell us there's this kink in the system, there's this inefficiency, there's this problem, and it could be having bad effects out there in the world.</p>
+
+<p>Then we followed the data, individual calls, out to doors and then we knocked to see what really happened in this case or that case where the data says something maybe went wrong. What we found often is, yeah, it did go wrong.</p>
+
+<p>So, there's this way in which you discover a story based on a spreadsheet. But then also there's this powerful moment of connection with the person on the other end of the journalistic exchange, where you help them understand why something bad happened in their life and help them be part of an effort to describe and share that with their community so that maybe it can be fixed and it doesn't happen to someone else.</p>
+
+<p>To me, those moments where statistics and shoe leather connect with the subject are the magic that data makes possible. Because when you don't just go off your own bias or instincts, when you let the math and science lead the way, you can have these powerful moments of discovery. They're not the same as Albert Einstein and E equals MC squared or whatever, but they are powerful.</p>
+
+<p>I struggle to describe it, and it would be almost impossible to give you every detail of what that feels like without writing a novel. But those moments of discovery and connection, where statistics and shoe leather meet, are intense.</p>

--- a/coltrane/content_loaders.py
+++ b/coltrane/content_loaders.py
@@ -1,5 +1,5 @@
 """
-YAML content loaders for bio-page data, slogans, and bots.
+YAML and Markdown content loaders for the site's published content.
 
 Each loader reads a YAML file, validates the structure and field types, and
 returns a list of typed dataclass instances ready for use in views.
@@ -49,8 +49,10 @@ from __future__ import annotations
 
 import datetime
 import random
+import re
 from dataclasses import dataclass
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 import yaml
 
@@ -58,6 +60,8 @@ CONTENT_PATH = Path(__file__).resolve().parent / "content"
 
 CLIP_TYPES = frozenset({"app", "lesson-plan", "story", "software"})
 DOC_TYPES = frozenset({"lesson-plan", "software"})
+LOS_ANGELES = ZoneInfo("America/Los_Angeles")
+POST_FRONT_MATTER_FIELDS = frozenset({"title", "slug", "published_at", "repr_image", "wordpress_id"})
 
 
 # ---------------------------------------------------------------------------
@@ -110,6 +114,24 @@ class Bot:
     twitter_url: str = ""
 
 
+@dataclass(frozen=True)
+class MarkdownPost:
+    """A public blog post loaded from validated Markdown content."""
+
+    title: str
+    slug: str
+    published_at: datetime.datetime
+    body_markup: str
+    repr_image: str = ""
+    wordpress_id: int | None = None
+
+    def get_absolute_url(self) -> str:
+        """Return the legacy publication-date permalink."""
+        return f"/posts/{self.published_at:%Y}/{self.published_at:%m}/{self.published_at:%d}/{self.slug}/"
+
+    url = property(get_absolute_url)
+
+
 # ---------------------------------------------------------------------------
 # Validation helpers
 # ---------------------------------------------------------------------------
@@ -150,6 +172,52 @@ def _optional_str(record: dict, field_name: str, path: str) -> str:
             f"{path}: record {record!r} field '{field_name}' must be a string, got {type(value).__name__}"
         )
     return value
+
+
+def _require_los_angeles_datetime(record: dict, field_name: str, path: str) -> datetime.datetime:
+    """Return an ISO datetime expressed in the Los Angeles timezone."""
+    value = _require_str(record, field_name, path)
+    try:
+        parsed = datetime.datetime.fromisoformat(value)
+    except ValueError as error:
+        raise ContentError(f"{path}: field '{field_name}' must be an ISO 8601 datetime") from error
+    if parsed.tzinfo is None:
+        raise ContentError(f"{path}: field '{field_name}' must include a timezone offset")
+    los_angeles_time = parsed.astimezone(LOS_ANGELES)
+    if (
+        parsed.replace(tzinfo=None) != los_angeles_time.replace(tzinfo=None)
+        or parsed.utcoffset() != los_angeles_time.utcoffset()
+    ):
+        raise ContentError(f"{path}: field '{field_name}' must be expressed in America/Los_Angeles time")
+    return los_angeles_time
+
+
+def _require_slug(record: dict, path: str) -> str:
+    """Return a slug accepted by the existing URL pattern."""
+    slug = _require_str(record, "slug", path)
+    if re.fullmatch(r"[-\w]+", slug) is None:
+        raise ContentError(f"{path}: field 'slug' must contain only letters, numbers, underscores, and hyphens")
+    return slug
+
+
+def _optional_wordpress_id(record: dict, path: str) -> int | None:
+    """Return an optional positive legacy WordPress ID."""
+    value = record.get("wordpress_id")
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ContentError(f"{path}: field 'wordpress_id' must be a positive integer")
+    return value
+
+
+def _split_front_matter(content: str, path: str) -> tuple[str, str]:
+    """Split YAML front matter from a Markdown body without changing its HTML."""
+    if not content.startswith("---\n"):
+        raise ContentError(f"{path}: Markdown posts must begin with YAML front matter")
+    end_marker = content.find("\n---\n", len("---\n"))
+    if end_marker == -1:
+        raise ContentError(f"{path}: Markdown post front matter is not closed")
+    return content[len("---\n") : end_marker], content[end_marker + len("\n---\n") :]
 
 
 # ---------------------------------------------------------------------------
@@ -342,3 +410,54 @@ def load_bots(path: Path | None = None) -> list[Bot]:
             seen_twitter.add(twitter_url)
         bots.append(Bot(title=title, mastodon_url=mastodon_url, twitter_url=twitter_url))
     return bots
+
+
+def load_posts(path: Path | None = None) -> list[MarkdownPost]:
+    """Load validated public Markdown posts, newest publication first."""
+    if path is None:
+        path = CONTENT_PATH / "posts"
+    if not path.is_dir():
+        raise ContentError(f"{path}: post content directory does not exist")
+
+    posts: list[MarkdownPost] = []
+    seen_slugs: set[str] = set()
+    seen_url_keys: set[tuple[datetime.date, str]] = set()
+    for post_path in sorted(path.glob("*.md")):
+        label = str(post_path)
+        with post_path.open(encoding="utf-8", newline="") as post_file:
+            front_matter, body_markup = _split_front_matter(post_file.read(), label)
+        try:
+            record = yaml.safe_load(front_matter)
+        except yaml.YAMLError as error:
+            raise ContentError(f"{label}: invalid YAML front matter") from error
+        if not isinstance(record, dict):
+            raise ContentError(f"{label}: front matter must be a mapping")
+        unexpected_fields = set(record) - POST_FRONT_MATTER_FIELDS
+        if unexpected_fields:
+            raise ContentError(f"{label}: unsupported front matter fields {sorted(unexpected_fields)}")
+
+        title = _require_str(record, "title", label)
+        slug = _require_slug(record, label)
+        published_at = _require_los_angeles_datetime(record, "published_at", label)
+        repr_image = _optional_str(record, "repr_image", label)
+        wordpress_id = _optional_wordpress_id(record, label)
+
+        if slug in seen_slugs:
+            raise ContentError(f"{label}: duplicate post slug '{slug}'")
+        seen_slugs.add(slug)
+        url_key = (published_at.date(), slug)
+        if url_key in seen_url_keys:
+            raise ContentError(f"{label}: duplicate post publication-date/slug key '{url_key}'")
+        seen_url_keys.add(url_key)
+        posts.append(
+            MarkdownPost(
+                title=title,
+                slug=slug,
+                published_at=published_at,
+                body_markup=body_markup,
+                repr_image=repr_image,
+                wordpress_id=wordpress_id,
+            )
+        )
+    posts.sort(key=lambda post: post.published_at, reverse=True)
+    return posts

--- a/scripts/export_posts.py
+++ b/scripts/export_posts.py
@@ -1,0 +1,325 @@
+r"""Export database posts to a private archive and public Markdown files.
+
+This script accepts a CSV created with PostgreSQL's ``\copy`` command. It
+never connects to production or writes to the public database. The archive
+directory must be outside this repository because it contains drafts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import re
+import shutil
+import tempfile
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import yaml
+
+LOS_ANGELES = ZoneInfo("America/Los_Angeles")
+LIVE_STATUS = 1
+EXPECTED_COUNTS = {1: 72, 2: 94, 3: 0}
+LEGACY_PRE_PATTERN = re.compile(r"<pre\s+[^>]*\blang=", re.IGNORECASE)
+PUBLIC_REPOSITORY_PATH = Path(__file__).resolve().parent.parent
+
+
+@dataclass(frozen=True)
+class ExportedPost:
+    """One post exported from the production database."""
+
+    id: int
+    wordpress_id: int | None
+    title: str
+    slug: str
+    body_markup: str
+    body_html: str | None
+    pub_date: datetime
+    author_id: int
+    status: int
+    repr_image: str
+
+    @property
+    def published_at(self) -> datetime:
+        """Return the original publication moment in Los Angeles time."""
+        return self.pub_date.astimezone(LOS_ANGELES)
+
+    @property
+    def permalink(self) -> str:
+        """Return the database-backed permalink that must remain stable."""
+        return f"/posts/{self.published_at:%Y/%m/%d}/{self.slug}/"
+
+
+def sha256_bytes(value: bytes) -> str:
+    """Return a stable SHA-256 digest."""
+    return hashlib.sha256(value).hexdigest()
+
+
+def read_optional_int(value: str) -> int | None:
+    """Read an optional integer from PostgreSQL CSV output."""
+    return int(value) if value else None
+
+
+def load_posts(csv_path: Path) -> list[ExportedPost]:
+    """Parse a PostgreSQL CSV export and validate its expected columns."""
+    required_columns = {
+        "id",
+        "wordpress_id",
+        "title",
+        "slug",
+        "body_markup",
+        "body_html",
+        "pub_date",
+        "author_id",
+        "status",
+        "repr_image",
+    }
+    with csv_path.open(encoding="utf-8", newline="") as csv_file:
+        reader = csv.DictReader(csv_file)
+        if reader.fieldnames is None or set(reader.fieldnames) != required_columns:
+            raise ValueError(f"{csv_path}: unexpected CSV columns {reader.fieldnames!r}")
+        posts = [
+            ExportedPost(
+                id=int(row["id"]),
+                wordpress_id=read_optional_int(row["wordpress_id"]),
+                title=row["title"],
+                slug=row["slug"],
+                body_markup=row["body_markup"],
+                body_html=row["body_html"] or None,
+                pub_date=datetime.fromisoformat(row["pub_date"]),
+                author_id=int(row["author_id"]),
+                status=int(row["status"]),
+                repr_image=row["repr_image"],
+            )
+            for row in reader
+        ]
+    if any(post.pub_date.tzinfo is None for post in posts):
+        raise ValueError(f"{csv_path}: every publication datetime must include a timezone")
+    return posts
+
+
+def validate_posts(posts: list[ExportedPost]) -> Counter[int]:
+    """Validate production counts and the unique public URL keys."""
+    counts = Counter(post.status for post in posts)
+    actual_counts = {status: counts[status] for status in EXPECTED_COUNTS}
+    if (
+        len(posts) != sum(EXPECTED_COUNTS.values())
+        or actual_counts != EXPECTED_COUNTS
+        or set(counts) - set(EXPECTED_COUNTS)
+    ):
+        raise ValueError(f"unexpected status counts: total={len(posts)}, statuses={dict(counts)}")
+    live_posts = [post for post in posts if post.status == LIVE_STATUS]
+    keys = [(post.published_at.date(), post.slug) for post in live_posts]
+    if len(keys) != len(set(keys)):
+        raise ValueError("live posts have duplicate publication-date/slug keys")
+    slugs = [post.slug for post in live_posts]
+    if len(slugs) != len(set(slugs)):
+        raise ValueError("live posts have duplicate slugs")
+    return counts
+
+
+def post_record(post: ExportedPost) -> dict[str, Any]:
+    """Serialize an archived post without changing its source values."""
+    return {
+        "id": post.id,
+        "wordpress_id": post.wordpress_id,
+        "title": post.title,
+        "slug": post.slug,
+        "body_markup": post.body_markup,
+        "body_html": post.body_html,
+        "pub_date": post.pub_date.isoformat(),
+        "author_id": post.author_id,
+        "status": post.status,
+        "repr_image": post.repr_image,
+    }
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    """Write a deterministic JSON document."""
+    path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def path_is_within(path: Path, parent: Path) -> bool:
+    """Return whether a resolved path is the parent or one of its children."""
+    return path == parent or parent in path.parents
+
+
+def validate_export_paths(archive_path: Path, content_path: Path) -> tuple[Path, Path]:
+    """Reject destinations that could place draft data in the public checkout."""
+    resolved_archive_path = archive_path.resolve()
+    resolved_content_path = content_path.resolve()
+    if path_is_within(resolved_archive_path, PUBLIC_REPOSITORY_PATH):
+        raise ValueError("archive path must be outside the public repository")
+    if path_is_within(resolved_archive_path, resolved_content_path) or path_is_within(
+        resolved_content_path, resolved_archive_path
+    ):
+        raise ValueError("archive path must not overlap the public content path")
+    return resolved_archive_path, resolved_content_path
+
+
+def write_archive_files(posts: list[ExportedPost], counts: Counter[int], archive_path: Path, source_csv: Path) -> None:
+    """Write individual archive records and a checksum manifest to a staging path."""
+    records_path = archive_path / "posts"
+    if records_path.exists():
+        shutil.rmtree(records_path)
+    records_path.mkdir(parents=True)
+    shutil.copy2(source_csv, archive_path / "posts.csv")
+
+    checksum_lines: list[str] = []
+    for post in posts:
+        relative_path = Path("posts") / f"{post.id}.json"
+        record_path = archive_path / relative_path
+        write_json(record_path, post_record(post))
+        checksum_lines.append(f"{sha256_bytes(record_path.read_bytes())}  {relative_path.as_posix()}")
+
+    checksum_path = archive_path / "checksums.sha256"
+    checksum_path.write_text("\n".join(checksum_lines) + "\n", encoding="utf-8")
+    manifest = {
+        "schema_version": 1,
+        "source": "palewire production PostgreSQL",
+        "source_csv_sha256": sha256_bytes(source_csv.read_bytes()),
+        "record_count": len(posts),
+        "status_counts": {str(status): count for status, count in sorted(counts.items())},
+        "legacy_pre_lang_count": sum(bool(LEGACY_PRE_PATTERN.search(post.body_markup)) for post in posts),
+        "checksums_sha256": sha256_bytes(checksum_path.read_bytes()),
+    }
+    write_json(archive_path / "archive-manifest.json", manifest)
+
+
+def validate_private_archive(archive_path: Path, expected_count: int, expected_counts: Counter[int]) -> None:
+    """Confirm a private archive has complete, checksummed post records."""
+    checksum_path = archive_path / "checksums.sha256"
+    checksum_lines = checksum_path.read_text(encoding="utf-8").splitlines()
+    checksums = {path: digest for digest, path in (line.split("  ", 1) for line in checksum_lines)}
+    records = [
+        json.loads(record_path.read_text(encoding="utf-8")) for record_path in (archive_path / "posts").glob("*.json")
+    ]
+    if len(records) != expected_count or len(checksums) != expected_count:
+        raise ValueError("private archive record count does not match the production export")
+    if Counter(record["status"] for record in records) != expected_counts:
+        raise ValueError("private archive status counts do not match the production export")
+    for relative_path, expected_hash in checksums.items():
+        actual_hash = sha256_bytes((archive_path / relative_path).read_bytes())
+        if actual_hash != expected_hash:
+            raise ValueError(f"private archive checksum mismatch: {relative_path}")
+
+
+def replace_private_archive(
+    posts: list[ExportedPost],
+    counts: Counter[int],
+    archive_path: Path,
+    source_csv: Path,
+) -> None:
+    """Stage and validate a replacement before replacing the existing archive.
+
+    Until the new archive has been fully written and verified, the prior archive
+    stays untouched. During the final swap it is retained as a sibling backup,
+    so an interrupted process leaves a complete copy recoverable on disk.
+    """
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    backup_path = archive_path.with_name(f".{archive_path.name}.backup")
+    if backup_path.exists():
+        if archive_path.exists():
+            raise ValueError(f"existing backup requires manual review: {backup_path}")
+        backup_path.rename(archive_path)
+
+    staging_path = Path(tempfile.mkdtemp(prefix=f".{archive_path.name}.staging-", dir=archive_path.parent))
+    if archive_path.exists():
+        shutil.copytree(archive_path, staging_path, dirs_exist_ok=True)
+    write_archive_files(posts, counts, staging_path, source_csv)
+    validate_private_archive(staging_path, len(posts), counts)
+    if archive_path.exists():
+        archive_path.rename(backup_path)
+    staging_path.rename(archive_path)
+    if backup_path.exists():
+        shutil.rmtree(backup_path)
+
+
+def markdown_front_matter(post: ExportedPost) -> dict[str, str | int]:
+    """Build the public metadata contract for one live post."""
+    metadata: dict[str, str | int] = {
+        "title": post.title,
+        "slug": post.slug,
+        "published_at": post.published_at.isoformat(),
+    }
+    if post.repr_image:
+        metadata["repr_image"] = post.repr_image
+    if post.wordpress_id is not None:
+        metadata["wordpress_id"] = post.wordpress_id
+    return metadata
+
+
+def markdown_content(post: ExportedPost) -> str:
+    """Return YAML front matter followed by the exact database HTML body."""
+    front_matter = yaml.safe_dump(
+        markdown_front_matter(post),
+        allow_unicode=True,
+        default_flow_style=False,
+        sort_keys=False,
+    )
+    return f"---\n{front_matter}---\n{post.body_markup}"
+
+
+def write_public_posts(posts: list[ExportedPost], content_path: Path) -> None:
+    """Write public-only Markdown posts and their non-private fingerprint."""
+    posts_path = content_path / "posts"
+    if posts_path.exists():
+        shutil.rmtree(posts_path)
+    posts_path.mkdir(parents=True)
+
+    manifest_posts: list[dict[str, str]] = []
+    for post in sorted(posts, key=lambda item: (item.published_at, item.slug)):
+        filename = f"{post.published_at:%Y-%m-%d}--{post.slug}.md"
+        relative_path = Path("posts") / filename
+        post_path = content_path / relative_path
+        post_path.write_text(markdown_content(post), encoding="utf-8")
+        manifest_posts.append(
+            {
+                "path": relative_path.as_posix(),
+                "permalink": post.permalink,
+                "published_at": post.published_at.isoformat(),
+                "sha256": sha256_bytes(post_path.read_bytes()),
+                "body_sha256": sha256_bytes(post.body_markup.encode()),
+            }
+        )
+
+    manifest_digest = sha256_bytes(
+        json.dumps(manifest_posts, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode()
+    )
+    manifest = {
+        "schema_version": 1,
+        "post_count": len(posts),
+        "production_inventory": {"total": 166, "live": 72, "draft": 94, "hidden": 0},
+        "legacy_pre_lang_post_count": sum(bool(LEGACY_PRE_PATTERN.search(post.body_markup)) for post in posts),
+        "posts": manifest_posts,
+        "posts_fingerprint_sha256": manifest_digest,
+    }
+    write_json(content_path / "posts-manifest.json", manifest)
+
+
+def main() -> None:
+    """Export validated private and public post artifacts."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("csv_path", type=Path)
+    parser.add_argument("--archive-path", type=Path, required=True)
+    parser.add_argument("--content-path", type=Path, required=True)
+    args = parser.parse_args()
+
+    archive_path, content_path = validate_export_paths(args.archive_path, args.content_path)
+    posts = load_posts(args.csv_path)
+    counts = validate_posts(posts)
+    replace_private_archive(posts, counts, archive_path, args.csv_path)
+    write_public_posts([post for post in posts if post.status == LIVE_STATUS], content_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_markdown_posts.py
+++ b/tests/test_markdown_posts.py
@@ -1,0 +1,124 @@
+"""Tests for the public Markdown post archive."""
+
+import hashlib
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from coltrane.content_loaders import ContentError, load_posts
+from coltrane.utils.pygmenter import pygmenter
+from scripts.export_posts import validate_export_paths
+
+CONTENT_PATH = Path(__file__).resolve().parent.parent / "coltrane" / "content"
+POSTS_PATH = CONTENT_PATH / "posts"
+MANIFEST_PATH = CONTENT_PATH / "posts-manifest.json"
+LOS_ANGELES = ZoneInfo("America/Los_Angeles")
+
+
+def load_manifest() -> dict:
+    """Read the public-only export manifest."""
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_markdown_posts_match_public_export_manifest():
+    """Every public file and its lossless body match the checked-in fingerprint."""
+    manifest = load_manifest()
+    manifest_posts = manifest["posts"]
+    expected_paths = {entry["path"] for entry in manifest_posts}
+    actual_paths = {f"posts/{path.name}" for path in POSTS_PATH.glob("*.md")}
+    assert manifest["post_count"] == 72
+    assert len(manifest_posts) == 72
+    assert actual_paths == expected_paths
+    assert manifest["production_inventory"] == {"total": 166, "live": 72, "draft": 94, "hidden": 0}
+
+    fingerprint = hashlib.sha256(
+        json.dumps(manifest_posts, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode()
+    ).hexdigest()
+    assert fingerprint == manifest["posts_fingerprint_sha256"]
+
+    posts_by_permalink = {post.get_absolute_url(): post for post in load_posts()}
+    assert set(posts_by_permalink) == {entry["permalink"] for entry in manifest_posts}
+    for entry in manifest_posts:
+        post_path = CONTENT_PATH / entry["path"]
+        assert hashlib.sha256(post_path.read_bytes()).hexdigest() == entry["sha256"]
+        assert (
+            hashlib.sha256(posts_by_permalink[entry["permalink"]].body_markup.encode()).hexdigest()
+            == entry["body_sha256"]
+        )
+
+
+def test_markdown_posts_have_unique_slugs_and_preserved_permalinks():
+    """Posts retain globally unique slugs and their legacy date URLs."""
+    posts = load_posts()
+    assert len(posts) == 72
+    assert len({post.slug for post in posts}) == len(posts)
+    assert len({(post.published_at.date(), post.slug) for post in posts}) == len(posts)
+
+    manifest_permalinks = {entry["permalink"] for entry in load_manifest()["posts"]}
+    assert {post.get_absolute_url() for post in posts} == manifest_permalinks
+
+
+def test_markdown_posts_keep_los_angeles_publication_datetimes():
+    """The front matter preserves the original Los Angeles local clock time."""
+    manifest_by_permalink = {entry["permalink"]: entry for entry in load_manifest()["posts"]}
+    for post in load_posts():
+        expected = datetime.fromisoformat(manifest_by_permalink[post.get_absolute_url()]["published_at"])
+        assert post.published_at.tzinfo == LOS_ANGELES
+        assert post.published_at == expected
+        assert post.get_absolute_url().startswith(f"/posts/{post.published_at:%Y/%m/%d}/")
+
+
+def test_markdown_posts_preserve_legacy_pre_lang_markup():
+    """Raw HTML bodies retain the code markup consumed by the current renderer."""
+    legacy_posts = [post for post in load_posts() if re.search(r"<pre\s+[^>]*\blang=", post.body_markup)]
+    assert len(legacy_posts) == load_manifest()["legacy_pre_lang_post_count"] == 25
+
+    python_post = next(post for post in legacy_posts if '<pre lang="python">' in post.body_markup)
+    assert '<pre lang="python">' in python_post.body_markup
+    assert 'class="source"' in pygmenter(python_post.body_markup)
+
+
+def test_markdown_post_requires_los_angeles_datetime(tmp_path):
+    """UTC front matter is rejected even when it represents the same instant."""
+    post_path = tmp_path / "post.md"
+    post_path.write_text(
+        "---\ntitle: Example\nslug: example\npublished_at: '2025-01-01T20:00:00+00:00'\n---\n<p>Body</p>",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ContentError, match="America/Los_Angeles"):
+        load_posts(tmp_path)
+
+
+def test_markdown_post_rejects_unknown_front_matter(tmp_path):
+    """The authoring contract rejects accidental metadata fields."""
+    post_path = tmp_path / "post.md"
+    post_path.write_text(
+        "---\ntitle: Example\nslug: example\npublished_at: '2025-01-01T12:00:00-08:00'\nstatus: draft\n---\n<p>Body</p>",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ContentError, match="unsupported"):
+        load_posts(tmp_path)
+
+
+def test_markdown_post_rejects_duplicate_slug(tmp_path):
+    """Slugs must remain globally unique before file-backed routing is enabled."""
+    for name in ("one.md", "two.md"):
+        (tmp_path / name).write_text(
+            "---\ntitle: Example\nslug: example\npublished_at: '2025-01-01T12:00:00-08:00'\n---\n<p>Body</p>",
+            encoding="utf-8",
+        )
+
+    with pytest.raises(ContentError, match="duplicate post slug"):
+        load_posts(tmp_path)
+
+
+def test_exporter_rejects_archive_path_inside_public_repository():
+    """The export command cannot write draft records into this checkout."""
+    with pytest.raises(ValueError, match="outside the public repository"):
+        validate_export_paths(CONTENT_PATH / "private-archive", CONTENT_PATH)


### PR DESCRIPTION
## Layer 1/3 of #354

Part of #354. This layer archives production post records and adds the validated public Markdown corpus without changing any runtime reads.

- Stores a private, checksummed archive of all 166 production records (72 live, 94 drafts).
- Adds exactly 72 public Markdown files, preserving Los Angeles timestamps, legacy URLs, optional representative images and WordPress IDs, and raw HTML bodies.
- Adds typed validation, a public-only fingerprint manifest, lossless-body and legacy `<pre lang="...">` regression tests, and the authoring contract.
- Keeps views, feeds, sitemaps, and database-backed post reads unchanged for the next layer.

Private archive release: https://github.com/palewire/palewi.re-archive/releases/tag/posts-export-20260824

Validation: `make check`; two independent code-review passes (first found and resolved exporter safety issues; second reported no remaining significant issues).

Fixes: #354