### PR TITLE
Bootstrap uv and Heroku CLI for local and cloud sessions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,7 +32,8 @@ This runs Ruff lint + format check, **ty static type analysis**, and pytest with
 ## Key conventions
 
 - **Packaging**: `uv` + `pyproject.toml` + `uv.lock`. Never use `pip install` directly.
-- **Bootstrap**: use `make bootstrap` in local worktrees and agent environments; CI uses `make ci-bootstrap`.
+- **Bootstrap**: use `make bootstrap` in local worktrees and agent environments; it requires `uv` and the Heroku CLI. CI uses `make ci-bootstrap`.
+- **Cloud Heroku access**: setup installs the CLI but does not authenticate. If an agent needs Heroku access, use a `HEROKU_API_KEY` GitHub Copilot Agents secret; never commit credentials or auth files.
 - **Linting**: Ruff with `select = ["E", "F", "W", "I", "UP"]` (UP031 ignored).
 - **Type checking**: `ty check .` — Django dynamic attributes are downgraded to warnings; new code should pass clean.
 - **Tests**: pytest-django in `tests/`. No database service is required.

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install Heroku CLI
+        run: |
+          curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location https://cli-assets.heroku.com/install.sh | bash
+          heroku version
+
       - name: Configure development environment
         run: |
           echo "SECRET_KEY=copilot-setup-key" >> "$GITHUB_ENV"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,8 @@
 ## Start here
 
 Run `make bootstrap` once after creating a clone or worktree. It installs locked
-dependencies and installs the pre-commit hooks.
+dependencies and installs the pre-commit hooks. It first confirms that `uv` and
+the Heroku CLI are available; it does not install or authenticate either tool.
 
 Run the development server with `make serve`. Linked worktrees automatically
 receive an available local port.
@@ -27,6 +28,11 @@ secrets, generated files, or `.goals/` agent state.
 
 Use `uv` and `pyproject.toml` for Python dependencies, Ruff for formatting and
 linting, and ty for static analysis.
+
+Copilot cloud agents receive `uv` and the Heroku CLI from
+`.github/workflows/copilot-setup-steps.yml`. Authentication remains
+user-provided. If a cloud agent needs authenticated Heroku access, use a
+`HEROKU_API_KEY` GitHub Copilot Agents secret, never repository data.
 
 ## YAML content types
 

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,16 @@
 
 export UV_NO_ENV_FILE = 1
 
-.PHONY: help bootstrap ci-bootstrap install hooks serve check test lint typecheck django-check fmt
+HOMEBREW_BIN := $(shell for path in /opt/homebrew/bin /usr/local/bin; do test -x "$$path/brew" && { printf '%s' "$$path"; break; }; done)
+export PATH := $(HOME)/.local/bin:$(HOME)/.local/share/heroku/client/bin:$(HOMEBREW_BIN):$(PATH)
+
+.PHONY: help bootstrap ci-bootstrap check-tools install hooks serve check test lint typecheck django-check fmt
 
 help:
 	@echo "Available targets:"
-	@echo "  bootstrap  Prepare dependencies and hooks"
+	@echo "  bootstrap  Check developer tools, then prepare dependencies and hooks"
 	@echo "  ci-bootstrap  Prepare dependencies for CI"
+	@echo "  check-tools  Confirm uv and the Heroku CLI are available"
 	@echo "  install    Install all dependencies without changing Git hooks"
 	@echo "  hooks      Install pre-commit hooks"
 	@echo "  serve      Start the development server"
@@ -23,7 +27,11 @@ install:
 hooks:
 	uv run pre-commit install
 
-bootstrap: install hooks
+check-tools:
+	@command -v uv > /dev/null || { echo "uv is required. Install it from https://docs.astral.sh/uv/getting-started/installation/" >&2; exit 1; }
+	@command -v heroku > /dev/null || { echo "The Heroku CLI is required. Install it from https://devcenter.heroku.com/articles/heroku-cli#install-the-heroku-cli" >&2; exit 1; }
+
+bootstrap: check-tools install hooks
 
 ci-bootstrap: install
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Ben Welsh's personal site — a Django blog and portfolio at [palewi.re](https:/
 
 - Python 3.12
 - [uv](https://docs.astral.sh/uv/) for package management
+- [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli) for local setup and Heroku commands
 
 ## Setup
 
@@ -20,6 +21,11 @@ make bootstrap
 # Start server
 make serve
 ```
+
+`make bootstrap` checks both commands before it installs anything. For its
+commands, it also adds common user installation paths including
+`$HOME/.local/bin`, Heroku's user client directory, and a detected Homebrew
+bin directory. It does not install either command or authenticate with Heroku.
 
 Open the URL printed by the server. Linked Git worktrees automatically use
 available local ports, so multiple agents can run the site at the same time.
@@ -88,6 +94,12 @@ committing to validate the front matter, public URL inventory, and rendering.
 ## Deployment
 
 The app deploys to Heroku automatically when a pull request merges to `main` **after CI passes**.
+
+The Heroku CLI is available in Copilot cloud-agent sessions through the
+official installer in `.github/workflows/copilot-setup-steps.yml`. Authentication
+is not part of repository setup. For a cloud agent that must run authenticated
+Heroku commands, add `HEROKU_API_KEY` as a GitHub Copilot Agents secret; never
+store it in this repository.
 
 For the database retirement deployment, take a fresh Heroku backup first. Deploy
 the exact merged SHA, then verify `/health/`, the main pages, all post


### PR DESCRIPTION
## Summary

- Make local `make bootstrap` add standard user tool locations, check `uv` and the Heroku CLI before changing dependencies, and give direct install guidance when either is missing.
- Keep ordinary CI fast: `make ci-bootstrap` still installs only Python dependencies.
- Install `uv` with the existing pinned Astral action and the Heroku CLI with Heroku's official stable installer for Copilot cloud-agent sessions.
- Document that setup does not authenticate with Heroku. Authenticated cloud tasks should use a `HEROKU_API_KEY` GitHub Copilot Agents secret, which replaces legacy `copilot` environment secrets and is not repository data.

## Behavior

- **Local worktrees:** `make bootstrap` makes `$HOME/.local/bin`, Heroku's user-client bin directory, and a detected Homebrew bin directory available to Make commands. It does not reinstall either CLI.
- **Cloud-agent sessions:** the setup workflow installs both CLIs in its Ubuntu environment. A Heroku credential is optional and not needed for bootstrap.

## Validation

- Verified `make check-tools` succeeds with the local tools and produces the expected failure message for missing `uv` and missing Heroku CLI.
- Parsed and asserted the Copilot setup workflow configuration; pre-commit YAML checks passed.
- `make check` (125 passed, 2 skipped).
- Independent review found and resolved a potential secret exposure through normal PR workflow runs.