### PR TITLE
Adopt timezone-aware publication dates

### DIFF
--- a/coltrane/content_loaders.py
+++ b/coltrane/content_loaders.py
@@ -56,6 +56,7 @@ from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import yaml
+from django.utils import timezone
 
 CONTENT_PATH = Path(__file__).resolve().parent / "content"
 
@@ -198,9 +199,11 @@ def _require_los_angeles_datetime(record: dict, field_name: str, path: str) -> d
         parsed = datetime.datetime.fromisoformat(value)
     except ValueError as error:
         raise ContentError(f"{path}: field '{field_name}' must be an ISO 8601 datetime") from error
-    if parsed.tzinfo is None:
+    if not timezone.is_aware(parsed):
         raise ContentError(f"{path}: field '{field_name}' must include a timezone offset")
     los_angeles_time = parsed.astimezone(LOS_ANGELES)
+    # This round trip rejects invalid spring-forward wall times while retaining
+    # the supplied offset that distinguishes either fall-back occurrence.
     if (
         parsed.replace(tzinfo=None) != los_angeles_time.replace(tzinfo=None)
         or parsed.utcoffset() != los_angeles_time.utcoffset()

--- a/coltrane/utils/pygmenter.py
+++ b/coltrane/utils/pygmenter.py
@@ -6,7 +6,7 @@ import functools
 
 from bs4 import BeautifulSoup
 from pygments import highlight
-from pygments.formatters import HtmlFormatter
+from pygments.formatters.html import HtmlFormatter
 from pygments.lexers import LEXERS, get_lexer_by_name
 
 # a tuple of known lexer names
@@ -31,13 +31,15 @@ def pygmenter(raw_html):
     markdown.pl from John Gruber - have shown that the inner HTML of the
     ``<code>`` tag is not immune to translation.
     """
-    soup = BeautifulSoup(raw_html)
-    for tag in soup.findAll("pre"):
-        lexer_name = tag.get("lang").lower()
-        linenos = tag.get("linenos", False) or False
-        _formatter = HtmlFormatter(cssclass="source", linenos=linenos)
+    soup = BeautifulSoup(raw_html, "html.parser")
+    for tag in soup.find_all("pre"):
+        lexer_name = tag.get("lang")
+        if not isinstance(lexer_name, str):
+            continue
+        _formatter = HtmlFormatter(cssclass="source", linenos=bool(tag.get("linenos")))
+        lexer_name = lexer_name.lower()
         if lexer_name and lexer_name in _lexer_names:
             lexer = get_lexer_by_name(lexer_name, stripnl=True, encoding="UTF-8")
-            tag.replaceWith(highlight(tag.renderContents(), lexer, _formatter))
+            tag.replace_with(highlight(tag.encode_contents(), lexer, _formatter))
 
     return str(soup)

--- a/coltrane/views.py
+++ b/coltrane/views.py
@@ -1,7 +1,4 @@
-import datetime
-
-# Time
-import time
+from datetime import date
 from functools import lru_cache
 from pathlib import Path
 
@@ -66,8 +63,10 @@ def post_detail(request, year, month, day, slug):
     """
     A detail page that shows an entire post.
     """
-    date_stamp = time.strptime(year + month + day, "%Y%m%d")
-    pub_date = datetime.date(*date_stamp[:3])
+    try:
+        pub_date = date.fromisoformat(f"{year}-{month}-{day}")
+    except ValueError as error:
+        raise Http404 from error
     post = next(
         (
             candidate

--- a/project/settings.py
+++ b/project/settings.py
@@ -40,7 +40,7 @@ STATICFILES_FINDERS = [
 ]
 
 TIME_ZONE = "America/Los_Angeles"
-USE_TZ = False
+USE_TZ = True
 LANGUAGE_CODE = "en-us"
 USE_I18N = True
 

--- a/tests/test_context_processors.py
+++ b/tests/test_context_processors.py
@@ -1,9 +1,19 @@
 """Tests for shared template context."""
 
 import subprocess
+from datetime import UTC
 from unittest.mock import patch
 
-from toolbox.context_processors import REPOSITORY_URL, _main_commit, repository
+from django.utils import timezone
+
+from toolbox.context_processors import REPOSITORY_URL, _main_commit, now, repository
+
+
+def test_now_is_timezone_aware():
+    context_now = now(None)["now"]
+
+    assert timezone.is_aware(context_now)
+    assert context_now.tzinfo == UTC
 
 
 def test_repository_uses_heroku_commit():

--- a/tests/test_file_backed_posts.py
+++ b/tests/test_file_backed_posts.py
@@ -69,7 +69,7 @@ def test_post_detail_keeps_representative_image_metadata(client, public_posts):
 
 
 def test_feed_uses_latest_ten_file_backed_posts(client, public_posts):
-    """The feed has the same newest-first ten-post selection as the old queryset."""
+    """The feed retains the published newest-first ten-post selection."""
     response = client.get("/feeds/posts/")
     root = xml.fromstring(response.content)
     items = root.findall("./channel/item")
@@ -79,6 +79,7 @@ def test_feed_uses_latest_ten_file_backed_posts(client, public_posts):
     assert [item.findtext("link") for item in items] == [
         f"http://testserver{post.get_absolute_url()}" for post in public_posts[:10]
     ]
+    assert [item.findtext("pubDate") for item in items] == [None] * 10
 
 
 def test_sitemap_lists_every_file_backed_post_with_publication_date(client, public_posts):
@@ -100,5 +101,11 @@ def test_sitemap_lists_every_file_backed_post_with_publication_date(client, publ
 def test_unknown_post_permalink_returns_not_found(client):
     """A URL absent from the public files retains the legacy 404 behavior."""
     response = client.get("/posts/2026/01/01/not-a-public-post/")
+
+    assert response.status_code == 404
+
+
+def test_invalid_calendar_date_returns_not_found(client):
+    response = client.get("/posts/2025/02/30/example/")
 
     assert response.status_code == 404

--- a/tests/test_markdown_posts.py
+++ b/tests/test_markdown_posts.py
@@ -3,11 +3,13 @@
 import hashlib
 import json
 import re
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import pytest
+from django.conf import settings
+from django.utils import timezone
 
 from coltrane.content_loaders import ContentError, load_posts
 from coltrane.utils.pygmenter import pygmenter
@@ -67,9 +69,14 @@ def test_markdown_posts_keep_los_angeles_publication_datetimes():
     manifest_by_permalink = {entry["permalink"]: entry for entry in load_manifest()["posts"]}
     for post in load_posts():
         expected = datetime.fromisoformat(manifest_by_permalink[post.get_absolute_url()]["published_at"])
+        assert timezone.is_aware(post.published_at)
         assert post.published_at.tzinfo == LOS_ANGELES
         assert post.published_at == expected
         assert post.get_absolute_url().startswith(f"/posts/{post.published_at:%Y/%m/%d}/")
+
+
+def test_django_uses_timezone_aware_datetimes():
+    assert settings.USE_TZ is True
 
 
 def test_markdown_posts_preserve_legacy_pre_lang_markup():
@@ -87,6 +94,48 @@ def test_markdown_post_requires_los_angeles_datetime(tmp_path):
     post_path = tmp_path / "post.md"
     post_path.write_text(
         "---\ntitle: Example\nslug: example\npublished_at: '2025-01-01T20:00:00+00:00'\n---\n<p>Body</p>",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ContentError, match="America/Los_Angeles"):
+        load_posts(tmp_path)
+
+
+def test_markdown_post_requires_an_aware_datetime(tmp_path):
+    post_path = tmp_path / "post.md"
+    post_path.write_text(
+        "---\ntitle: Example\nslug: example\npublished_at: '2025-01-01T12:00:00'\n---\n<p>Body</p>",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ContentError, match="timezone offset"):
+        load_posts(tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("published_at", "fold", "utc_time"),
+    [
+        ("2025-11-02T01:30:00-07:00", 0, "2025-11-02T08:30:00+00:00"),
+        ("2025-11-02T01:30:00-08:00", 1, "2025-11-02T09:30:00+00:00"),
+    ],
+)
+def test_markdown_post_preserves_each_ambiguous_los_angeles_time(tmp_path, published_at, fold, utc_time):
+    post_path = tmp_path / "post.md"
+    post_path.write_text(
+        f"---\ntitle: Example\nslug: example\npublished_at: '{published_at}'\n---\n<p>Body</p>",
+        encoding="utf-8",
+    )
+
+    post = load_posts(tmp_path)[0]
+
+    assert post.published_at.fold == fold
+    assert post.published_at.astimezone(UTC).isoformat() == utc_time
+
+
+def test_markdown_post_rejects_nonexistent_los_angeles_time(tmp_path):
+    post_path = tmp_path / "post.md"
+    post_path.write_text(
+        "---\ntitle: Example\nslug: example\npublished_at: '2025-03-09T02:30:00-08:00'\n---\n<p>Body</p>",
         encoding="utf-8",
     )
 

--- a/toolbox/context_processors.py
+++ b/toolbox/context_processors.py
@@ -2,9 +2,10 @@ import logging
 import os
 import re
 import subprocess
-from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
+
+from django.utils import timezone
 
 logger = logging.getLogger(__name__)
 REPOSITORY_URL = "https://github.com/palewire/palewi.re"
@@ -20,7 +21,7 @@ def current_site(_request):
 
 
 def now(request):
-    return {"now": datetime.now()}
+    return {"now": timezone.now()}
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
## Summary
- enable Django timezone support with `America/Los_Angeles` publication semantics
- keep post instants offset-aware, reject naive and nonexistent local timestamps, and preserve both fall-back instants
- preserve the 72 post files, calendar URLs, ordering, feed shape, date-only sitemap output, and rendered timestamps
- use an aware template clock and remove legacy HTML parser runtime warnings

## Validation
- `make check`
- focused post, feed, sitemap, timezone, context, and view tests
- independent code review: no findings

## Issue note
The live [#364](https://github.com/palewire/palewi.re/issues/364) is a separate quality-gate issue, so this PR intentionally does not close it.