### PR TITLE
Fix footer revision link

### DIFF
--- a/coltrane/templates/coltrane/base.html
+++ b/coltrane/templates/coltrane/base.html
@@ -113,9 +113,9 @@
                 <div class="twelvecol last">
                     <span property="rnews:copyrightNotice">© <span property="rnews:copyrightYear">{% now "Y" %}</span> palewire</span>
                     {% if repository_commit %}
-                    <a class="footer-commit"
+                    Revision <a class="footer-commit"
                        href="{{ repository_url }}/commit/{{ repository_commit }}"
-                       aria-label="View commit {{ repository_commit_short }} on GitHub">Revision {{ repository_commit_short }}</a>
+                       aria-label="View commit {{ repository_commit_short }} on GitHub">{{ repository_commit_short }}</a>
                     {% endif %}
                 </div>
             </div>

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -55,7 +55,8 @@ def test_bio_page_footer_links_to_main_commit(client):
 
     content = response.content.decode()
     assert f'href="https://github.com/palewire/palewi.re/commit/{commit}"' in content
-    assert ">Revision 0123456</a>" in content
+    assert "Revision <a " in content
+    assert ">0123456</a>" in content
 
 
 @pytest.mark.parametrize("page", ["/work/", "/talks/", "/posts/", "/docs/", "/bots/"])


### PR DESCRIPTION
## Summary

- keep “Revision” as plain footer text
- link only the shortened commit hash
- update the footer view test