### PR TITLE
Retire Django legacy redirects (stage 2/2)

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -31,6 +31,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          python-version: "3.12"
+
+      - name: Install legacy redirect verifier dependencies
+        run: uv sync --locked --no-dev
+
       - name: Health check (with retries)
         run: |
           echo "Testing health endpoint: $BASE_URL/health/"
@@ -61,6 +69,14 @@ jobs:
           WORKER_MARKER_ATTEMPTS=4 \
           WORKER_MARKER_WAIT_SECONDS=15 \
           scripts/verify-worker-endpoints.sh
+
+      - name: Legacy redirect Worker (with propagation retries)
+        run: |
+          BASE_URL="$BASE_URL" \
+          CURL_MAX_TIME=20 \
+          WORKER_MARKER_ATTEMPTS=4 \
+          WORKER_MARKER_WAIT_SECONDS=15 \
+          scripts/verify-legacy-redirects.sh
 
       - name: Bio page (with retries)
         run: |

--- a/README.md
+++ b/README.md
@@ -367,16 +367,16 @@ version controls after a verified canary.
 
 `project/redirects.yaml` is the readable, validated source of truth for legacy
 redirects. It currently has 22 exact paths and 8 dynamic patterns; this is the
-full current Django inventory (the issue's earlier 21/7 count was stale).
-`project/redirect_manifest.py` validates the file before Django loads its
-fallback URL patterns. `workers/legacy-redirects/` reads that same file as a
-bundled text module and has no `fetch()` call. Its small explicit
+full retired Django inventory (the issue's earlier 21/7 count was stale).
+`project/redirect_manifest.py` is pure Python validation and route-plan tooling
+used by the Worker tests, deployment commands, and production verifier.
+`workers/legacy-redirects/` reads that same file as a bundled text module and
+has no `fetch()` call. Its small explicit
 `WorkerEnvironment` interface covers the only optional canary binding, avoiding
 a second generated 15,000-line Workerd declaration while preserving strict
 TypeScript and Wrangler dry-run validation. A matching request receives a
 302, its manifest destination, and
-`X-Palewire-Legacy-Redirect: cloudflare-worker-v1`. Queries are dropped just
-as Django's `RedirectView` drops them.
+`X-Palewire-Legacy-Redirect: cloudflare-worker-v1`. Queries are dropped.
 
 The generated plan has 37 explicit `palewi.re` routes for the 30 manifest
 entries. Every pattern has one terminal wildcard, which Cloudflare requires;
@@ -388,11 +388,11 @@ instead of proxying to Heroku. This Worker does not fetch a same-zone origin, so
 `global_fetch_strictly_public` is neither needed nor enabled. Its tests assert
 that redirect matches never create a subrequest.
 
-Smoke coverage for the Worker is deliberately deferred until Stage 2. Before
-the Worker is deployed, the production smoke workflow must continue to pass
-against Django's fallback redirects. Stage 1 uses the explicit verifier below;
-Stage 2 may add the same checks to the smoke workflow only after the routes are
-attached and verified.
+The production smoke workflow runs the same verifier after every successful
+Heroku deployment. It checks every exact rule, two representative cases for
+each dynamic rule, the exact `Location`, the Worker marker, and adjacent
+non-legacy paths. It uses a 20-second curl timeout and waits 15 seconds between
+up to four marker checks for route propagation.
 
 Use a dedicated Cloudflare token for deployment, restricted to the owning
 account and `palewi.re` zone. It needs only **Account > Workers Scripts >
@@ -430,19 +430,32 @@ WORKER_MARKER_ATTEMPTS=4 WORKER_MARKER_WAIT_SECONDS=15 make legacy-worker-verify
 
 Every mutating command requires its named confirmation variable. The verifier
 waits for the marker during route propagation but fails immediately on a bad
-status or Location. Django stays active throughout this PR, so an edge rollback
-is simply:
+status or Location.
+
+Before this Stage 2 deployment, record the latest fallback-capable Heroku
+release with `heroku releases --app palewire`. Once this version is deployed,
+Django deliberately returns `404` for every legacy redirect path. **Never
+detach or delete the Worker first:** that produces public `404`s.
+
+For an emergency rollback, use this order:
 
 ```bash
+# 1. Restore the exact release recorded before Stage 2.
+heroku rollback vN --app palewire
+
+# 2. Confirm its direct-origin Django redirects before changing Cloudflare.
+FALLBACK_ORIGIN="https://palewire.herokuapp.com"
+BASE_URL="$FALLBACK_ORIGIN" REQUIRE_WORKER_MARKER=false \
+  scripts/verify-legacy-redirects.sh
+
+# 3. Only then detach the Worker routes and verify public redirects.
 CONFIRM_LEGACY_WORKER_DETACH_ROUTES=1 make legacy-worker-detach-routes
+REQUIRE_WORKER_MARKER=false make legacy-worker-verify-production
 ```
 
-That deletion removes the Worker and its routes, exposing Django's fallback.
-Do not perform Stage 2 (remove `project/redirects.py` and its URL wiring) until
-the Stage 1 verifier and a normal production smoke cycle pass. Before Stage 2,
-record the fallback-capable Heroku release with `heroku releases --app
-palewire`. If a Stage 2 rollback is needed, restore that Heroku release first,
-then detach the Worker routes and verify the Django redirects.
+Keep the canary-first update process above for any future Worker update. A
+normal Worker code rollback without route changes uses Cloudflare version
+controls only after a verified canary.
 
 For the database retirement deployment, take a fresh Heroku backup first. Deploy
 the exact merged SHA, then verify `/health/`, the main pages, all post

--- a/project/redirect_manifest.py
+++ b/project/redirect_manifest.py
@@ -10,8 +10,6 @@ from typing import Any
 from urllib.parse import urlparse
 
 import yaml
-from django.urls import path, re_path
-from django.views.generic import RedirectView
 
 MANIFEST_PATH = Path(__file__).with_name("redirects.yaml")
 ROUTE_HOST = "palewi.re"
@@ -44,7 +42,7 @@ class RedirectRule:
         return bool(self.captures)
 
     @property
-    def django_pattern(self) -> str:
+    def match_pattern(self) -> str:
         parts: list[str] = []
         position = 0
         for match in _CAPTURE.finditer(self.source):
@@ -55,12 +53,8 @@ class RedirectRule:
         parts.append(re.escape(self.source[position:]))
         return f"^{''.join(parts)}$"
 
-    @property
-    def django_destination(self) -> str:
-        return _CAPTURE.sub(lambda match: f"%({match.group(1)})s", self.destination)
-
     def destination_for(self, path_value: str) -> str | None:
-        match = re.fullmatch(self.django_pattern, path_value.lstrip("/"))
+        match = re.fullmatch(self.match_pattern, path_value.lstrip("/"))
         if match is None:
             return None
         return self.destination.format(**match.groupdict())
@@ -176,7 +170,7 @@ def _validate_rule(record: Any, index: int) -> RedirectRule:
 
 
 def load_redirect_manifest(path_value: Path = MANIFEST_PATH) -> tuple[RedirectRule, ...]:
-    """Load and validate the YAML manifest before Django or Workers consume it."""
+    """Load and validate the YAML manifest before deployment tooling consumes it."""
     try:
         raw = yaml.safe_load(path_value.read_text())
     except yaml.YAMLError as error:
@@ -206,17 +200,6 @@ def cloudflare_route_plan(rules: tuple[RedirectRule, ...]) -> tuple[str, ...]:
 
 
 RULES = load_redirect_manifest()
-STATIC_REDIRECTS = {rule.source: rule.destination for rule in RULES if not rule.is_dynamic}
-
-
-patterns = [
-    *(
-        path(rule.source, RedirectView.as_view(url=rule.destination))
-        if not rule.is_dynamic
-        else re_path(rule.django_pattern, RedirectView.as_view(url=rule.django_destination))
-        for rule in RULES
-    ),
-]
 
 
 def main() -> None:

--- a/project/redirects.py
+++ b/project/redirects.py
@@ -1,6 +1,0 @@
-"""Django fallback redirects generated from the validated YAML manifest."""
-
-from . import redirect_manifest
-
-STATIC_REDIRECTS = redirect_manifest.STATIC_REDIRECTS
-patterns = redirect_manifest.patterns

--- a/project/urls.py
+++ b/project/urls.py
@@ -9,8 +9,6 @@ from coltrane.feeds import LatestPostsFeed
 from coltrane.sitemaps import sitemaps
 from toolbox.views import health_check
 
-from .redirects import patterns as redirectpatterns
-
 urlpatterns = [
     # Health check
     path("health/", health_check, name="health_check"),
@@ -48,5 +46,3 @@ urlpatterns = [
     path("favicon.ico", RedirectView.as_view(url=f"{settings.STATIC_URL}favicon.ico"), name="favicon"),
     path("@palewire", views.username_redirect),
 ]
-
-urlpatterns = [*redirectpatterns, *urlpatterns]

--- a/scripts/verify-legacy-redirects.sh
+++ b/scripts/verify-legacy-redirects.sh
@@ -6,6 +6,7 @@ base_url=${BASE_URL:-https://palewi.re}
 timeout=${CURL_MAX_TIME:-20}
 marker_attempts=${WORKER_MARKER_ATTEMPTS:-4}
 marker_wait_seconds=${WORKER_MARKER_WAIT_SECONDS:-15}
+require_marker=${REQUIRE_WORKER_MARKER:-true}
 
 case "$base_url" in
   http://*|https://*) ;;
@@ -13,6 +14,10 @@ case "$base_url" in
 esac
 case "$timeout:$marker_attempts:$marker_wait_seconds" in
   *[!0-9:]*|*::*) echo "CURL_MAX_TIME, WORKER_MARKER_ATTEMPTS, and WORKER_MARKER_WAIT_SECONDS must be integers." >&2; exit 1 ;;
+esac
+case "$require_marker" in
+  true|false) ;;
+  *) echo "REQUIRE_WORKER_MARKER must be true or false." >&2; exit 1 ;;
 esac
 if [ "$timeout" -eq 0 ] || [ "$marker_attempts" -eq 0 ]; then
   echo "CURL_MAX_TIME and WORKER_MARKER_ATTEMPTS must be positive." >&2
@@ -36,7 +41,8 @@ verify_redirect() {
     echo "$source_path: expected 302 Location $expected_location, received $status $location" >&2
     return 1
   fi
-  if ! printf '%s\n' "$headers" | grep -Fqx "x-palewire-legacy-redirect: cloudflare-worker-v1"; then
+  if [ "$require_marker" = "true" ] &&
+    ! printf '%s\n' "$headers" | grep -Fqx "x-palewire-legacy-redirect: cloudflare-worker-v1"; then
     return 2
   fi
 }
@@ -50,9 +56,20 @@ verify_all() {
 }
 
 verify_untouched() {
-  for path in /who-is-ben-welsh/ /health/ /posts/2026/08/24/current-post/; do
-    curl --silent --show-error --max-time "$timeout" --dump-header "$headers_file" --output "$body_file" "${base_url%/}${path}" >/dev/null || return 1
+  for expected in \
+    "/who-is-ben-welsh/:200" \
+    "/work/:200" \
+    "/docs/:200" \
+    "/posts/:200"
+  do
+    path=${expected%:*}
+    expected_status=${expected##*:}
+    status=$(curl --silent --show-error --max-time "$timeout" --dump-header "$headers_file" --output "$body_file" --write-out '%{http_code}' "${base_url%/}${path}") || return 1
     headers=$(tr '[:upper:]' '[:lower:]' < "$headers_file" | tr -d '\r')
+    if [ "$status" != "$expected_status" ]; then
+      echo "$path: expected HTTP $expected_status, received $status." >&2
+      return 1
+    fi
     if printf '%s\n' "$headers" | grep -Fq "x-palewire-legacy-redirect:"; then
       echo "$path: an adjacent non-legacy path was intercepted." >&2
       return 1
@@ -67,7 +84,7 @@ while :; do
   else
     result=$?
   fi
-  if [ "$result" -ne 2 ] || [ "$attempt" -ge "$marker_attempts" ]; then
+  if [ "$require_marker" != "true" ] || [ "$result" -ne 2 ] || [ "$attempt" -ge "$marker_attempts" ]; then
     echo "legacy redirect verification failed." >&2
     exit 1
   fi

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -9,7 +9,6 @@ from django.test.utils import override_settings
 from django.urls import include, path
 
 from project.redirect_manifest import RULES
-from project.redirects import STATIC_REDIRECTS
 
 
 def failing_view(_request):
@@ -27,7 +26,7 @@ def client():
 def test_root_redirects_to_bio(client):
     response = client.get("/")
     assert response.status_code in (301, 302)
-    assert "/who-is-ben-welsh/" in response["Location"]
+    assert response["Location"] == "/who-is-ben-welsh/"
 
 
 def test_bio_page_ok(client):
@@ -82,45 +81,19 @@ def test_django_no_longer_serves_mastodon_discovery_endpoints(client, page):
     assert client.get(page).status_code == 404
 
 
-@pytest.mark.parametrize(("source", "destination"), STATIC_REDIRECTS.items())
-def test_static_legacy_redirects_remain_stable(client, source, destination):
-    response = client.get(f"/{source}?source=test")
-    assert response.status_code == 302
-    assert response["Location"] == destination
-
-
 @pytest.mark.parametrize(
-    ("source", "destination"),
+    "path",
     [
-        ("/tag/django/", "/who-is-ben-welsh/"),
-        ("/tags/django/", "/who-is-ben-welsh/"),
-        ("/happyhours/old/", "/"),
-        ("/images/test.jpg", "https://palewire.s3.amazonaws.com/img/test.jpg"),
-        ("/applications/legacy/page/", "/apps/legacy/page/"),
-        ("/apps/page/2/", "/apps/"),
-        ("/posts/page/2/", "/posts/"),
-        ("/2009/09/01/test-post/", "/posts/2009/09/01/test-post/"),
+        *(f"/{rule.source}" for rule in RULES if not rule.is_dynamic),
+        *(example for rule in RULES if rule.is_dynamic for example in rule.examples),
     ],
 )
-def test_dynamic_legacy_redirects_remain_stable(client, source, destination):
-    response = client.get(source)
-    assert response.status_code == 302
-    assert response["Location"] == destination
-
-
-@pytest.mark.parametrize(
-    ("source", "destination"),
-    [(example, rule.destination_for(example)) for rule in RULES if rule.is_dynamic for example in rule.examples],
-)
-def test_dynamic_manifest_examples_match_django_redirects(client, source, destination):
-    response = client.get(f"{source}?source=test")
-
-    assert response.status_code == 302
-    assert response["Location"] == destination
+def test_legacy_manifest_paths_return_not_found_at_django_origin(client, path):
+    assert client.get(f"{path}?source=test").status_code == 404
 
 
 @pytest.mark.parametrize("source", ["/1/02/03/post/", "/2024/2/03/post/", "/2024/02/3/post/"])
-def test_date_redirect_rejects_malformed_capture_widths(client, source):
+def test_malformed_legacy_date_paths_return_not_found(client, source):
     assert client.get(source).status_code == 404
 
 
@@ -129,6 +102,13 @@ def test_favicon_route_exists(client):
     assert response.status_code in (200, 301, 302)
     if response.status_code in (301, 302):
         assert response["Location"] == static("favicon.ico")
+
+
+def test_username_redirect_remains_unchanged(client):
+    response = client.get("/@palewire")
+
+    assert response.status_code == 302
+    assert response["Location"] == "https://mastodon.palewi.re/@palewire"
 
 
 @override_settings(DEBUG=False)


### PR DESCRIPTION
## Summary

Closes #385.

Stage 2/2 removes Django's legacy redirect fallback. `project/redirects.py` and its URL wiring are gone; the YAML manifest remains the source of truth, and `project.redirect_manifest` is now pure validation, route-plan, and verifier-case tooling for the Worker.

The production smoke workflow now installs the verifier dependency and checks all 22 exact rules, both representative cases for each of 8 dynamic rules, exact redirect locations, Worker markers, and current non-legacy pages with propagation-aware retries. Django tests confirm all manifest legacy paths now return 404 while root, favicon, and `@palewire` behavior remains intact.

The rollback runbook requires restoring the recorded fallback-capable Heroku release and verifying its direct origin before detaching Worker routes. Detaching first produces public 404s.

## Testing

- [x] `make legacy-worker-test`
- [x] `make legacy-worker-validate`
- [x] `make legacy-worker-verify-production`
- [x] `make check`
- [x] Manifest case/route-plan checks, `uv lock --check`, and shell syntax
- [x] Independent code and security review

## Changelog

- [x] `maintenance`

## Deployment notes

Before deploy, record the exact fallback-capable Heroku release. If recovery is needed after deployment: roll back Heroku to that recorded release, verify direct-origin Django redirects at `palewire.herokuapp.com`, then detach the Cloudflare Worker routes and verify public redirects. Keep the Worker attached until the fallback is confirmed.