### PR TITLE
Switch public posts to file-backed Markdown (stack 2/3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,24 @@ not add drafts or a status field. The filename format is
 `YYYY-MM-DD--slug.md`, and `posts-manifest.json` is the checked-in public
 fingerprint generated during the production export.
 
+To author a post, create a file with this shape:
+
+```markdown
+---
+title: Example post
+slug: example-post
+published_at: "2026-08-24T09:00:00-07:00"
+repr_image: "https://example.com/image.jpg" # optional
+wordpress_id: 123 # optional legacy ID
+---
+<p>Write the published body as raw HTML.</p>
+```
+
+Only files in this directory are public. Drafts belong in a private workspace,
+not this repository. Run `make serve`, open the printed local URL, and visit
+`/posts/` or the post's date-based URL to preview it. Run `make check` before
+committing to validate the front matter, public URL inventory, and rendering.
+
 ## Deployment
 
 The app deploys to Heroku automatically when a pull request merges to `main` **after CI passes**.

--- a/coltrane/content_loaders.py
+++ b/coltrane/content_loaders.py
@@ -51,6 +51,7 @@ import datetime
 import random
 import re
 from dataclasses import dataclass
+from functools import cached_property
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
@@ -124,6 +125,22 @@ class MarkdownPost:
     body_markup: str
     repr_image: str = ""
     wordpress_id: int | None = None
+
+    def __str__(self) -> str:
+        """Return the title used by the existing post list template."""
+        return self.title
+
+    @property
+    def pub_date(self) -> datetime.datetime:
+        """Expose the legacy template and sitemap publication field."""
+        return self.published_at
+
+    @cached_property
+    def body_html(self) -> str:
+        """Apply the existing legacy code-block renderer to stored raw HTML."""
+        from coltrane.utils.pygmenter import pygmenter
+
+        return pygmenter(self.body_markup)
 
     def get_absolute_url(self) -> str:
         """Return the legacy publication-date permalink."""

--- a/coltrane/feeds.py
+++ b/coltrane/feeds.py
@@ -1,6 +1,6 @@
 from django.contrib.syndication.views import Feed
 
-from coltrane.models import Post
+from coltrane.content_loaders import load_posts
 
 
 class LatestPostsFeed(Feed):
@@ -9,7 +9,7 @@ class LatestPostsFeed(Feed):
     description = "the latest"
 
     def items(self):
-        return Post.live.all().order_by("-pub_date")[:10]
+        return load_posts()[:10]
 
     def item_title(self, item):
         return item.title

--- a/coltrane/sitemaps.py
+++ b/coltrane/sitemaps.py
@@ -1,12 +1,6 @@
-from django.contrib import sitemaps
-from django.contrib.sitemaps import GenericSitemap
+from django.contrib import sitemaps as django_sitemaps
 
-from coltrane.models import Post
-
-post_dict = {
-    "queryset": Post.live.all(),
-    "date_field": "pub_date",
-}
+from coltrane.content_loaders import MarkdownPost, load_posts
 
 
 class AbstractSitemapClass:
@@ -16,7 +10,7 @@ class AbstractSitemapClass:
         return self.url
 
 
-class StaticSitemap(sitemaps.Sitemap):
+class StaticSitemap(django_sitemaps.Sitemap):
     pages = {
         "bio": "/who-is-ben-welsh/",
         "clips": "/clips/",
@@ -33,7 +27,20 @@ class StaticSitemap(sitemaps.Sitemap):
         return self.main_sitemaps
 
 
+class PostsSitemap(django_sitemaps.Sitemap):
+    priority = 0.9
+
+    def items(self) -> list[MarkdownPost]:
+        return load_posts()
+
+    def lastmod(self, item: MarkdownPost):
+        return item.published_at
+
+    def location(self, item: MarkdownPost) -> str:
+        return item.get_absolute_url()
+
+
 sitemaps = {
     "static": StaticSitemap,
-    "posts": GenericSitemap(post_dict, priority=0.9),
+    "posts": PostsSitemap,
 }

--- a/coltrane/sitemaps.py
+++ b/coltrane/sitemaps.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.contrib import sitemaps as django_sitemaps
 
 from coltrane.content_loaders import MarkdownPost, load_posts
@@ -33,8 +35,8 @@ class PostsSitemap(django_sitemaps.Sitemap):
     def items(self) -> list[MarkdownPost]:
         return load_posts()
 
-    def lastmod(self, item: MarkdownPost):
-        return item.published_at
+    def lastmod(self, item: MarkdownPost) -> datetime.date:
+        return item.published_at.date()
 
     def location(self, item: MarkdownPost) -> str:
         return item.get_absolute_url()

--- a/coltrane/views.py
+++ b/coltrane/views.py
@@ -19,10 +19,7 @@ from django.views.generic import ListView, TemplateView
 # Helpers
 from proxy.views import proxy_view
 
-from coltrane.content_loaders import load_awards, load_bots, load_clips, load_docs, load_talks
-
-# Models
-from coltrane.models import Post
+from coltrane.content_loaders import load_awards, load_bots, load_clips, load_docs, load_posts, load_talks
 
 CONTENT_PATH = Path(__file__).resolve().parent / "content"
 
@@ -71,14 +68,15 @@ def post_detail(request, year, month, day, slug):
     """
     date_stamp = time.strptime(year + month + day, "%Y%m%d")
     pub_date = datetime.date(*date_stamp[:3])
-    try:
-        post = Post.live.get(
-            pub_date__year=pub_date.year,
-            pub_date__month=pub_date.month,
-            pub_date__day=pub_date.day,
-            slug=slug,
-        )
-    except Post.DoesNotExist:
+    post = next(
+        (
+            candidate
+            for candidate in load_posts()
+            if candidate.published_at.date() == pub_date and candidate.slug == slug
+        ),
+        None,
+    )
+    if post is None:
         raise Http404
     context = {
         "object": post,
@@ -113,7 +111,10 @@ class TalkListView(TemplateView):
 
 
 class PostListView(ListView):
-    queryset = Post.live.all().order_by("-pub_date")
+    template_name = "coltrane/post_list.html"
+
+    def get_queryset(self):
+        return load_posts()
 
 
 class DocListView(TemplateView):

--- a/tests/test_file_backed_posts.py
+++ b/tests/test_file_backed_posts.py
@@ -1,0 +1,144 @@
+"""Tests for public post views backed solely by checked-in Markdown files."""
+
+import xml.etree.ElementTree as xml
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client
+
+from coltrane.content_loaders import load_posts
+from coltrane.models import Post
+from coltrane.utils.pygmenter import pygmenter
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+@pytest.fixture
+def public_posts():
+    return load_posts()
+
+
+@pytest.mark.django_db
+def test_all_public_post_permalinks_resolve_without_database_posts(client, public_posts, django_assert_num_queries):
+    """Every manifest-backed public URL is served after Post rows are removed."""
+    Post.objects.all().delete()
+
+    with django_assert_num_queries(0):
+        for post in public_posts:
+            response = client.get(post.get_absolute_url())
+            assert response.status_code == 200
+            assert response.context["object"] == post
+
+
+@pytest.mark.django_db
+def test_post_list_uses_file_order_and_needs_no_post_rows(client, public_posts):
+    """The list retains descending Los Angeles publication order from files."""
+    Post.objects.all().delete()
+
+    response = client.get("/posts/")
+
+    assert response.status_code == 200
+    assert list(response.context["object_list"]) == public_posts
+    assert response.context["is_paginated"] is False
+    content = response.content.decode()
+    first_link = content.index(public_posts[0].get_absolute_url())
+    last_link = content.index(public_posts[-1].get_absolute_url())
+    assert first_link < last_link
+
+
+@pytest.mark.django_db
+def test_post_detail_keeps_raw_html_and_legacy_code_highlighting(client, public_posts):
+    """Stored HTML remains safe output and legacy <pre lang> blocks are highlighted."""
+    raw_html_post = next(post for post in public_posts if "<iframe" in post.body_markup)
+    code_post = next(post for post in public_posts if '<pre lang="python">' in post.body_markup)
+
+    raw_response = client.get(raw_html_post.get_absolute_url())
+    code_response = client.get(code_post.get_absolute_url())
+
+    assert "<iframe" in raw_response.content.decode()
+    assert 'class="source"' in code_response.content.decode()
+
+
+def test_post_html_is_highlighted_once_per_loaded_post(public_posts):
+    """Templates can reuse rendered HTML without repeating legacy highlighting."""
+    post = next(post for post in public_posts if '<pre lang="python">' in post.body_markup)
+
+    with patch("coltrane.utils.pygmenter.pygmenter", wraps=pygmenter) as mocked_pygmenter:
+        assert post.body_html == post.body_html
+
+    mocked_pygmenter.assert_called_once_with(post.body_markup)
+
+
+@pytest.mark.django_db
+def test_post_detail_keeps_representative_image_metadata(client, public_posts):
+    """The structured metadata retains each exported representative image."""
+    for post in (post for post in public_posts if post.repr_image):
+        response = client.get(post.get_absolute_url())
+        assert post.repr_image in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_feed_uses_latest_ten_file_backed_posts(client, public_posts):
+    """The feed has the same newest-first ten-post selection as the old queryset."""
+    Post.objects.all().delete()
+
+    response = client.get("/feeds/posts/")
+    root = xml.fromstring(response.content)
+    items = root.findall("./channel/item")
+
+    assert response.status_code == 200
+    assert [item.findtext("title") for item in items] == [post.title for post in public_posts[:10]]
+    assert [item.findtext("link") for item in items] == [
+        f"http://testserver{post.get_absolute_url()}" for post in public_posts[:10]
+    ]
+
+
+@pytest.mark.django_db
+def test_sitemap_lists_every_file_backed_post_with_publication_date(client, public_posts):
+    """The posts sitemap is complete without database records."""
+    Post.objects.all().delete()
+
+    response = client.get("/sitemap-posts.xml")
+    root = xml.fromstring(response.content)
+    namespace = {"sitemap": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    entries = root.findall("sitemap:url", namespace)
+
+    assert response.status_code == 200
+    assert [entry.findtext("sitemap:loc", namespaces=namespace) for entry in entries] == [
+        f"http://testserver{post.get_absolute_url()}" for post in public_posts
+    ]
+    assert [entry.findtext("sitemap:lastmod", namespaces=namespace) for entry in entries] == [
+        post.published_at.date().isoformat() for post in public_posts
+    ]
+
+
+@pytest.mark.django_db
+def test_public_post_routes_ignore_database_rows(client, public_posts):
+    """A conflicting database post cannot replace a public Markdown post."""
+    author = User.objects.create_user(username="legacy-author", password="unused")
+    post = public_posts[0]
+    Post.objects.create(
+        title="Database-only title",
+        slug=post.slug,
+        body_markup="<p>Database-only body</p>",
+        pub_date=post.published_at,
+        author=author,
+    )
+
+    response = client.get(post.get_absolute_url())
+
+    content = response.content.decode()
+    assert post.title in content
+    assert "Database-only title" not in content
+
+
+@pytest.mark.django_db
+def test_unknown_post_permalink_returns_not_found(client):
+    """A URL absent from the public files retains the legacy 404 behavior."""
+    response = client.get("/posts/2026/01/01/not-a-public-post/")
+
+    assert response.status_code == 404


### PR DESCRIPTION
## Stack

**Layer 2 of 3** for #354. This PR is based on `palewire-archive-live-markdown-posts` from #368.

## Changes

- Serves post lists, details, feeds, and sitemaps from validated public Markdown files.
- Preserves legacy URLs, Los Angeles publication dates, raw HTML, `<pre lang="...">` highlighting, representative-image metadata, and newest-first ordering.
- Keeps the `Post` model and database infrastructure unchanged for layer 3.
- Documents public post authoring and local preview.

## Coverage

- Verifies all 72 public permalinks resolve with zero database queries and no `Post` rows.
- Verifies list order and pagination behavior, feed selection, sitemap entries, metadata, HTML rendering, code highlighting, and unknown-post 404s.

## Validation

`make check`