### PR TITLE
Simplify Django plumbing

### DIFF
--- a/coltrane/templates/coltrane/base.html
+++ b/coltrane/templates/coltrane/base.html
@@ -1,4 +1,4 @@
-{% load sass_tags %}<!doctype html>
+{% load sass_tags static %}<!doctype html>
 <html lang="en"
       xmlns:rnews="http://iptc.org/std/rNews/2011-05-17#"
       xmlns:og="http://ogp.me/ns#" {% block extrahtmlattrs %}{% endblock %}>
@@ -13,7 +13,7 @@
         <meta name="theme-color" content="#ffffff" />
         <meta name="color-scheme" content="light" />
 
-        <link rel="icon" href="{{ STATIC_URL }}favicon.ico" />
+        <link rel="icon" href="{% static 'favicon.ico' %}" />
 
         <meta name="author" content="Ben Welsh" />
         <meta name="description" content="{% block description %}Blog. Editor and Proprietor Ben Welsh.{% endblock %}" />
@@ -35,7 +35,7 @@
         <meta property="og:description" content="{% block ogdescription %}Blog. Editor and Publisher Ben Welsh.{% endblock %}"/>
         <meta property="og:url" content="{% block ogurl %}https://palewi.re/{% endblock %}"/>
         <meta property="og:locale" content="{% block oglocale %}en_US{% endblock %}"/>
-        <meta property="og:image" content="{% block ogimage %}https://palewi.re/static/img/facebook-icon.png{% endblock %}"/>
+        <meta property="og:image" content="{% block ogimage %}https://palewi.re{% static 'img/facebook-icon.png' %}{% endblock %}"/>
         {% endblock %}
 
         {% block twittermeta %}
@@ -43,7 +43,7 @@
         <meta name="twitter:title" content="{% block twittertitle %}palewire{% endblock %}" />
         <meta name="twitter:description" content="{% block twitterdescription %}Blog. Editor and Proprietor Ben Welsh.{% endblock %}" />
         <meta name="twitter:url" content="{% block twitterurl %}https://palewi.re/{% endblock %}" />
-        <meta name="twitter:image" content="{% block twitterimage %}https://palewi.re/static/img/facebook-icon.png{% endblock %}" />
+        <meta name="twitter:image" content="{% block twitterimage %}https://palewi.re{% static 'img/facebook-icon.png' %}{% endblock %}" />
         <meta name="twitter:site" content="@palewire" />
         <meta name="twitter:creator" content="@palewire" />
         {% endblock %}
@@ -62,7 +62,7 @@
             "name": "{% block googleheadline %}palewire{% endblock %}",
             "description": "{% block googledescription %}Blog. Editor and Publisher Ben Welsh.{% endblock %}",
             "inLanguage": "en-US",
-            "image": "https://palewi.re/static/img/facebook-icon.png"
+            "image": "https://palewi.re{% static 'img/facebook-icon.png' %}"
         }
         </script>
         <script type="application/ld+json">
@@ -71,7 +71,7 @@
             "@type": "Organization",
             "name": "palewire",
             "url": "https://palewi.re/",
-            "logo": "https://palewi.re/static/img/facebook-icon.png",
+            "logo": "https://palewi.re{% static 'img/facebook-icon.png' %}",
             "sameAs": [
                 "https://mastodon.palewi.re/@palewire"
             ]
@@ -111,7 +111,7 @@
         <footer>
             <div id="ft" class="row">
                 <div class="twelvecol last">
-                    <span property="rnews:copyrightNotice">© <span property="rnews:copyrightYear">{{ now|date:"Y" }}</span> palewire</span>
+                    <span property="rnews:copyrightNotice">© <span property="rnews:copyrightYear">{% now "Y" %}</span> palewire</span>
                     {% if repository_commit %}
                     <a class="footer-commit"
                        href="{{ repository_url }}/commit/{{ repository_commit }}"

--- a/coltrane/templates/coltrane/bio.html
+++ b/coltrane/templates/coltrane/bio.html
@@ -3,18 +3,18 @@
 
 {% block title %}who is ben welsh? . {{ block.super }}{% endblock %}
 
-{% block canonicalurl %}https://{{ current_site }}/who-is-ben-welsh/{% endblock %}
+{% block canonicalurl %}https://palewi.re/who-is-ben-welsh/{% endblock %}
 
 {% block ogtitle %}Who is Ben Welsh?{% endblock %}
 {% block ogtype %}profile{% endblock %}
-{% block ogurl %}https://{{ current_site }}/who-is-ben-welsh/{% endblock %}
+{% block ogurl %}https://palewi.re/who-is-ben-welsh/{% endblock %}
 {% block ogdescription %}hello.{% endblock %}
 
 {% block twittertitle %}Who is Ben Welsh?{% endblock %}
 {% block twitterdescription %}hello.{% endblock %}
-{% block twitterurl %}https://{{ current_site }}/who-is-ben-welsh/{% endblock %}
+{% block twitterurl %}https://palewi.re/who-is-ben-welsh/{% endblock %}
 
-{% block googleurl %}https://{{ current_site }}/who-is-ben-welsh/{% endblock %}
+{% block googleurl %}https://palewi.re/who-is-ben-welsh/{% endblock %}
 {% block googleheadline %}who is ben welsh?{% endblock %}
 {% block googledescription %}hello.{% endblock %}
 {% block googlecreated %}2019-11-10T00:00:00{% endblock %}
@@ -28,8 +28,8 @@
             "@context": "https://schema.org",
             "@type": "Person",
             "name": "Ben Welsh",
-            "url": "https://{{ current_site }}/who-is-ben-welsh/",
-            "image": "https://{{ current_site }}{% static 'img/ben-blue-800.jpg' %}",
+            "url": "https://palewi.re/who-is-ben-welsh/",
+            "image": "https://palewi.re{% static 'img/ben-blue-800.jpg' %}",
             "sameAs": [
                 {% for obj in socialmedia_list %}"{{ obj.url }}"{% if not forloop.last %}, {% endif %}{% endfor %}
             ]

--- a/coltrane/templates/coltrane/bot_list.html
+++ b/coltrane/templates/coltrane/bot_list.html
@@ -2,16 +2,16 @@
 
 {% block title %}bots . {{ block.super }}{% endblock %}
 
-{% block canonicalurl %}https://{{ current_site }}/bots/{% endblock %}
+{% block canonicalurl %}https://palewi.re/bots/{% endblock %}
 
 {% block ogtitle %}bots{% endblock %}
 {% block ogtype %}website{% endblock %}
-{% block ogurl %}https://{{ current_site }}/bots/{% endblock %}
+{% block ogurl %}https://palewi.re/bots/{% endblock %}
 {% block ogdescription %}My fleet of automated accounts.{% endblock %}
 
 {% block twittertitle %}bots{% endblock %}
 {% block twitterdescription %}My fleet of automated accounts.{% endblock %}
-{% block twitterurl %}https://{{ current_site }}/bots/{% endblock %}
+{% block twitterurl %}https://palewi.re/bots/{% endblock %}
 
 {% block extrameta %}
     {{ block.super }}
@@ -21,7 +21,7 @@
     {% endfor %}
 {% endblock %}
 
-{% block googleurl %}https://{{ current_site }}/bots/{% endblock %}
+{% block googleurl %}https://palewi.re/bots/{% endblock %}
 {% block googleheadline %}bots{% endblock %}
 {% block googledescription %}My fleet of automated accounts{% endblock %}
 {% block googlecreated %}2022-12-16T00:00:00{% endblock %}
@@ -34,7 +34,7 @@
         {
             "@context": "https://schema.org",
             "@type": "ItemList",
-            "url": "https://{{ current_site }}/bots/",
+            "url": "https://palewi.re/bots/",
             "itemListOrder": "Unordered",
             "numberOfItems": {{ object_list|length }},
             "itemListElement": [

--- a/coltrane/templates/coltrane/clip_list.html
+++ b/coltrane/templates/coltrane/clip_list.html
@@ -2,18 +2,18 @@
 
 {% block title %}work . {{ block.super }}{% endblock %}
 
-{% block canonicalurl %}https://{{ current_site }}/work/{% endblock %}
+{% block canonicalurl %}https://palewi.re/work/{% endblock %}
 
 {% block ogtitle %}work{% endblock %}
 {% block ogtype %}website{% endblock %}
-{% block ogurl %}https://{{ current_site }}/work/{% endblock %}
+{% block ogurl %}https://palewi.re/work/{% endblock %}
 {% block ogdescription %}Stories, apps and open-source software I've authored, typically in partnership with others.{% endblock %}
 
 {% block twittertitle %}work{% endblock %}
 {% block twitterdescription %}Stories, apps and open-source software I've authored, typically in partnership with others.{% endblock %}
-{% block twitterurl %}https://{{ current_site }}/work/{% endblock %}
+{% block twitterurl %}https://palewi.re/work/{% endblock %}
 
-{% block googleurl %}https://{{ current_site }}/work/{% endblock %}
+{% block googleurl %}https://palewi.re/work/{% endblock %}
 {% block googleheadline %}work{% endblock %}
 {% block googledescription %}Stories, apps and open-source software I've authored, typically in partnership with others.{% endblock %}
 {% block googlecreated %}2019-11-10T00:00:00{% endblock %}
@@ -26,7 +26,7 @@
         {
             "@context": "https://schema.org",
             "@type": "ItemList",
-            "url": "https://{{ current_site }}/work/",
+            "url": "https://palewi.re/work/",
             "itemListOrder": "Descending",
             "numberOfItems": {{ object_list|length }},
             "itemListElement": [

--- a/coltrane/templates/coltrane/doc_list.html
+++ b/coltrane/templates/coltrane/doc_list.html
@@ -2,18 +2,18 @@
 
 {% block title %}docs . {{ block.super }}{% endblock %}
 
-{% block canonicalurl %}https://{{ current_site }}/docs/{% endblock %}
+{% block canonicalurl %}https://palewi.re/docs/{% endblock %}
 
 {% block ogtitle %}docs{% endblock %}
 {% block ogtype %}website{% endblock %}
-{% block ogurl %}https://{{ current_site }}/docs/{% endblock %}
+{% block ogurl %}https://palewi.re/docs/{% endblock %}
 {% block ogdescription %}Documentation for my lesson plans and open-source software.{% endblock %}
 
 {% block twittertitle %}docs{% endblock %}
 {% block twitterdescription %}Documentation for my lesson plans and open-source software.{% endblock %}
-{% block twitterurl %}https://{{ current_site }}/docs/{% endblock %}
+{% block twitterurl %}https://palewi.re/docs/{% endblock %}
 
-{% block googleurl %}https://{{ current_site }}/docs/{% endblock %}
+{% block googleurl %}https://palewi.re/docs/{% endblock %}
 {% block googleheadline %}docs{% endblock %}
 {% block googledescription %}Documentation for my lesson plans and open-source software.{% endblock %}
 {% block googletype %}CollectionPage{% endblock %}
@@ -24,7 +24,7 @@
         {
             "@context": "https://schema.org",
             "@type": "ItemList",
-            "url": "https://{{ current_site }}/docs/",
+            "url": "https://palewi.re/docs/",
             "itemListOrder": "Unordered",
             "numberOfItems": {{ lesson_list|length }},
             "name": "Lesson plans",
@@ -44,7 +44,7 @@
         {
             "@context": "https://schema.org",
             "@type": "ItemList",
-            "url": "https://{{ current_site }}/docs/",
+            "url": "https://palewi.re/docs/",
             "itemListOrder": "Unordered",
             "numberOfItems": {{ software_list|length }},
             "name": "Open-source software",

--- a/coltrane/templates/coltrane/nav.html
+++ b/coltrane/templates/coltrane/nav.html
@@ -4,7 +4,7 @@
             <div class="shingle">
                 <a href="/">
                     <div rel="rnews:copyrightedBy rnews:hasSource rnews:providedBy">
-                        <div about="http://{{ current_site }}"
+                        <div about="https://palewi.re"
                               typeof="rnews:Organization">
                             <div property="rnews:name">palewire</div>
                         </div>

--- a/coltrane/templates/coltrane/post_detail.html
+++ b/coltrane/templates/coltrane/post_detail.html
@@ -4,27 +4,27 @@
 
 {% block title %}{{ object.title|lower }} . {{ block.super }}{% endblock %}
 
-{% block canonicalurl %}https://{{ current_site }}{{ object.get_absolute_url }}{% endblock %}
+{% block canonicalurl %}https://palewi.re{{ object.get_absolute_url }}{% endblock %}
 
 {% block ogtitle %}{{ object.title }}{% endblock %}
 {% block ogtype %}article{% endblock %}
-{% block ogurl %}https://{{ current_site }}{{ object.get_absolute_url }}{% endblock %}
+{% block ogurl %}https://palewi.re{{ object.get_absolute_url }}{% endblock %}
 {% block ogdescription %}{{ object.body_html|striptags|truncatechars:180 }}{% endblock %}
 
 {% block twittertitle %}{{ object.title }}{% endblock %}
 {% block twitterdescription %}{{ object.body_html|striptags|truncatechars:180 }}{% endblock %}
-{% block twitterurl %}https://{{ current_site }}{{ object.get_absolute_url }}{% endblock %}
+{% block twitterurl %}https://palewi.re{{ object.get_absolute_url }}{% endblock %}
 
 {% block extrameta %}
     {{ block.super }}
     <meta itemprop="headline" content="{{ object.title }}">
-    <meta itemprop="url" content="https://{{ current_site }}{{ object.get_absolute_url }}">
+    <meta itemprop="url" content="https://palewi.re{{ object.get_absolute_url }}">
     <meta itemprop="author" content="Ben Welsh">
     <meta itemprop="datePublished" content="{{ object.pub_date|date:"c" }}">
     <meta itemprop="inLanguage" content="en">
 {% endblock %}
 
-{% block googleurl %}https://{{ current_site }}{{ object.get_absolute_url }}{% endblock %}
+{% block googleurl %}https://palewi.re{{ object.get_absolute_url }}{% endblock %}
 {% block googleheadline %}{{ object.title|lower }}{% endblock %}
 {% block googledescription %}{{ object.body_html|striptags|truncatechars:180 }}{% endblock %}
 
@@ -36,13 +36,13 @@
             "headline": "{{ object.title|escapejs }}",
             "description": "{{ object.body_html|striptags|truncatechars:180|escapejs }}",
             "inLanguage": "en-US",
-            "url": "https://{{ current_site }}{{ object.get_absolute_url }}",
+            "url": "https://palewi.re{{ object.get_absolute_url }}",
             "datePublished": "{{ object.pub_date|date:"c" }}",
             "dateModified": "{{ object.pub_date|date:"c" }}",
             "author": {
                 "@type": "Person",
                 "name": "Ben Welsh",
-                "url": "https://{{ current_site }}/who-is-ben-welsh/"
+                "url": "https://palewi.re/who-is-ben-welsh/"
             },
             "publisher": {
                 "@type": "Organization",

--- a/coltrane/templates/coltrane/post_list.html
+++ b/coltrane/templates/coltrane/post_list.html
@@ -2,18 +2,18 @@
 
 {% block title %}posts . {{ block.super }}{% endblock %}
 
-{% block canonicalurl %}https://{{ current_site }}/posts/{% endblock %}
+{% block canonicalurl %}https://palewi.re/posts/{% endblock %}
 
 {% block ogtitle %}posts{% endblock %}
 {% block ogtype %}website{% endblock %}
-{% block ogurl %}https://{{ current_site }}/posts/{% endblock %}
+{% block ogurl %}https://palewi.re/posts/{% endblock %}
 {% block ogdescription %}A complete list of articles written for this site.{% endblock %}
 
 {% block twittertitle %}posts{% endblock %}
 {% block twitterdescription %}A complete list of articles written for this site.{% endblock %}
-{% block twitterurl %}https://{{ current_site }}/posts/{% endblock %}
+{% block twitterurl %}https://palewi.re/posts/{% endblock %}
 
-{% block googleurl %}https://{{ current_site }}/posts/{% endblock %}
+{% block googleurl %}https://palewi.re/posts/{% endblock %}
 {% block googleheadline %}posts{% endblock %}
 {% block googledescription %}A complete list of articles written for this site.{% endblock %}
 {% block googletype %}CollectionPage{% endblock %}
@@ -24,7 +24,7 @@
         {
             "@context": "https://schema.org",
             "@type": "ItemList",
-            "url": "https://{{ current_site }}/posts/",
+            "url": "https://palewi.re/posts/",
             "itemListOrder": "Descending",
             "numberOfItems": {{ object_list|length }},
             "itemListElement": [
@@ -32,7 +32,7 @@
                 {
                     "@type": "ListItem",
                     "position": {{ forloop.counter }},
-                    "url": "https://{{ current_site }}{{ object.get_absolute_url }}"
+                    "url": "https://palewi.re{{ object.get_absolute_url }}"
                 }{% if not forloop.last %},{% endif %}
                 {% endfor %}
             ]

--- a/coltrane/templates/coltrane/talk_list.html
+++ b/coltrane/templates/coltrane/talk_list.html
@@ -2,18 +2,18 @@
 
 {% block title %}talks . {{ block.super }}{% endblock %}
 
-{% block canonicalurl %}https://{{ current_site }}/talks/{% endblock %}
+{% block canonicalurl %}https://palewi.re/talks/{% endblock %}
 
 {% block ogtitle %}talks{% endblock %}
 {% block ogtype %}website{% endblock %}
-{% block ogurl %}https://{{ current_site }}/talks/{% endblock %}
+{% block ogurl %}https://palewi.re/talks/{% endblock %}
 {% block ogdescription %}A selection of recordings, slides and other materials from my public-speaking appearances.{% endblock %}
 
 {% block twittertitle %}talks{% endblock %}
 {% block twitterdescription %}A selection of recordings, slides and other materials from my public-speaking appearances.{% endblock %}
-{% block twitterurl %}https://{{ current_site }}/talks/{% endblock %}
+{% block twitterurl %}https://palewi.re/talks/{% endblock %}
 
-{% block googleurl %}https://{{ current_site }}/talks/{% endblock %}
+{% block googleurl %}https://palewi.re/talks/{% endblock %}
 {% block googleheadline %}talks{% endblock %}
 {% block googledescription %}A selection of slides and videos from my public-speaking appearances.{% endblock %}
 {% block googlecreated %}2019-11-10T00:00:00{% endblock %}
@@ -26,7 +26,7 @@
         {
             "@context": "https://schema.org",
             "@type": "ItemList",
-            "url": "https://{{ current_site }}/talks/",
+            "url": "https://palewi.re/talks/",
             "itemListOrder": "Descending",
             "numberOfItems": {{ object_list|length }},
             "itemListElement": [
@@ -35,7 +35,7 @@
                     "@type": "ListItem",
                     "position": {{ forloop.counter }},
                     "name": "{{ object.title|escapejs }}",
-                    "url": "https://{{ current_site }}/talks/"
+                    "url": "https://palewi.re/talks/"
                 }{% if not forloop.last %},{% endif %}
                 {% endfor %}
             ]

--- a/coltrane/views.py
+++ b/coltrane/views.py
@@ -5,10 +5,8 @@ from pathlib import Path
 # Third-party
 import markdown
 import yaml
-from django.conf import settings
-from django.http import Http404, HttpResponseRedirect, HttpResponseServerError
+from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import render
-from django.template import loader
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.views.generic import ListView, TemplateView
@@ -81,14 +79,6 @@ def post_detail(request, year, month, day, slug):
         "object": post,
     }
     return render(request, "coltrane/post_detail.html", context)
-
-
-def server_error(request, template_name="500.html"):
-    """
-    500 error handler. Necessary to make sure STATIC_URL is available.
-    """
-    t = loader.get_template(template_name)
-    return HttpResponseServerError(t.render({"STATIC_URL": settings.STATIC_URL}))
 
 
 class ClipListView(TemplateView):

--- a/project/settings.py
+++ b/project/settings.py
@@ -73,8 +73,6 @@ TEMPLATES = [
         "OPTIONS": {
             "context_processors": [
                 "django.template.context_processors.static",
-                "toolbox.context_processors.current_site",
-                "toolbox.context_processors.now",
                 "toolbox.context_processors.repository",
             ],
             "debug": DEBUG,

--- a/project/urls.py
+++ b/project/urls.py
@@ -1,12 +1,13 @@
+from django.conf import settings
 from django.contrib.sitemaps import views as sitemap_views
 from django.urls import path, re_path
-from django.views.generic import RedirectView
+from django.views.generic import RedirectView, TemplateView
 
 # Views
 from coltrane import views
 from coltrane.feeds import LatestPostsFeed
 from coltrane.sitemaps import sitemaps
-from toolbox.views import DirectTemplateView, health_check
+from toolbox.views import health_check
 
 from .redirects import patterns as redirectpatterns
 
@@ -41,10 +42,10 @@ urlpatterns = [
     path("feeds/posts/", LatestPostsFeed()),
     path(
         "robots.txt",
-        DirectTemplateView.as_view(template_name="robots.txt", content_type="text/plain"),
+        TemplateView.as_view(template_name="robots.txt", content_type="text/plain"),
         name="robots",
     ),
-    path("favicon.ico", RedirectView.as_view(url="/static/favicon.ico"), name="favicon"),
+    path("favicon.ico", RedirectView.as_view(url=f"{settings.STATIC_URL}favicon.ico"), name="favicon"),
     # Mastodon
     path(".well-known/webfinger", views.wellknown_webfinger),
     path(".well-known/host-meta", views.wellknown_hostmeta),
@@ -53,6 +54,3 @@ urlpatterns = [
 ]
 
 urlpatterns = [*redirectpatterns, *urlpatterns]
-
-# 500 page fix
-handler500 = "coltrane.views.server_error"

--- a/tests/test_context_processors.py
+++ b/tests/test_context_processors.py
@@ -1,19 +1,9 @@
 """Tests for shared template context."""
 
 import subprocess
-from datetime import UTC
 from unittest.mock import patch
 
-from django.utils import timezone
-
-from toolbox.context_processors import REPOSITORY_URL, _main_commit, now, repository
-
-
-def test_now_is_timezone_aware():
-    context_now = now(None)["now"]
-
-    assert timezone.is_aware(context_now)
-    assert context_now.tzinfo == UTC
+from toolbox.context_processors import REPOSITORY_URL, _main_commit, repository
 
 
 def test_repository_uses_heroku_commit():

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3,11 +3,19 @@
 from unittest.mock import patch
 
 import pytest
+from django.templatetags.static import static
 from django.test import Client
 from django.test.utils import override_settings
+from django.urls import include, path
 
-from coltrane.views import server_error
 from project.redirects import STATIC_REDIRECTS
+
+
+def failing_view(_request):
+    raise RuntimeError("Expected test error")
+
+
+urlpatterns = [path("", include("project.urls")), path("failing/", failing_view)]
 
 
 @pytest.fixture
@@ -30,10 +38,13 @@ def test_bio_page_ok(client):
     assert 'fetchpriority="high"' in content
 
 
-def test_bio_page_context_includes_fixed_current_site(client):
+def test_bio_page_uses_canonical_domain(client):
     response = client.get("/who-is-ben-welsh/")
+
     assert response.status_code == 200
-    assert any(context.get("current_site") == "palewi.re" for context in response.context)
+    content = response.content.decode()
+    assert '<link rel="canonical" href="https://palewi.re/who-is-ben-welsh/" />' in content
+    assert '"url": "https://palewi.re/who-is-ben-welsh/"' in content
 
 
 def test_bio_page_footer_links_to_main_commit(client):
@@ -87,7 +98,7 @@ def test_favicon_route_exists(client):
     response = client.get("/favicon.ico")
     assert response.status_code in (200, 301, 302)
     if response.status_code in (301, 302):
-        assert response["Location"].endswith("/static/favicon.ico")
+        assert response["Location"] == static("favicon.ico")
 
 
 @override_settings(DEBUG=False)
@@ -123,9 +134,9 @@ def test_retired_legacy_pages_return_not_found(client, path):
     assert client.get(path).status_code == 404
 
 
-@override_settings(DEBUG=False)
-def test_server_error_page_uses_simplified_message(rf):
-    response = server_error(rf.get("/"))
+@override_settings(DEBUG=False, ROOT_URLCONF=__name__)
+def test_server_error_page_uses_default_handler():
+    response = Client(raise_request_exception=False).get("/failing/")
 
     assert response.status_code == 500
     content = response.content.decode()
@@ -133,6 +144,7 @@ def test_server_error_page_uses_simplified_message(rf):
     assert '<meta name="robots" content="noindex" />' in content
     assert '<h1 id="error-heading">500</h1>' in content
     assert "Something went wrong. Please try again later." in content
+    assert '<link rel="icon" href="/static/favicon.ico" />' in content
 
 
 def test_health_check_ok(client):

--- a/toolbox/context_processors.py
+++ b/toolbox/context_processors.py
@@ -5,23 +5,10 @@ import subprocess
 from functools import lru_cache
 from pathlib import Path
 
-from django.utils import timezone
-
 logger = logging.getLogger(__name__)
 REPOSITORY_URL = "https://github.com/palewire/palewi.re"
 COMMIT_PATTERN = re.compile(r"^[0-9a-f]{7,40}$")
 REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
-
-
-def current_site(_request):
-    """
-    Add the current site to the template context.
-    """
-    return {"current_site": "palewi.re"}
-
-
-def now(request):
-    return {"now": timezone.now()}
 
 
 @lru_cache(maxsize=1)

--- a/toolbox/views.py
+++ b/toolbox/views.py
@@ -1,19 +1,4 @@
 from django.http import JsonResponse
-from django.views.generic import TemplateView
-
-
-class DirectTemplateView(TemplateView):
-    extra_context = None
-
-    def get_context_data(self, **kwargs):
-        context = super(self.__class__, self).get_context_data(**kwargs)
-        if self.extra_context is not None:
-            for key, value in self.extra_context.items():
-                if callable(value):
-                    context[key] = value()
-                else:
-                    context[key] = value
-        return context
 
 
 def health_check(request):


### PR DESCRIPTION
## Summary

- Replace the custom template wrapper and 500 handler with Django's built-in behavior.
- Remove fixed-domain and current-time context processors; canonical URLs are explicit and templates use Django static/time helpers.
- Preserve robots, favicon, static assets, canonical metadata, and production error pages with focused regression coverage.

## Database retirement audit

Issue #366 was independently audited on current main and remains complete. The audit comment confirms there is no PostgreSQL runtime/configuration, database service, migration step, or unused Django administrative stack. No reopening was needed: https://github.com/palewire/palewi.re/issues/366#issuecomment-5395648248

## Validation

- `make check`
- Production `collectstatic` and DEBUG=False public-route checks
- Independent code review: no findings

Closes #365