### PR TITLE
Enforce clip archive metadata in make check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ css-dev:
 serve: css-dev
 	@"$$(command -v uv)" run python -m scripts.worktree serve
 
-check: lint typecheck django-check test
+check: lint typecheck django-check check-clip-archives test
 
 test: css
 	@"$$(command -v uv)" run pytest tests/


### PR DESCRIPTION
## Summary\n- add  to the default All checks passed!
123 files already formatted
All checks passed!
System check identified no issues (0 silenced).
All 459 clip URLs have archive metadata.

> build:css
> rm -f coltrane/static/styles.css.map && sass --silence-deprecation=import --style=compressed --no-source-map coltrane/static/styles.scss:coltrane/static/styles.css

============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.1.1, pluggy-1.6.0
django: version: 5.2.17, settings: project.settings (from ini)
rootdir: /Users/U6122976/Code/copilot-worktrees/palewi.re/palewire-fuzzy-funicular
configfile: pyproject.toml
plugins: cov-7.1.0, django-4.14.0
collected 208 items

tests/test_archive_clips.py .........                                    [  4%]
tests/test_content.py .................................................. [ 28%]
.............                                                            [ 34%]
tests/test_context_processors.py ...                                     [ 36%]
tests/test_database_free.py .                                            [ 36%]
tests/test_export_posts.py ...                                           [ 37%]
tests/test_file_backed_posts.py .........                                [ 42%]
tests/test_management.py ..                                              [ 43%]
tests/test_markdown_posts.py .............                               [ 49%]
tests/test_redirect_manifest.py ............                             [ 55%]
tests/test_static.py .ss                                                 [ 56%]
tests/test_views.py .................................................... [ 81%]
.................................                                        [ 97%]
tests/test_worktree.py ..                                                [ 98%]
tests/test_worktree_script.py ...                                        [100%]

=============================== warnings summary ===============================
tests/test_file_backed_posts.py: 8 warnings
tests/test_static.py: 1 warning
tests/test_views.py: 85 warnings
  /Users/U6122976/Code/copilot-worktrees/palewi.re/palewire-fuzzy-funicular/.venv/lib/python3.12/site-packages/django/core/handlers/base.py:61: UserWarning: No directory at: /Users/U6122976/Code/copilot-worktrees/palewi.re/palewire-fuzzy-funicular/collected_static/
    mw_instance = middleware(adapted_handler)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================ tests coverage ================================
_______________ coverage: platform darwin, python 3.12.8-final-0 _______________

Name                                       Stmts   Miss  Cover   Missing
------------------------------------------------------------------------
coltrane/__init__.py                           0      0   100%
coltrane/apps.py                               3      0   100%
coltrane/content_loaders.py                  341      1    99%   527
coltrane/feeds.py                             12      0   100%
coltrane/management/__init__.py                0      0   100%
coltrane/management/commands/__init__.py       0      0   100%
coltrane/sitemaps.py                          25      1    96%   12
coltrane/utils/__init__.py                     0      0   100%
coltrane/utils/pygmenter.py                   18      1    94%   38
coltrane/views.py                             71      1    99%   127
project/__init__.py                            0      0   100%
project/redirect_manifest.py                 165     35    79%   71, 77, 83, 89, 124, 128, 137, 139, 146, 148, 150, 152, 161, 164, 166, 170, 172, 182-183, 185, 193, 195, 224-235, 239
project/redirects.py                           3      0   100%
project/settings.py                           30      6    80%   14, 146-150
project/urls.py                               11      0   100%
project/worktree.py                           23      6    74%   19-24
scripts/__init__.py                            0      0   100%
scripts/archive_clips.py                     141     22    84%   33-34, 37, 40, 56, 70, 73, 78, 81, 111, 115, 117, 140, 171, 173-174, 184, 186, 189, 203-204, 215
scripts/export_posts.py                      163     27    83%   123, 162-166, 173, 207, 209, 213, 231-233, 237, 241, 244, 255, 276, 311-321, 325
scripts/worktree.py                           38      5    87%   27-30, 58
toolbox/__init__.py                            0      0   100%
toolbox/context_processors.py                 27      3    89%   27-29
toolbox/middleware/__init__.py                 0      0   100%
toolbox/middleware/domains.py                 14      0   100%
toolbox/views.py                               3      0   100%
------------------------------------------------------------------------
TOTAL                                       1088    108    90%
Required test coverage of 90% reached. Total coverage: 90.07%
================= 206 passed, 2 skipped, 94 warnings in 8.36s ================== target\n- keep enforcement offline by using the existing local clip metadata check script\n- close the future-enforcement gap tracked in #175\n\n## Why\nIssue #175 identified a gap: clip archive metadata could be enforced manually but not through the default CI quality gate. This change makes the existing enforcement part of the standard check path used locally and in CI.\n\n## Notes\n- no network calls were added to CI\n- no credentials are required for this check