### PR TITLE
Raise coverage and type-checking gates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ lint:
 	@"$$(command -v uv)" run ruff format --check .
 
 typecheck:
-	@"$$(command -v uv)" run ty check --exit-zero-on-warning .
+	@"$$(command -v uv)" run ty check .
 
 django-check:
 	@"$$(command -v uv)" run python manage.py check

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ make check
 ```
 
 This runs Ruff linting and formatting checks, ty static analysis, Django's
-system check, and the full pytest suite. CI uses the same Make targets.
+system check, and the full pytest suite. Coverage measures application and
+maintenance source code (not tests) and must be at least 90%, raised from 40%.
+CI uses the same Make targets.
 
 To auto-format code:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,10 @@ quote-style = "double"
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "project.settings"
 python_files = ["tests.py", "test_*.py"]
-addopts = "--cov=. --cov-report=term-missing --cov-fail-under=40"
+addopts = "--cov --cov-report=term-missing --cov-fail-under=90"
 
 [tool.coverage.run]
+source = ["coltrane", "project", "scripts", "toolbox"]
 omit = [
     "*/migrations/*",
     "*/staticfiles/*",
@@ -60,13 +61,13 @@ omit = [
 show_missing = true
 
 [tool.ty]
-# Django uses many dynamic attributes (get_FOO_display, .objects, etc.) that
-# ty cannot statically resolve. We treat those categories as warnings rather
-# than errors so ty still catches real new mistakes in our own code.
+# Django uses dynamic attributes (such as ``.objects``) that ty cannot resolve
+# in every case. Treat the known framework gaps as errors too, so the check
+# cannot pass with diagnostics.
 [tool.ty.rules]
-unresolved-attribute = "warn"
-invalid-argument-type = "warn"
-invalid-assignment = "warn"
-invalid-method-override = "warn"
-no-matching-overload = "warn"
-unresolved-import = "warn"
+unresolved-attribute = "error"
+invalid-argument-type = "error"
+invalid-assignment = "error"
+invalid-method-override = "error"
+no-matching-overload = "error"
+unresolved-import = "error"

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1,5 +1,6 @@
 """Tests for YAML content loading."""
 
+import datetime
 from pathlib import Path
 
 import pytest
@@ -11,6 +12,7 @@ from coltrane.content_loaders import (
     load_bots,
     load_clips,
     load_docs,
+    load_posts,
     load_slogans,
     load_talks,
     random_slogan,
@@ -117,6 +119,13 @@ def test_clip_bad_date_raises(tmp_path):
     p.write_text("clips:\n  - title: T\n    type: story\n    date: 'not-a-date'\n    url: http://x.com\n")
     with pytest.raises(ContentError, match="date"):
         load_clips(p)
+
+
+def test_clip_accepts_yaml_date_values(tmp_path):
+    p = tmp_path / "clips.yaml"
+    p.write_text("clips:\n  - title: T\n    type: story\n    date: 2024-01-01\n    url: http://x.com\n")
+
+    assert load_clips(p)[0].date == datetime.date(2024, 1, 1)
 
 
 def test_clips_empty_list_ok(tmp_path):
@@ -317,7 +326,110 @@ def test_bots_invalid_mastodon_url_raises(tmp_path):
         load_bots(p)
 
 
+def test_bots_invalid_twitter_url_raises(tmp_path):
+    p = tmp_path / "bots.yaml"
+    p.write_text("bots:\n  - title: '@X'\n    mastodon_url: 'https://example.com/@x'\n    twitter_url: 'not-a-url'\n")
+    with pytest.raises(ContentError, match="URL"):
+        load_bots(p)
+
+
 def test_bots_empty_list_ok(tmp_path):
     p = tmp_path / "bots.yaml"
     p.write_text("bots: []\n")
     assert load_bots(p) == []
+
+
+@pytest.mark.parametrize(
+    ("loader", "key"),
+    [
+        (load_awards, "awards"),
+        (load_clips, "clips"),
+        (load_talks, "talks"),
+        (load_docs, "docs"),
+        (load_slogans, "slogans"),
+        (load_bots, "bots"),
+    ],
+)
+def test_yaml_loaders_reject_invalid_top_level_and_records(tmp_path, loader, key):
+    path = tmp_path / f"{key}.yaml"
+    path.write_text("- not-a-mapping\n")
+    with pytest.raises(ContentError, match="top-level structure"):
+        loader(path)
+
+    path.write_text(f"{key}: not-a-list\n")
+    with pytest.raises(ContentError, match="must be a list"):
+        loader(path)
+
+    path.write_text(f"{key}:\n  - not-a-mapping\n")
+    with pytest.raises(ContentError, match="must be a mapping"):
+        loader(path)
+
+
+def test_optional_content_fields_validate_their_types(tmp_path):
+    path = tmp_path / "awards.yaml"
+    path.write_text("awards:\n  - title: A\n    url: 123\n")
+    with pytest.raises(ContentError, match="must be a string"):
+        load_awards(path)
+
+    path.write_text("awards:\n  - title: A\n    url: null\n")
+    assert load_awards(path)[0].url == ""
+
+
+def test_markdown_post_loader_validates_all_front_matter_edges(tmp_path):
+    missing_directory = tmp_path / "missing"
+    with pytest.raises(ContentError, match="does not exist"):
+        load_posts(missing_directory)
+
+    post = tmp_path / "post.md"
+    post.write_text("<p>Missing front matter</p>", encoding="utf-8")
+    with pytest.raises(ContentError, match="must begin"):
+        load_posts(tmp_path)
+
+    post.write_text("---\ntitle: Example\n", encoding="utf-8")
+    with pytest.raises(ContentError, match="not closed"):
+        load_posts(tmp_path)
+
+    post.write_text("---\ninvalid: [\n---\n<p>Body</p>", encoding="utf-8")
+    with pytest.raises(ContentError, match="invalid YAML"):
+        load_posts(tmp_path)
+
+    post.write_text("---\n- not-a-mapping\n---\n<p>Body</p>", encoding="utf-8")
+    with pytest.raises(ContentError, match="must be a mapping"):
+        load_posts(tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("front_matter", "message"),
+    [
+        ("title: Example\nslug: bad slug\npublished_at: '2025-01-01T12:00:00-08:00'", "slug"),
+        ("title: Example\nslug: example\npublished_at: '2025-01-01T12:00:00'", "timezone"),
+        ("title: Example\nslug: example\npublished_at: not-a-datetime", "ISO 8601"),
+        ("title: Example\nslug: example\npublished_at: '2025-01-01T12:00:00-08:00'\nwordpress_id: 0", "positive"),
+    ],
+)
+def test_markdown_post_loader_rejects_invalid_fields(tmp_path, front_matter, message):
+    post = tmp_path / "post.md"
+    post.write_text(f"---\n{front_matter}\n---\n<p>Body</p>", encoding="utf-8")
+
+    with pytest.raises(ContentError, match=message):
+        load_posts(tmp_path)
+
+
+def test_markdown_post_loader_accepts_yaml_dates_and_optional_values(tmp_path):
+    post = tmp_path / "post.md"
+    post.write_text(
+        "---\n"
+        "title: Example\n"
+        "slug: example\n"
+        "published_at: '2025-01-01T12:00:00-08:00'\n"
+        "repr_image: null\n"
+        "---\n"
+        "<p>Body</p>",
+        encoding="utf-8",
+    )
+
+    loaded_post = load_posts(tmp_path)[0]
+    assert loaded_post.published_at == datetime.datetime(
+        2025, 1, 1, 12, tzinfo=datetime.timezone(datetime.timedelta(hours=-8))
+    )
+    assert loaded_post.repr_image == ""

--- a/tests/test_export_posts.py
+++ b/tests/test_export_posts.py
@@ -1,0 +1,104 @@
+"""Tests for the one-time, private post-export utility."""
+
+from collections import Counter
+from datetime import UTC, datetime
+
+import pytest
+
+from scripts.export_posts import (
+    EXPECTED_COUNTS,
+    LIVE_STATUS,
+    ExportedPost,
+    load_posts,
+    replace_private_archive,
+    validate_posts,
+    write_public_posts,
+)
+
+
+def make_post(
+    post_id: int,
+    *,
+    status: int = LIVE_STATUS,
+    slug: str | None = None,
+    body_markup: str = "<p>Body</p>",
+) -> ExportedPost:
+    """Create a post matching the old database export shape."""
+    return ExportedPost(
+        id=post_id,
+        wordpress_id=post_id,
+        title=f"Post {post_id}",
+        slug=slug or f"post-{post_id}",
+        body_markup=body_markup,
+        body_html=None,
+        pub_date=datetime(2025, 1, 1, 12, tzinfo=UTC),
+        author_id=1,
+        status=status,
+        repr_image="",
+    )
+
+
+def test_load_posts_reads_valid_csv_and_rejects_invalid_exports(tmp_path):
+    csv_path = tmp_path / "posts.csv"
+    csv_path.write_text(
+        "id,wordpress_id,title,slug,body_markup,body_html,pub_date,author_id,status,repr_image\n"
+        '1,,Example,example,"<p>Body</p>",,2025-01-01T12:00:00+00:00,1,1,\n',
+        encoding="utf-8",
+    )
+
+    posts = load_posts(csv_path)
+
+    assert posts[0].id == 1
+    assert posts[0].wordpress_id is None
+    assert posts[0].title == "Example"
+    assert posts[0].slug == "example"
+
+    csv_path.write_text("id,title\n1,Example\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="unexpected CSV columns"):
+        load_posts(csv_path)
+
+    csv_path.write_text(
+        "id,wordpress_id,title,slug,body_markup,body_html,pub_date,author_id,status,repr_image\n"
+        '1,,Example,example,"<p>Body</p>",,2025-01-01T12:00:00,1,1,\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="timezone"):
+        load_posts(csv_path)
+
+
+def test_validate_posts_accepts_expected_inventory_and_rejects_duplicates():
+    posts = [
+        *(make_post(post_id) for post_id in range(1, EXPECTED_COUNTS[LIVE_STATUS] + 1)),
+        *(
+            make_post(post_id, status=2)
+            for post_id in range(EXPECTED_COUNTS[LIVE_STATUS] + 1, sum(EXPECTED_COUNTS.values()) + 1)
+        ),
+    ]
+
+    assert validate_posts(posts) == Counter(EXPECTED_COUNTS)
+
+    with pytest.raises(ValueError, match="unexpected status counts"):
+        validate_posts(posts[:-1])
+
+    duplicate_slug_posts = [*posts]
+    duplicate_slug_posts[1] = make_post(2, slug=duplicate_slug_posts[0].slug)
+    with pytest.raises(ValueError, match="duplicate publication-date/slug keys"):
+        validate_posts(duplicate_slug_posts)
+
+
+def test_export_writes_verified_private_and_public_artifacts(tmp_path):
+    posts = [make_post(1, body_markup='<pre lang="python">print("hello")</pre>'), make_post(2, status=2)]
+    counts = Counter(post.status for post in posts)
+    archive_path = tmp_path / "archive"
+    content_path = tmp_path / "content"
+    source_csv = tmp_path / "source.csv"
+    source_csv.write_text("source", encoding="utf-8")
+
+    replace_private_archive(posts, counts, archive_path, source_csv)
+    write_public_posts([post for post in posts if post.status == LIVE_STATUS], content_path)
+
+    assert (archive_path / "posts" / "1.json").exists()
+    assert (archive_path / "archive-manifest.json").exists()
+    assert not (archive_path.parent / ".archive.backup").exists()
+    assert (content_path / "posts" / "2025-01-01--post-1.md").exists()
+    assert '"post_count": 1' in (content_path / "posts-manifest.json").read_text(encoding="utf-8")

--- a/tests/test_worktree_script.py
+++ b/tests/test_worktree_script.py
@@ -1,0 +1,51 @@
+"""Tests for the worktree-aware development server command."""
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from scripts import worktree
+
+
+def test_run_server_reports_port_claims(monkeypatch: pytest.MonkeyPatch):
+    class Process:
+        stderr = iter(["Watching for file changes\n", "Error: That port is already in use.\n"])
+
+        def wait(self):
+            return 1
+
+    monkeypatch.setattr(worktree.subprocess, "Popen", lambda *args, **kwargs: Process())
+
+    assert worktree.run_server(8123) == (1, True)
+
+
+def test_serve_retries_when_port_is_claimed(monkeypatch: pytest.MonkeyPatch):
+    ports = iter([8100, 8101])
+    attempts: list[int] = []
+
+    def select_port(root: Path, excluded: set[int]) -> int:
+        assert root == worktree.ROOT
+        return next(ports)
+
+    def run_server(port: int) -> tuple[int, bool]:
+        attempts.append(port)
+        return (1, True) if port == 8100 else (0, False)
+
+    monkeypatch.setattr(worktree, "available_port", select_port)
+    monkeypatch.setattr(worktree, "run_server", run_server)
+
+    result = CliRunner().invoke(worktree.cli, ["serve"])
+
+    assert result.exit_code == 0
+    assert attempts == [8100, 8101]
+    assert "retrying" in result.output
+
+
+def test_serve_reports_when_no_ports_are_available(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(worktree, "available_port", lambda *_: (_ for _ in ()).throw(RuntimeError("No available port")))
+
+    result = CliRunner().invoke(worktree.cli, ["serve"])
+
+    assert result.exit_code == 1
+    assert "No available port" in result.output


### PR DESCRIPTION
## Summary
- measure coverage only for application and maintenance source code, then raise the required floor from 40% to 90%
- add regression coverage for YAML/Markdown validation, private post export artifacts, and the worktree-aware server launcher
- make ty diagnostics fatal, promote configured rules to errors, and fix the remaining highlighter diagnostic

## Quality gates
- previous configured coverage threshold: 40% (83.86% measured while test files were included)
- source-only baseline before this change: 75.00%
- new configured coverage threshold: 90%
- measured source-only coverage: 92.55% (150 passed, 2 skipped)
- ty diagnostics: 1 warning before; 0 diagnostics after
- independent code review: no significant issues found

Closes #366