### PR TITLE
Add repository metadata to docs catalog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,9 +106,12 @@ docs:
     type: software           # lesson-plan | software
     url: "https://..."       # must be unique across all docs
     description: "..."       # optional
+    repository_url: "https://..." # optional canonical source repository; unique if set
 ```
 
-Ordered by type, then alphabetically by title.
+`repository_url` must be an HTTP(S) URL. Omit it or use an empty value when a
+canonical repository cannot be verified. It is catalog metadata and is not
+rendered on `/docs/`. Docs are ordered by type, then alphabetically by title.
 
 ### bio_skills.yaml
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ make test
 
 Tests and local serving do not require PostgreSQL or `DATABASE_URL`.
 
+## Content catalogs
+
+`coltrane/content/docs.yaml` lists the documentation catalog. Each record
+requires `title`, `type`, and a unique `url`; `description` is optional.
+`repository_url` is optional machine-readable metadata for a verified canonical
+source repository. When set, it must be a unique HTTP(S) URL. It is not
+displayed on the docs page.
+
 ## Blog post Markdown
 
 Public posts in `coltrane/content/posts/` are one `.md` file each. Their YAML

--- a/coltrane/content/docs.yaml
+++ b/coltrane/content/docs.yaml
@@ -2,221 +2,271 @@ docs:
 - title: Coding the News
   type: lesson-plan
   url: https://palewi.re/docs/coding-the-news/
+  repository_url: https://github.com/palewire/cuny-jour-73361-coding-the-news
   description: Learn how America's top news organizations escape rigid publishing
     systems to design beautiful data-driven stories on deadline
 - title: First Athena Query
   type: lesson-plan
   url: https://palewi.re/docs/first-athena-query/
+  repository_url: https://github.com/palewire/first-athena-query
   description: Analyze millions of records in seconds with Amazon Web Services and
     SQL
 - title: First Automated Chart
   type: lesson-plan
   url: https://palewi.re/docs/first-automated-chart/
+  repository_url: https://github.com/palewire/first-automated-chart
   description: Learn how you can use Python and the Datawrapper API to create a limitless
     number of charts and maps.
 - title: First Basemap
   type: lesson-plan
   url: https://palewi.re/docs/first-basemap/
+  repository_url: https://github.com/palewire/first-basemap
   description: Create a shockingly fast and virtually free interactive map of the
     world using OpenStreetMap and PMTiles
 - title: First Django Admin
   type: lesson-plan
   url: https://palewi.re/docs/first-django-admin/
+  repository_url: https://github.com/palewire/first-django-admin
   description: A guide to creating a web application for enlisting reporters in data
     entry and refinement
 - title: First GitHub Scraper
   type: lesson-plan
   url: https://palewi.re/docs/first-github-scraper/
+  repository_url: https://github.com/palewire/first-github-scraper
   description: An introduction to free, automated web scraping with GitHub Actions
 - title: First LLM Classifier
   type: lesson-plan
   url: https://palewi.re/docs/first-llm-classifier/
+  repository_url: https://github.com/palewire/first-llm-classifier
   description: Learn how journalists use large-language models to organize and analyze
     massive datasets
 - title: First PMTiles Map
   type: lesson-plan
   url: https://palewi.re/docs/first-pmtiles-map/
+  repository_url: https://github.com/palewire/first-pmtiles-map
   description: Learn how to display a massive dataset on an interactive map using
     PMTiles and MapLibre
 - title: First Pull Request
   type: lesson-plan
   url: https://palewi.re/docs/first-pull-request/
+  repository_url: https://github.com/palewire/first-pull-request
   description: How to propose changes to open-source software using GitHub pull requests
 - title: First Python Notebook
   type: lesson-plan
   url: https://palewi.re/docs/first-python-notebook/
+  repository_url: https://github.com/palewire/first-python-notebook
   description: A guide to analyzing data with Python and the Jupyter notebook
 - title: First Visual Story
   type: lesson-plan
   url: https://palewi.re/docs/first-visual-story/
+  repository_url: https://github.com/palewire/first-visual-story
   description: A guide to publishing a standalone story from a dataset
 - title: First Web Scraper
   type: lesson-plan
   url: https://palewi.re/docs/first-web-scraper/
+  repository_url: https://github.com/palewire/first-web-scraper
   description: A guide to writing a web scraper with Python
 - title: Go big with GitHub Actions
   type: lesson-plan
   url: https://palewi.re/docs/go-big-with-github-actions/
+  repository_url: https://github.com/palewire/go-big-with-github-actions
   description: Scale up your data pipelines using GitHub’s powerful Actions framework
 - title: air-quality-index
   type: software
   url: https://palewi.re/docs/air-quality-index/
+  repository_url: https://github.com/datadesk/air-quality-index
   description: Download air quality index data from AirNow
 - title: atcf-data-parser
   type: software
   url: https://palewi.re/docs/atcf-data-parser/
+  repository_url: https://github.com/palewire/atcf-data-parser
   description: A Python parser and command-line utility for the “a-deck” data posted
     online by the Automated Tropical Cyclone Forecasting System
 - title: bln-python-client
   type: software
   url: https://bln-python-client.readthedocs.io/
+  repository_url: https://github.com/biglocalnews/bln-python-client
   description: Python client for the biglocalnews.org API
 - title: calfire-wildfires
   type: software
   url: https://palewi.re/docs/calfire-wildfires/
+  repository_url: https://github.com/datadesk/calfire-wildfires
   description: Download wildfires data from CalFire
 - title: censusbatchgeocoder
   type: software
   url: https://palewi.re/docs/censusbatchgeocoder/
+  repository_url: https://github.com/palewire/censusbatchgeocoder
   description: A simple Python wrapper for the U.S. Census Geocoding Services API
     batch service
 - title: census-data-aggregator
   type: software
   url: https://github.com/datadesk/census-data-aggregator
+  repository_url: https://github.com/datadesk/census-data-aggregator
   description: Combine U.S. census data responsibly
 - title: census-error-analyzer
   type: software
   url: https://github.com/datadesk/census-error-analyzer
+  repository_url: https://github.com/datadesk/census-error-analyzer
   description: Analyze the margin of error in U.S. census data
 - title: census-map-consolidator
   type: software
   url: https://github.com/datadesk/census-map-consolidator
+  repository_url: https://github.com/datadesk/census-map-consolidator
   description: Combine Census blocks into new shapes
 - title: census-map-downloader
   type: software
   url: https://github.com/datadesk/census-map-downloader
+  repository_url: https://github.com/datadesk/census-map-downloader
   description: Easily download U.S. census maps
 - title: cpi
   type: software
   url: https://palewi.re/docs/cpi/
+  repository_url: https://github.com/palewire/cpi
   description: A Python library that quickly adjusts U.S. dollars for inflation using
     the Consumer Price Index
 - title: Datawrapper JSON bookmarklet
   type: software
   url: https://palewi.re/docs/datawrapper-json-bookmarklet/
+  repository_url: https://github.com/palewire/datawrapper-json-bookmarklet
   description: Quickly access the JSON configuration of your Datawrapper chart
 - title: django-anss-archive
   type: software
   url: https://palewi.re/docs/django-anss-archive/
+  repository_url: https://github.com/palewire/django-anss-archive
   description: A Django application to archive real-time earthquake notifications
     from the U.S. Geological Survey’s Advanced National Seismic System
 - title: django-bakery
   type: software
   url: https://palewi.re/docs/django-bakery/
+  repository_url: https://github.com/palewire/django-bakery
   description: A set of helpers for baking your Django site out as flat files
 - title: django-greeking
   type: software
   url: https://palewi.re/docs/django-greeking/
+  repository_url: https://github.com/palewire/django-greeking
   description: Django template tools for printing filler, a technique from the days
     of hot type known as greeking
 - title: django-internetarchive-storage
   type: software
   url: https://palewi.re/docs/django-internetarchive-storage/
+  repository_url: https://github.com/palewire/django-internetarchive-storage
   description: A custom Django storage system for Internet Archive collections
 - title: django-postgres-copy
   type: software
   url: https://palewi.re/docs/django-postgres-copy/
+  repository_url: https://github.com/palewire/django-postgres-copy
   description: Quickly import and export delimited data with Django and PostgreSQL
 - title: django-yamlfield
   type: software
   url: https://palewi.re/docs/django-yamlfield/
+  repository_url: https://github.com/palewire/django-yamlfield
   description: A Django database field for storing YAML data
 - title: geodataframe-to-pmtiles
   type: software
   url: https://palewi.re/docs/geodataframe-to-pmtiles/
+  repository_url: https://github.com/palewire/geodataframe-to-pmtiles
   description: Write PMTiles archives from GeoPandas GeoDataFrames with a Python API
 - title: inciweb-wildfires
   type: software
   url: https://palewi.re/docs/inciweb-wildfires/
+  repository_url: https://github.com/datadesk/inciweb-wildfires
   description: Download wildfire incidents data from InciWeb
 - title: ipsos-credibility-interval
   type: software
   url: https://palewi.re/docs/ipsos-credibility-interval/
+  repository_url: https://github.com/palewire/ipsos-credibility-interval
   description: A Python tool that calculates Bayesian credibility intervals for online
     polling using the Ipsos method
 - title: isobands
   type: software
   url: https://palewi.re/docs/isobands/
+  repository_url: https://github.com/palewire/isobands
   description: An easy way to make filled contour maps with Python
 - title: nasa-wildfires
   type: software
   url: https://palewi.re/docs/nasa-wildfires/
+  repository_url: https://github.com/datadesk/nasa-wildfires
   description: Download wildfire hotspots detected by NASA satellites and the Fire
     Information for Resource Management System (FIRMS)
 - title: news-homepages
   type: software
   url: https://palewi.re/docs/news-homepages/index.html
+  repository_url: https://github.com/palewire/news-homepages
   description: A bot that gathers, archives and shares screenshots of news homepages
 - title: noaa-wildfires
   type: software
   url: https://palewi.re/docs/noaa-wildfires/
+  repository_url: https://github.com/datadesk/noaa-wildfires
   description: Download wildfires data from NOAA satellites
 - title: nws-aurora
   type: software
   url: https://palewi.re/docs/nws-aurora/
+  repository_url: https://github.com/palewire/nws-aurora
   description: Download forecast data for Aurora Borealis and Aurora Australis from
     the National Weather Service
 - title: nws-wwa
   type: software
   url: https://palewi.re/docs/nws-wwa/
+  repository_url: https://github.com/datadesk/nws-wwa
   description: Download watch, warning and advisory data from the National Weather
     Service
 - title: prefect-flow-template
   type: software
   url: https://github.com/biglocalnews/prefect-flow-template/wiki
+  repository_url: https://github.com/biglocalnews/prefect-flow-template
   description: A template repository with all the fundamentals needed to develop and
     deploy a Python data-processing routine for Prefect pipelines.
 - title: python-googlegeocoder
   type: software
   url: https://palewi.re/docs/python-googlegeocoder/
+  repository_url: https://github.com/palewire/python-googlegeocoder
   description: A simple Python wrapper for Google’s geocoder API
 - title: python-muckrock
   type: software
   url: https://palewi.re/docs/python-muckrock/
+  repository_url: https://github.com/palewire/python-muckrock
   description: A simple Python wrapper for the MuckRock API
 - title: Refinitiv Data Python Cookbook
   type: software
   url: https://palewi.re/docs/refinitiv-data-python-cookbook/
+  repository_url: https://github.com/palewire/refinitiv-data-python-cookbook
   description: Practical examples for users of the Refinitiv Data Library for Python
 - title: reuters-style
   type: software
   url: https://palewi.re/docs/reuters-style/
+  repository_url: https://github.com/palewire/reuters-style
   description: A Python library that format dates, numbers and text to conform with
     the Reuters Style Guide, the standards that guide the world’s largest independent
     newsroom
 - title: savepagenow
   type: software
   url: https://palewi.re/docs/savepagenow/
+  repository_url: https://github.com/palewire/savepagenow
   description: A Python wrapper and command-line interface for archive.org’s capturing
     service
 - title: storysniffer
   type: software
   url: https://palewi.re/docs/storysniffer/
+  repository_url: https://github.com/palewire/storysniffer
   description: Inspect a URL and estimate if it links to news story
 - title: upload-data-to-biglocalnews-org
   type: software
   url: https://github.com/marketplace/actions/upload-data-to-biglocalnews-org
+  repository_url: https://github.com/biglocalnews/upload-files
   description: Upload comma-delimited files to biglocalnews.org in your GitHub Action
 - title: warn-github-flow
   type: software
   url: https://github.com/biglocalnews/warn-github-flow
+  repository_url: https://github.com/biglocalnews/warn-github-flow
   description: GitHub Action workflow for automating a WARN Act notice ETL pipeline
 - title: warn-scraper
   type: software
   url: https://warn-scraper.readthedocs.io/en/latest/
+  repository_url: https://github.com/biglocalnews/warn-scraper
   description: Command-line interface for downloading WARN Act notices of qualified
     plant closings and mass layoffs from state government websites
 - title: warn-transformer
   type: software
   url: https://warn-transformer.readthedocs.io/
+  repository_url: https://github.com/biglocalnews/warn-transformer
   description: Consolidate, enrich and republish the data gathered by warn-scraper

--- a/coltrane/content_loaders.py
+++ b/coltrane/content_loaders.py
@@ -28,7 +28,8 @@ Edit the appropriate file under ``coltrane/content/``:
 * ``docs.yaml``    – Documentation listed on the /docs/ page.
   Required fields: ``title`` (str), ``type`` (one of
   ``lesson-plan``, ``software``), ``url`` (str, unique).
-  Optional fields: ``description`` (str).
+  Optional fields: ``description`` (str), ``repository_url`` (HTTP(S) URL,
+  unique when non-empty).
   Ordering: ``type``, then ``title`` (alphabetical).
 
 * ``slogans.yaml`` – Short phrases that appear in the site header.
@@ -53,6 +54,7 @@ import re
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
+from urllib.parse import urlparse
 from zoneinfo import ZoneInfo
 
 import yaml
@@ -102,6 +104,7 @@ class Doc:
     type: str
     url: str
     description: str = ""
+    repository_url: str = ""
 
 
 @dataclass(frozen=True)
@@ -189,6 +192,19 @@ def _optional_str(record: dict, field_name: str, path: str) -> str:
         raise ContentError(
             f"{path}: record {record!r} field '{field_name}' must be a string, got {type(value).__name__}"
         )
+    return value
+
+
+def _optional_http_url(record: dict, field_name: str, path: str, title: str) -> str:
+    """Return an optional HTTP(S) URL with doc-specific error context."""
+    value = record.get(field_name, "")
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise ContentError(f"{path}: doc '{title}' field '{field_name}' must be a string, got {type(value).__name__}")
+    parsed = urlparse(value)
+    if value and (parsed.scheme not in {"http", "https"} or not parsed.netloc or any(char.isspace() for char in value)):
+        raise ContentError(f"{path}: doc '{title}' {field_name} must be an HTTP(S) URL, got {value!r}")
     return value
 
 
@@ -352,6 +368,7 @@ def load_docs(path: Path | None = None) -> list[Doc]:
     if not isinstance(items, list):
         raise ContentError(f"{label}: 'docs' must be a list")
     seen_urls: set[str] = set()
+    seen_repository_urls: set[str] = set()
     docs: list[Doc] = []
     for record in items:
         if not isinstance(record, dict):
@@ -365,7 +382,20 @@ def load_docs(path: Path | None = None) -> list[Doc]:
             raise ContentError(f"{label}: duplicate doc URL '{url}'")
         seen_urls.add(url)
         description = _optional_str(record, "description", label)
-        docs.append(Doc(title=title, type=doc_type, url=url, description=description))
+        repository_url = _optional_http_url(record, "repository_url", label, title)
+        if repository_url:
+            if repository_url in seen_repository_urls:
+                raise ContentError(f"{label}: duplicate doc repository_url '{repository_url}' for doc '{title}'")
+            seen_repository_urls.add(repository_url)
+        docs.append(
+            Doc(
+                title=title,
+                type=doc_type,
+                url=url,
+                description=description,
+                repository_url=repository_url,
+            )
+        )
     docs.sort(key=lambda d: (d.type, d.title))
     return docs
 

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -173,6 +173,7 @@ def test_talk_missing_required_field_raises(tmp_path):
 def test_docs_yaml_loads():
     docs = load_docs()
     assert len(docs) > 0
+    assert all(doc.repository_url for doc in docs)
 
 
 def test_docs_sorted_by_type_then_title():
@@ -204,6 +205,67 @@ def test_doc_description_optional(tmp_path):
     p.write_text("docs:\n  - title: D\n    type: software\n    url: http://x.com\n")
     docs = load_docs(p)
     assert docs[0].description == ""
+    assert docs[0].repository_url == ""
+
+
+def test_doc_repository_url_null_is_optional(tmp_path):
+    p = tmp_path / "docs.yaml"
+    p.write_text("docs:\n  - title: D\n    type: software\n    url: http://x.com\n    repository_url: null\n")
+
+    assert load_docs(p)[0].repository_url == ""
+
+
+def test_doc_repository_url_valid_and_does_not_change_order(tmp_path):
+    p = tmp_path / "docs.yaml"
+    p.write_text(
+        "docs:\n"
+        "  - title: Z\n    type: software\n    url: http://z.example.com\n"
+        "    repository_url: https://code.example.com/z\n"
+        "  - title: A\n    type: software\n    url: http://a.example.com\n"
+        "    repository_url: http://code.example.com/a\n"
+    )
+
+    docs = load_docs(p)
+
+    assert [doc.title for doc in docs] == ["A", "Z"]
+    assert docs[0].repository_url == "http://code.example.com/a"
+    assert docs[1].repository_url == "https://code.example.com/z"
+
+
+@pytest.mark.parametrize(
+    "repository_url",
+    ["code.example.com/project", "ftp://code.example.com/project", "https://"],
+)
+def test_doc_invalid_repository_url_raises(tmp_path, repository_url):
+    p = tmp_path / "docs.yaml"
+    p.write_text(
+        f"docs:\n  - title: D\n    type: software\n    url: http://x.com\n    repository_url: {repository_url}\n"
+    )
+
+    with pytest.raises(ContentError, match="doc 'D'.*repository_url.*HTTP\\(S\\) URL"):
+        load_docs(p)
+
+
+def test_doc_repository_url_must_be_a_string(tmp_path):
+    p = tmp_path / "docs.yaml"
+    p.write_text("docs:\n  - title: D\n    type: software\n    url: http://x.com\n    repository_url: 123\n")
+
+    with pytest.raises(ContentError, match="doc 'D'.*repository_url.*must be a string"):
+        load_docs(p)
+
+
+def test_doc_duplicate_repository_url_raises_with_title(tmp_path):
+    p = tmp_path / "docs.yaml"
+    p.write_text(
+        "docs:\n"
+        "  - title: A\n    type: software\n    url: http://a.example.com\n"
+        "    repository_url: https://code.example.com/shared\n"
+        "  - title: B\n    type: software\n    url: http://b.example.com\n"
+        "    repository_url: https://code.example.com/shared\n"
+    )
+
+    with pytest.raises(ContentError, match="duplicate doc repository_url.*doc 'B'"):
+        load_docs(p)
 
 
 def test_docs_empty_list_ok(tmp_path):


### PR DESCRIPTION
## Summary

- Add optional `repository_url` metadata to the file-backed docs catalog without changing the `/docs/` UI or template.
- Validate non-empty values as unique HTTP(S) URLs; missing, empty, and `null` values resolve to an empty string.
- Document the field and cover valid, missing, invalid, duplicate, and ordering behavior.

## Repository audit

All **50** catalog records were populated (**13** lesson plans and **37** software records; **0** unresolved). For each record, GitHub repository metadata (`full_name`, homepage, and description) was compared with the existing catalog title, docs URL, and description; records already pointing to a GitHub repository were also confirmed directly. All verified canonical repositories are on GitHub; no non-GitHub canonical repository was identified.

## Validation

`make check` passes. An independent code-review agent found no high-confidence issues.