### PR TITLE
Upgrade smoke workflow checkout action

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -29,7 +29,7 @@ jobs:
       BASE_URL: ${{ github.event.inputs.base_url || 'https://palewi.re' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7


### PR DESCRIPTION
## Summary

- Upgrade the smoke workflow's checkout action from v4 to the current Node.js 24-supported v7 release.
- Match the existing repository-wide pinned checkout SHA.

## Validation

- `make check`
- Workflow YAML parsing
- Confirmed no `actions/checkout@v4` references remain

Independent code review found no significant issues.