### PR TITLE
Configure Cloudflare Wrangler access

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,8 +32,9 @@ This runs Ruff lint + format check, **ty static type analysis**, and pytest with
 ## Key conventions
 
 - **Packaging**: `uv` + `pyproject.toml` + `uv.lock`. Never use `pip install` directly.
-- **Bootstrap**: use `make bootstrap` in local worktrees and agent environments; it requires `uv` and the Heroku CLI. CI uses `make ci-bootstrap`.
+- **Bootstrap**: use `make bootstrap` in local worktrees and agent environments; it requires `uv`, the Heroku CLI, and Wrangler. CI uses `make ci-bootstrap`.
 - **Cloud Heroku access**: setup installs the CLI but does not authenticate. If an agent needs Heroku access, use a `HEROKU_API_KEY` GitHub Copilot Agents secret; never commit credentials or auth files.
+- **Cloudflare access**: cloud-agent setup installs Wrangler 4.125.0 on fresh runners. Local bootstrap only checks for an existing CLI. Use `make cloudflare-check` for the non-destructive `wrangler whoami --json` check. Authenticate locally with `wrangler login` or a `CLOUDFLARE_API_TOKEN`; cloud agents require that token as a Copilot Agents secret with only User Details and Memberships read permissions. The vendored Wrangler skill's `@latest` installation advice does not apply here: agents must run `make check-wrangler` and use the existing pinned CLI. Do not configure or deploy DNS, zones, Pages, or Workers until a target is chosen.
 - **Linting**: Ruff with `select = ["E", "F", "W", "I", "UP"]` (UP031 ignored).
 - **Type checking**: `ty check .` — Django dynamic attributes are downgraded to warnings; new code should pass clean.
 - **Tests**: pytest-django in `tests/`. No database service is required.

--- a/.github/skills/wrangler/LICENSE
+++ b/.github/skills/wrangler/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.github/skills/wrangler/README.md
+++ b/.github/skills/wrangler/README.md
@@ -1,0 +1,9 @@
+# Wrangler skill
+
+This directory vendors Cloudflare's official Wrangler skill so repository
+agents can discover it at `.github/skills/wrangler/SKILL.md`.
+
+Source: <https://github.com/cloudflare/skills/tree/f96bff754e428838818017f75817f0f9428acd48/skills/wrangler>
+
+`SKILL.md` is the upstream file at that revision. It is licensed under Apache
+License 2.0; the required license text is in [LICENSE](LICENSE).

--- a/.github/skills/wrangler/SKILL.md
+++ b/.github/skills/wrangler/SKILL.md
@@ -1,0 +1,922 @@
+---
+name: wrangler
+description: Cloudflare Workers CLI for deploying, developing, and managing Workers, KV, R2, D1, Vectorize, Hyperdrive, Workers AI, Containers, Queues, Workflows, Pipelines, and Secrets Store. Load before running wrangler commands to ensure correct syntax and best practices. Biases towards retrieval from Cloudflare docs over pre-trained knowledge.
+---
+
+# Wrangler CLI
+
+Your knowledge of Wrangler CLI flags, config fields, and subcommands may be outdated. **Prefer retrieval over pre-training** for any Wrangler task.
+
+## Retrieval Sources
+
+Fetch the **latest** information before writing or reviewing Wrangler commands and config. Do not rely on baked-in knowledge for CLI flags, config fields, or binding shapes.
+
+| Source | How to retrieve | Use for |
+|--------|----------------|---------|
+| Wrangler docs | `https://developers.cloudflare.com/workers/wrangler/` | CLI commands, flags, config reference |
+| Wrangler config schema | `node_modules/wrangler/config-schema.json` | Config fields, binding shapes, allowed values |
+| Cloudflare docs | Search tool or `https://developers.cloudflare.com/workers/` | API reference, compatibility dates/flags |
+
+## FIRST: Check if Wrangler is installed, and if not, install it
+
+Check if Wrangler is installed by running:
+
+```bash
+wrangler --version  # Requires v4.x+
+```
+
+If Wrangler is not installed, you should install it by running:
+
+```bash
+npm install -D wrangler@latest
+```
+
+Wherever possible, you should use Wrangler instead of manually constructing API requests.
+
+## Key Guidelines
+
+- **Use `wrangler.jsonc`**: Prefer JSON config over TOML. Newer features are JSON-only.
+- **Set `compatibility_date`**: Use a recent date (within 30 days). Check https://developers.cloudflare.com/workers/configuration/compatibility-dates/
+- **Generate types after config changes**: Run `wrangler types` to update TypeScript bindings.
+- **Local dev defaults to local storage**: Bindings use local simulation unless `remote: true`.
+- **Profile Worker startup**: Run `wrangler check startup` to measure startup time and detect scripts that exceed the startup time limit.
+- **Use environments for staging/prod**: Define `env.staging` and `env.production` in config.
+
+## Quick Start: New Worker
+
+```bash
+# Initialize new project
+npx wrangler init my-worker
+
+# Or with a framework
+npx create-cloudflare@latest my-app
+```
+
+## Quick Reference: Core Commands
+
+| Task | Command |
+|------|---------|
+| Start local dev server | `wrangler dev` |
+| Deploy to Cloudflare | `wrangler deploy` |
+| Deploy dry run | `wrangler deploy --dry-run` |
+| Generate TypeScript types | `wrangler types` |
+| Profile Worker startup time | `wrangler check startup` |
+| View live logs | `wrangler tail` |
+| Delete Worker | `wrangler delete` |
+| Auth status | `wrangler whoami` |
+
+---
+
+## Configuration (wrangler.jsonc)
+
+### Minimal Config
+
+```jsonc
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "my-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-01-01"
+}
+```
+
+### Full Config with Bindings
+
+```jsonc
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "my-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-01-01",
+  "compatibility_flags": ["nodejs_compat"],
+
+  // Environment variables
+  "vars": {
+    "ENVIRONMENT": "production"
+  },
+
+  // KV Namespace
+  "kv_namespaces": [
+    { "binding": "KV", "id": "<KV_NAMESPACE_ID>" }
+  ],
+
+  // R2 Bucket
+  "r2_buckets": [
+    { "binding": "BUCKET", "bucket_name": "my-bucket" }
+  ],
+
+  // D1 Database
+  "d1_databases": [
+    { "binding": "DB", "database_name": "my-db", "database_id": "<DB_ID>" }
+  ],
+
+  // Workers AI (always remote)
+  "ai": { "binding": "AI" },
+
+  // Vectorize
+  "vectorize": [
+    { "binding": "VECTOR_INDEX", "index_name": "my-index" }
+  ],
+
+  // Hyperdrive
+  "hyperdrive": [
+    { "binding": "HYPERDRIVE", "id": "<HYPERDRIVE_ID>" }
+  ],
+
+  // Durable Objects
+  "durable_objects": {
+    "bindings": [
+      { "name": "COUNTER", "class_name": "Counter" }
+    ]
+  },
+
+  // Cron triggers
+  "triggers": {
+    "crons": ["0 * * * *"]
+  },
+
+  // Environments
+  "env": {
+    "staging": {
+      "name": "my-worker-staging",
+      "vars": { "ENVIRONMENT": "staging" }
+    }
+  }
+}
+```
+
+### Generate Types from Config
+
+```bash
+# Generate worker-configuration.d.ts
+wrangler types
+
+# Custom output path
+wrangler types ./src/env.d.ts
+
+# Check types are up to date (CI)
+wrangler types --check
+```
+
+---
+
+## Local Development
+
+### Start Dev Server
+
+```bash
+# Local mode (default) - uses local storage simulation
+wrangler dev
+
+# With specific environment
+wrangler dev --env staging
+
+# Force local-only (disable remote bindings)
+wrangler dev --local
+
+# Remote mode - runs on Cloudflare edge (legacy)
+wrangler dev --remote
+
+# Custom port
+wrangler dev --port 8787
+
+# Live reload for HTML changes
+wrangler dev --live-reload
+
+# Test scheduled/cron handlers
+wrangler dev --test-scheduled
+# Then visit: http://localhost:8787/__scheduled
+```
+
+### Remote Bindings for Local Dev
+
+Use `remote: true` in binding config to connect to real resources while running locally:
+
+```jsonc
+{
+  "r2_buckets": [
+    { "binding": "BUCKET", "bucket_name": "my-bucket", "remote": true }
+  ],
+  "ai": { "binding": "AI", "remote": true },
+  "vectorize": [
+    { "binding": "INDEX", "index_name": "my-index", "remote": true }
+  ]
+}
+```
+
+**Recommended remote bindings**: AI (required), Vectorize, Browser Rendering, mTLS, Images.
+
+### Local Secrets
+
+Create `.dev.vars` for local development secrets:
+
+```
+API_KEY=local-dev-key
+DATABASE_URL=postgres://localhost:5432/dev
+```
+
+---
+
+## Deployment
+
+### Deploy Worker
+
+```bash
+# Deploy to production
+wrangler deploy
+
+# Deploy specific environment
+wrangler deploy --env staging
+
+# Dry run (validate without deploying)
+wrangler deploy --dry-run
+
+# Keep dashboard-set variables
+wrangler deploy --keep-vars
+
+# Minify code
+wrangler deploy --minify
+```
+
+### Manage Secrets
+
+> **Security**: Never pass secret values as command arguments or pipe them via `echo`.
+> Use the interactive prompt (preferred), pipe from a file, or use `secret bulk`.
+> Never output, log, or hardcode secret values in commands.
+
+```bash
+# Set secret — interactive prompt (preferred, wrangler will ask for the value securely)
+wrangler secret put API_KEY
+
+# Set secret from a file (useful for PEM keys, CI environments)
+wrangler secret put PRIVATE_KEY < path/to/private-key.pem
+
+# List secrets
+wrangler secret list
+
+# Delete secret
+wrangler secret delete API_KEY
+
+# Bulk secrets from JSON file (do not commit this file to version control)
+wrangler secret bulk secrets.json
+```
+
+### Versions and Rollback
+
+```bash
+# List recent versions
+wrangler versions list
+
+# View specific version
+wrangler versions view <VERSION_ID>
+
+# Rollback to previous version
+wrangler rollback
+
+# Rollback to specific version
+wrangler rollback <VERSION_ID>
+```
+
+---
+
+## KV (Key-Value Store)
+
+### Manage Namespaces
+
+```bash
+# Create namespace
+wrangler kv namespace create MY_KV
+
+# List namespaces
+wrangler kv namespace list
+
+# Delete namespace
+wrangler kv namespace delete --namespace-id <ID>
+```
+
+### Manage Keys
+
+```bash
+# Put value
+wrangler kv key put --namespace-id <ID> "key" "value"
+
+# Put with expiration (seconds)
+wrangler kv key put --namespace-id <ID> "key" "value" --expiration-ttl 3600
+
+# Get value
+wrangler kv key get --namespace-id <ID> "key"
+
+# List keys
+wrangler kv key list --namespace-id <ID>
+
+# Delete key
+wrangler kv key delete --namespace-id <ID> "key"
+
+# Bulk put from JSON
+wrangler kv bulk put --namespace-id <ID> data.json
+```
+
+### Config Binding
+
+```jsonc
+{
+  "kv_namespaces": [
+    { "binding": "CACHE", "id": "<NAMESPACE_ID>" }
+  ]
+}
+```
+
+---
+
+## R2 (Object Storage)
+
+### Manage Buckets
+
+```bash
+# Create bucket
+wrangler r2 bucket create my-bucket
+
+# Create with location hint
+wrangler r2 bucket create my-bucket --location wnam
+
+# List buckets
+wrangler r2 bucket list
+
+# Get bucket info
+wrangler r2 bucket info my-bucket
+
+# Delete bucket
+wrangler r2 bucket delete my-bucket
+```
+
+### Manage Objects
+
+```bash
+# Upload object
+wrangler r2 object put my-bucket/path/file.txt --file ./local-file.txt
+
+# Download object
+wrangler r2 object get my-bucket/path/file.txt
+
+# Delete object
+wrangler r2 object delete my-bucket/path/file.txt
+```
+
+### Config Binding
+
+```jsonc
+{
+  "r2_buckets": [
+    { "binding": "ASSETS", "bucket_name": "my-bucket" }
+  ]
+}
+```
+
+---
+
+## D1 (SQL Database)
+
+### Manage Databases
+
+```bash
+# Create database
+wrangler d1 create my-database
+
+# Create with location
+wrangler d1 create my-database --location wnam
+
+# List databases
+wrangler d1 list
+
+# Get database info
+wrangler d1 info my-database
+
+# Delete database
+wrangler d1 delete my-database
+```
+
+### Execute SQL
+
+```bash
+# Execute SQL command (remote)
+wrangler d1 execute my-database --remote --command "SELECT * FROM users"
+
+# Execute SQL file (remote)
+wrangler d1 execute my-database --remote --file ./schema.sql
+
+# Execute locally
+wrangler d1 execute my-database --local --command "SELECT * FROM users"
+```
+
+### Migrations
+
+```bash
+# Create migration
+wrangler d1 migrations create my-database create_users_table
+
+# List pending migrations
+wrangler d1 migrations list my-database --local
+
+# Apply migrations locally
+wrangler d1 migrations apply my-database --local
+
+# Apply migrations to remote
+wrangler d1 migrations apply my-database --remote
+```
+
+### Export/Backup
+
+```bash
+# Export schema and data
+wrangler d1 export my-database --remote --output backup.sql
+
+# Export schema only
+wrangler d1 export my-database --remote --output schema.sql --no-data
+```
+
+### Config Binding
+
+```jsonc
+{
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "my-database",
+      "database_id": "<DATABASE_ID>",
+      "migrations_dir": "./migrations"
+    }
+  ]
+}
+```
+
+---
+
+## Vectorize (Vector Database)
+
+### Manage Indexes
+
+```bash
+# Create index with dimensions
+wrangler vectorize create my-index --dimensions 768 --metric cosine
+
+# Create with preset (auto-configures dimensions/metric)
+wrangler vectorize create my-index --preset @cf/baai/bge-base-en-v1.5
+
+# List indexes
+wrangler vectorize list
+
+# Get index info
+wrangler vectorize get my-index
+
+# Delete index
+wrangler vectorize delete my-index
+```
+
+### Manage Vectors
+
+```bash
+# Insert vectors from NDJSON file
+wrangler vectorize insert my-index --file vectors.ndjson
+
+# Query vectors
+wrangler vectorize query my-index --vector "[0.1, 0.2, ...]" --top-k 10
+```
+
+### Config Binding
+
+```jsonc
+{
+  "vectorize": [
+    { "binding": "SEARCH_INDEX", "index_name": "my-index" }
+  ]
+}
+```
+
+---
+
+## Hyperdrive (Database Accelerator)
+
+### Manage Configs
+
+```bash
+# Create config
+wrangler hyperdrive create my-hyperdrive \
+  --origin-host db.example.com \
+  --origin-port 5432 \
+  --database my-database \
+  --origin-user db-user \
+  --origin-password "$DB_PASSWORD"
+
+# Or using a connection string from an environment variable
+wrangler hyperdrive create my-hyperdrive \
+  --connection-string "$HYPERDRIVE_CONNECTION_STRING"
+
+# List configs
+wrangler hyperdrive list
+
+# Get config details
+wrangler hyperdrive get <HYPERDRIVE_ID>
+
+# Update config
+wrangler hyperdrive update <HYPERDRIVE_ID> \
+  --origin-password "$DB_PASSWORD"
+
+# Delete config
+wrangler hyperdrive delete <HYPERDRIVE_ID>
+```
+
+### Config Binding
+
+```jsonc
+{
+  "compatibility_flags": ["nodejs_compat"],
+  "hyperdrive": [
+    { "binding": "HYPERDRIVE", "id": "<HYPERDRIVE_ID>" }
+  ]
+}
+```
+
+---
+
+## Workers AI
+
+### List Models
+
+```bash
+# List available models
+wrangler ai models
+
+# List finetunes
+wrangler ai finetune list
+```
+
+### Config Binding
+
+```jsonc
+{
+  "ai": { "binding": "AI" }
+}
+```
+
+**Note**: Workers AI always runs remotely and incurs usage charges even in local dev.
+
+---
+
+## Queues
+
+### Manage Queues
+
+```bash
+# Create queue
+wrangler queues create my-queue
+
+# List queues
+wrangler queues list
+
+# Delete queue
+wrangler queues delete my-queue
+
+# Add consumer to queue
+wrangler queues consumer add my-queue my-worker
+
+# Remove consumer
+wrangler queues consumer remove my-queue my-worker
+```
+
+### Config Binding
+
+```jsonc
+{
+  "queues": {
+    "producers": [
+      { "binding": "MY_QUEUE", "queue": "my-queue" }
+    ],
+    "consumers": [
+      {
+        "queue": "my-queue",
+        "max_batch_size": 10,
+        "max_batch_timeout": 30
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Containers
+
+### Build and Push Images
+
+```bash
+# Build container image
+wrangler containers build -t my-app:latest .
+
+# Build and push in one command
+wrangler containers build -t my-app:latest . --push
+
+# Push existing image to Cloudflare registry
+wrangler containers push my-app:latest
+```
+
+### Manage Containers
+
+```bash
+# List containers
+wrangler containers list
+
+# Get container info
+wrangler containers info <CONTAINER_ID>
+
+# Delete container
+wrangler containers delete <CONTAINER_ID>
+```
+
+### Manage Images
+
+```bash
+# List images in registry
+wrangler containers images list
+
+# Delete image
+wrangler containers images delete my-app:latest
+```
+
+### Manage External Registries
+
+> **Security**: Never hardcode registry credentials in commands. Use environment variables.
+
+```bash
+# List configured registries
+wrangler containers registries list
+
+# Configure external registry (e.g., ECR)
+wrangler containers registries configure <DOMAIN> \
+  --aws-access-key-id "$AWS_ACCESS_KEY_ID"
+
+# Configure DockerHub
+wrangler containers registries configure <DOMAIN> \
+  --dockerhub-username "$DOCKERHUB_USERNAME"
+
+# Delete registry configuration
+wrangler containers registries delete <DOMAIN>
+```
+
+---
+
+## Workflows
+
+### Manage Workflows
+
+```bash
+# List workflows
+wrangler workflows list
+
+# Describe workflow
+wrangler workflows describe my-workflow
+
+# Trigger workflow instance
+wrangler workflows trigger my-workflow
+
+# Trigger with parameters
+wrangler workflows trigger my-workflow --params '{"key": "value"}'
+
+# Delete workflow
+wrangler workflows delete my-workflow
+```
+
+### Manage Workflow Instances
+
+```bash
+# List instances
+wrangler workflows instances list my-workflow
+
+# Describe instance
+wrangler workflows instances describe my-workflow <INSTANCE_ID>
+
+# Terminate instance
+wrangler workflows instances terminate my-workflow <INSTANCE_ID>
+```
+
+### Config Binding
+
+```jsonc
+{
+  "workflows": [
+    {
+      "binding": "MY_WORKFLOW",
+      "name": "my-workflow",
+      "class_name": "MyWorkflow"
+    }
+  ]
+}
+```
+
+---
+
+## Pipelines
+
+### Manage Pipelines
+
+```bash
+# Create pipeline
+wrangler pipelines create my-pipeline --r2 my-bucket
+
+# List pipelines
+wrangler pipelines list
+
+# Show pipeline details
+wrangler pipelines show my-pipeline
+
+# Update pipeline
+wrangler pipelines update my-pipeline --batch-max-mb 100
+
+# Delete pipeline
+wrangler pipelines delete my-pipeline
+```
+
+### Config Binding
+
+```jsonc
+{
+  "pipelines": [
+    { "binding": "MY_PIPELINE", "pipeline": "my-pipeline" }
+  ]
+}
+```
+
+---
+
+## Secrets Store
+
+### Manage Stores
+
+```bash
+# Create store
+wrangler secrets-store store create my-store
+
+# List stores
+wrangler secrets-store store list
+
+# Delete store
+wrangler secrets-store store delete <STORE_ID>
+```
+
+### Manage Secrets in Store
+
+```bash
+# Add secret to store
+wrangler secrets-store secret put <STORE_ID> my-secret
+
+# List secrets in store
+wrangler secrets-store secret list <STORE_ID>
+
+# Get secret
+wrangler secrets-store secret get <STORE_ID> my-secret
+
+# Delete secret from store
+wrangler secrets-store secret delete <STORE_ID> my-secret
+```
+
+### Config Binding
+
+```jsonc
+{
+  "secrets_store_secrets": [
+    {
+      "binding": "MY_SECRET",
+      "store_id": "<STORE_ID>",
+      "secret_name": "my-secret"
+    }
+  ]
+}
+```
+
+---
+
+## Pages (Frontend Deployment)
+
+```bash
+# Create Pages project
+wrangler pages project create my-site
+
+# Deploy directory to Pages
+wrangler pages deploy ./dist
+
+# Deploy with specific branch
+wrangler pages deploy ./dist --branch main
+
+# List deployments
+wrangler pages deployment list --project-name my-site
+```
+
+---
+
+## Observability
+
+### Tail Logs
+
+```bash
+# Stream live logs
+wrangler tail
+
+# Tail specific Worker
+wrangler tail my-worker
+
+# Filter by status
+wrangler tail --status error
+
+# Filter by search term
+wrangler tail --search "error"
+
+# JSON output
+wrangler tail --format json
+```
+
+### Config Logging
+
+```jsonc
+{
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1
+  }
+}
+```
+
+---
+
+## Testing
+
+### Local Testing with Vitest
+
+```bash
+npm install -D @cloudflare/vitest-pool-workers vitest
+```
+
+`vitest.config.ts`:
+```typescript
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersConfig({
+  test: {
+    poolOptions: {
+      workers: {
+        wrangler: { configPath: "./wrangler.jsonc" },
+      },
+    },
+  },
+});
+```
+
+### Test Scheduled Events
+
+```bash
+# Enable in dev
+wrangler dev --test-scheduled
+
+# Trigger via HTTP
+curl http://localhost:8787/__scheduled
+```
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| `command not found: wrangler` | Install: `npm install -D wrangler` |
+| Auth errors | Run `wrangler login` |
+| Startup time limit exceeded | Run `wrangler check startup` to profile startup and generate CPU profiles |
+| Type errors after config change | Run `wrangler types` |
+| Local storage not persisting | Check `.wrangler/state` directory |
+| Binding undefined in Worker | Verify binding name matches config exactly |
+
+### Debug Commands
+
+```bash
+# Check auth status
+wrangler whoami
+
+# Profile Worker startup time
+wrangler check startup
+
+# View config schema
+wrangler docs configuration
+```
+
+---
+
+## Best Practices
+
+1. **Version control `wrangler.jsonc`**: Treat as source of truth for Worker config.
+2. **Use automatic provisioning**: Omit resource IDs for auto-creation on deploy.
+3. **Run `wrangler types` in CI**: Add to build step to catch binding mismatches.
+4. **Use environments**: Separate staging/production with `env.staging`, `env.production`.
+5. **Set `compatibility_date`**: Update quarterly to get new runtime features.
+6. **Use `.dev.vars` for local secrets**: Never commit secrets to config.
+7. **Test locally first**: `wrangler dev` with local bindings before deploying.
+8. **Use `--dry-run` before major deploys**: Validate changes without deployment.
+9. **Never embed secrets in commands**: Use interactive prompts (`wrangler secret put`), file-based input (`wrangler secret bulk`), or secure CI environment variables. Never echo, log, or pass secret values as CLI arguments.

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -34,6 +34,16 @@ jobs:
           curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location https://cli-assets.heroku.com/install.sh | bash
           heroku version
 
+      - name: Install Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+
+      - name: Install Wrangler
+        run: |
+          npm install --global --no-audit --no-fund wrangler@4.125.0
+          wrangler --version
+
       - name: Configure development environment
         run: |
           echo "SECRET_KEY=copilot-setup-key" >> "$GITHUB_ENV"

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ htmlcov/
 
 # Env
 .env
+.dev.vars
 
 # Local agent state
 .goals/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,9 @@
 ## Start here
 
 Run `make bootstrap` once after creating a clone or worktree. It installs locked
-dependencies and installs the pre-commit hooks. It first confirms that `uv` and
-the Heroku CLI are available; it does not install or authenticate either tool.
+dependencies and installs the pre-commit hooks. It first confirms that `uv`,
+the Heroku CLI, and Wrangler are available; it does not install or authenticate
+any tool.
 
 Run the development server with `make serve`. Linked worktrees automatically
 receive an available local port.
@@ -33,6 +34,19 @@ Copilot cloud agents receive `uv` and the Heroku CLI from
 `.github/workflows/copilot-setup-steps.yml`. Authentication remains
 user-provided. If a cloud agent needs authenticated Heroku access, use a
 `HEROKU_API_KEY` GitHub Copilot Agents secret, never repository data.
+
+Copilot cloud agents also receive Wrangler 4.125.0 from that setup workflow.
+For authenticated Cloudflare identity checks, add a least-privilege
+`CLOUDFLARE_API_TOKEN` Copilot Agents secret with **User Details: Read** and
+**Memberships: Read** permissions. Locally, run `wrangler login` or set that
+environment variable, then use `make cloudflare-check`. This check uses
+`wrangler whoami --json`; it does not need `CLOUDFLARE_ACCOUNT_ID` and must
+not be expanded into a deployment command until a target is chosen.
+
+The vendored Wrangler skill includes general installation advice. For this
+repository, do not install Wrangler from an agent or use `@latest`; run
+`make check-wrangler` and use the existing pinned 4.125.0 CLI instead. Local
+developers install it once outside the repository as documented in `README.md`.
 
 ## YAML content types
 

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,18 @@
 export UV_NO_ENV_FILE = 1
 
 HOMEBREW_BIN := $(shell for path in /opt/homebrew/bin /usr/local/bin; do test -x "$$path/brew" && { printf '%s' "$$path"; break; }; done)
-export PATH := $(HOME)/.local/bin:$(HOME)/.local/share/heroku/client/bin:$(HOMEBREW_BIN):$(PATH)
+WRANGLER_VERSION := 4.125.0
+export PATH := $(HOME)/.local/bin:$(HOME)/.local/share/heroku/client/bin:$(HOME)/.npm-global/bin:$(HOME)/.volta/bin:$(HOME)/.asdf/shims:$(HOME)/.fnm/current/bin:$(HOMEBREW_BIN):$(PATH)
 
-.PHONY: help bootstrap ci-bootstrap check-tools install hooks serve check test lint typecheck django-check fmt
+.PHONY: help bootstrap ci-bootstrap check-tools check-wrangler cloudflare-check install hooks serve check test lint typecheck django-check fmt
 
 help:
 	@echo "Available targets:"
 	@echo "  bootstrap  Check developer tools, then prepare dependencies and hooks"
 	@echo "  ci-bootstrap  Prepare dependencies for CI"
-	@echo "  check-tools  Confirm uv and the Heroku CLI are available"
+	@echo "  check-tools  Confirm uv, the Heroku CLI, and Wrangler are available"
+	@echo "  check-wrangler  Confirm Wrangler is available"
+	@echo "  cloudflare-check  Show the authenticated Cloudflare account"
 	@echo "  install    Install all dependencies without changing Git hooks"
 	@echo "  hooks      Install pre-commit hooks"
 	@echo "  serve      Start the development server"
@@ -22,37 +25,47 @@ help:
 	@echo "  fmt        Auto-format with Ruff"
 
 install:
-	uv sync --locked --group dev
+	@"$$(command -v uv)" sync --locked --group dev
 
 hooks:
-	uv run pre-commit install
+	@"$$(command -v uv)" run pre-commit install
 
 check-tools:
 	@command -v uv > /dev/null || { echo "uv is required. Install it from https://docs.astral.sh/uv/getting-started/installation/" >&2; exit 1; }
 	@command -v heroku > /dev/null || { echo "The Heroku CLI is required. Install it from https://devcenter.heroku.com/articles/heroku-cli#install-the-heroku-cli" >&2; exit 1; }
+	@$(MAKE) --no-print-directory check-wrangler
+
+check-wrangler:
+	@command -v wrangler > /dev/null || { echo "Wrangler is required. Install version $(WRANGLER_VERSION) with: npm install --global wrangler@$(WRANGLER_VERSION)" >&2; exit 1; }
+	@"$$(command -v wrangler)" --version
+	@version="$$("$$(command -v wrangler)" --version | awk 'match($$0, /[0-9]+\.[0-9]+\.[0-9]+/) { print substr($$0, RSTART, RLENGTH); exit }')"; \
+	test "$$version" = "$(WRANGLER_VERSION)" || { echo "Wrangler $(WRANGLER_VERSION) is required. Found $${version:-an unrecognized version}. Install it with: npm install --global wrangler@$(WRANGLER_VERSION)" >&2; exit 1; }
+
+cloudflare-check: check-wrangler
+	@"$$(command -v wrangler)" whoami --json || { echo "Cloudflare authentication failed. Run 'wrangler login' locally or set CLOUDFLARE_API_TOKEN." >&2; exit 1; }
 
 bootstrap: check-tools install hooks
 
 ci-bootstrap: install
 
 serve:
-	uv run python -m scripts.worktree serve
+	@"$$(command -v uv)" run python -m scripts.worktree serve
 
 check: lint typecheck django-check test
 
 test:
-	uv run pytest tests/
+	@"$$(command -v uv)" run pytest tests/
 
 lint:
-	uv run ruff check .
-	uv run ruff format --check .
+	@"$$(command -v uv)" run ruff check .
+	@"$$(command -v uv)" run ruff format --check .
 
 typecheck:
-	uv run ty check --exit-zero-on-warning .
+	@"$$(command -v uv)" run ty check --exit-zero-on-warning .
 
 django-check:
-	uv run python manage.py check
+	@"$$(command -v uv)" run python manage.py check
 
 fmt:
-	uv run ruff check --fix .
-	uv run ruff format .
+	@"$$(command -v uv)" run ruff check --fix .
+	@"$$(command -v uv)" run ruff format .

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Ben Welsh's personal site — a Django blog and portfolio at [palewi.re](https:/
 - Python 3.12
 - [uv](https://docs.astral.sh/uv/) for package management
 - [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli) for local setup and Heroku commands
+- [Wrangler 4.125.0](https://developers.cloudflare.com/workers/wrangler/install-and-update/) for Cloudflare account checks
 
 ## Setup
 
@@ -22,10 +23,17 @@ make bootstrap
 make serve
 ```
 
-`make bootstrap` checks both commands before it installs anything. For its
+`make bootstrap` checks these commands before it installs anything. For its
 commands, it also adds common user installation paths including
-`$HOME/.local/bin`, Heroku's user client directory, and a detected Homebrew
-bin directory. It does not install either command or authenticate with Heroku.
+`$HOME/.local/bin`, Heroku's user client directory, npm's user directory,
+Volta, asdf, fnm, and a detected Homebrew bin directory. It does not install
+or authenticate any command.
+
+Install Wrangler once with:
+
+```bash
+npm install --global wrangler@4.125.0
+```
 
 Open the URL printed by the server. Linked Git worktrees automatically use
 available local ports, so multiple agents can run the site at the same time.
@@ -100,6 +108,28 @@ official installer in `.github/workflows/copilot-setup-steps.yml`. Authenticatio
 is not part of repository setup. For a cloud agent that must run authenticated
 Heroku commands, add `HEROKU_API_KEY` as a GitHub Copilot Agents secret; never
 store it in this repository.
+
+## Cloudflare access
+
+Cloudflare access is limited to the non-destructive identity check:
+
+```bash
+make cloudflare-check
+```
+
+For local use, authenticate interactively with `wrangler login`, then run the
+check. In non-interactive environments, set `CLOUDFLARE_API_TOKEN` in the
+environment instead. Do not commit tokens or add them to `.env` files.
+
+For a Copilot cloud-agent session, create a **user API token** with only
+**User > User Details > Read** and **User > Memberships > Read**, then save it
+as the `CLOUDFLARE_API_TOKEN` GitHub Copilot Agents secret. Restrict and expire
+the token as your Cloudflare account allows. `wrangler whoami` does not need
+`CLOUDFLARE_ACCOUNT_ID`, so do not add that secret or variable yet.
+
+The cloud-agent setup installs the pinned Wrangler version on each fresh
+runner. Local setup only finds an existing CLI. This repository does not
+configure or deploy Cloudflare DNS, zones, Pages, or Workers.
 
 For the database retirement deployment, take a fresh Heroku backup first. Deploy
 the exact merged SHA, then verify `/health/`, the main pages, all post


### PR DESCRIPTION
## Summary
- vendor Cloudflare's official Wrangler skill with Apache-2.0 attribution
- pin Wrangler 4.125.0 for Copilot cloud-agent setup and require the same local version
- document and add safe Cloudflare identity checks without deployment configuration

## Validation
- `make check`
- simulated local bootstrap and Cloudflare authentication success/failure paths