### PR TITLE
Fix footer revision alignment

### DIFF
--- a/coltrane/static/_footer.scss
+++ b/coltrane/static/_footer.scss
@@ -9,8 +9,9 @@
     display: flex;
     justify-content: space-between;
   }
-  .footer-commit {
+  .footer-revision {
     margin-left: auto;
+    white-space: nowrap;
   }
   @media (max-width: 550px) {
     font-size: 0.65em;

--- a/coltrane/templates/coltrane/base.html
+++ b/coltrane/templates/coltrane/base.html
@@ -113,9 +113,10 @@
                 <div class="twelvecol last">
                     <span property="rnews:copyrightNotice">© <span property="rnews:copyrightYear">{% now "Y" %}</span> palewire</span>
                     {% if repository_commit %}
-                    Revision <a class="footer-commit"
-                       href="{{ repository_url }}/commit/{{ repository_commit }}"
-                       aria-label="View commit {{ repository_commit_short }} on GitHub">{{ repository_commit_short }}</a>
+                    <span class="footer-revision">
+                        Revision <a href="{{ repository_url }}/commit/{{ repository_commit }}"
+                                    aria-label="View commit {{ repository_commit_short }} on GitHub">{{ repository_commit_short }}</a>
+                    </span>
                     {% endif %}
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- group the revision label with its commit hash
- keep the revision block aligned to the right without wrapping

## Testing
- `make check`