### PR TITLE
Add preservation-only audio/video backup tooling

### DIFF
--- a/.github/skills/archive-media/SKILL.md
+++ b/.github/skills/archive-media/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: archive-media
+description: Preservation-only backup of audio/video referenced by coltrane/content/talks.yaml and coltrane/content/posts/. Use whenever running, auditing, or troubleshooting a durable local media backup so embeds are not lost if they disappear from the web.
+---
+
+# Archive audio/video media
+
+This tooling discovers every playable audio/video source referenced by talks
+and blog posts, then uses `yt-dlp` to download a durable copy into a
+directory **outside** this Git repository. Nothing is ever committed, and
+nothing is ever written under a repo static path. See issue #176.
+
+## Safety rules (read first)
+
+- Binaries only ever go to `--archive-root` (or `MEDIA_ARCHIVE_PATH`), a
+  directory you choose **outside** this repository. The CLI refuses any path
+  inside the repo.
+- This is preservation only. It never bypasses DRM, private access, login
+  requirements, paywalls, or any other access control. If yt-dlp cannot fetch
+  something without doing that, treat the failure as expected and move on.
+- `ffmpeg` is only required for sources that need muxing (YouTube, Vimeo, or
+  an unrecognized host). Direct file links and SoundCloud usually don't need
+  it. `ffmpeg` is never installed by `make bootstrap`; install it yourself
+  (e.g. `brew install ffmpeg`) only when you are about to back up those kinds.
+- Every run is idempotent and resumable. Re-running `backup` skips anything
+  already marked `success` in the manifest, and the manifest is rewritten
+  after every single item, so an interrupted run loses no progress.
+
+## Commands
+
+All commands live under `python -m scripts.media_archive` (or the equivalent
+`make` targets).
+
+### 1. Inventory (dry run, no network, no archive root needed)
+
+```bash
+make media-archive-inventory
+```
+
+Lists every discovered candidate, deduplicated by URL, with a breakdown by
+talk/post origin and by kind (`direct`, `youtube`, `vimeo`, `soundcloud`,
+`unknown`). Add `--json-output path.json` for machine-readable output. This
+step never touches the network or writes any media.
+
+### 2. Backup (downloads to your chosen archive root)
+
+```bash
+ARCHIVE_ROOT=/absolute/path/outside/the/repo make media-archive-backup
+```
+
+or directly:
+
+```bash
+uv run python -m scripts.media_archive backup --archive-root /absolute/path/outside/the/repo
+```
+
+Useful flags:
+
+- `--limit N` — process at most N candidates (good for a first careful run).
+- `--delay SECONDS` — pause between downloads (default 1s); be polite to
+  hosts.
+- `--force` — re-download and overwrite entries already marked `success`.
+- `--no-retry-failed` — skip candidates that failed on a previous run instead
+  of retrying them (retrying is the default).
+
+The command warns (but does not stop) if `ffmpeg` is missing and pending
+candidates need it. It exits non-zero if any candidate fails, so CI/automation
+can detect problems, but every attempted item's error is always written to the
+manifest — nothing fails silently.
+
+### 3. Verify (offline, recomputes checksums)
+
+```bash
+uv run python -m scripts.media_archive verify --archive-root /absolute/path/outside/the/repo
+```
+
+Recomputes the SHA-256 and size of every file marked `success` and reports
+`MISSING` or `MISMATCH` for any problem. Never touches the network.
+
+## The manifest
+
+`<archive-root>/manifest.json` is the single source of truth. It is always
+written atomically (temp file + rename), so a crash never leaves a corrupt
+manifest. Each entry records: source URL, every occurrence (talk/post that
+referenced it), extractor and media identity, status (`pending` / `success` /
+`failed` / `skipped`), output filename, size, SHA-256 checksum, the yt-dlp
+`.info.json` sidecar path when available, timestamps, and — on failure — the
+exact error message. Entries are never deleted, even if content changes
+later, so the manifest is a durable history.
+
+## Typical safe workflow
+
+1. `make media-archive-inventory` to see what would be backed up.
+2. Pick (or create) a real external archive directory, e.g. an attached
+   drive or a directory outside any repo.
+3. `ARCHIVE_ROOT=/path/to/archive make media-archive-backup` — start small
+   with `--limit` if you want to sanity check the first few downloads.
+4. Re-run the same command any time; it only attempts what is still pending
+   or previously failed.
+5. `uv run python -m scripts.media_archive verify --archive-root /path/to/archive`
+   periodically to confirm nothing has bit-rotted or gone missing.
+
+## Do not
+
+- Do not point `--archive-root` / `MEDIA_ARCHIVE_PATH` at anything inside
+  this repository — the CLI refuses this on purpose.
+- Do not add Actions schedules, cloud storage configuration (R2/S3), or
+  Django static-file storage for this tooling. It is a local/manual
+  maintenance script, not a deployed feature.
+- Do not close issue #176 after adding this tooling. Close it only once a
+  real, durable backup run has actually been completed against a real
+  archive location.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,10 @@ When adding or changing a URL in `coltrane/content/clips.yaml`, load the
 `archive-clips` skill and run `make archive-clips`. Every clip must retain the
 resulting `archive_url` or a specific `archive_exemption`.
 
+When running, auditing, or troubleshooting a local audio/video backup of the
+media referenced by `coltrane/content/talks.yaml` or blog posts, load the
+`archive-media` skill (`.github/skills/archive-media/SKILL.md`) first.
+
 ## Before finishing
 
 Run `make check`. This is the same set of lint, type, Django, and test checks
@@ -30,6 +34,7 @@ secrets, generated files, or `.goals/` agent state.
   - `coltrane/content_loaders.py`: validated loaders for all YAML content types
 - `toolbox/`: shared utilities
 - `project/`: Django settings and URL routing
+- `scripts/media_archive/`: preservation-only audio/video backup tooling (see below)
 - `tests/`: pytest suite
 
 Use `uv` and `pyproject.toml` for Python dependencies, the locked Dart Sass npm
@@ -163,3 +168,34 @@ bots:
 Order is preserved as written (no automatic sorting). Both `mastodon_url` and
 non-empty `twitter_url` values must be unique across the list. URLs must start
 with `http`.
+
+## Media archive (audio/video backup)
+
+`scripts/media_archive/` is a preservation-only backup tool for the
+audio/video referenced by `coltrane/content/talks.yaml` and blog posts under
+`coltrane/content/posts/`, tracked in issue #176 ("Back up video embeds
+locally"). Load `.github/skills/archive-media/SKILL.md` before running it.
+
+Key rules for agents:
+
+- Binaries and the manifest live **only** under a user-chosen
+  `--archive-root` / `MEDIA_ARCHIVE_PATH` directory **outside** this
+  repository. The CLI refuses any path inside the repo. Never write media
+  under a repo static path, and never commit media or a manifest.
+- It uses `yt-dlp` (a `dev` dependency group package) as the extractor and
+  downloader, plus `ffmpeg` only when a source needs stream muxing (YouTube,
+  Vimeo, unrecognized hosts). `ffmpeg` is intentionally excluded from
+  `make bootstrap`; install it only when actually backing up those kinds.
+- It never bypasses DRM, private access, login requirements, or other
+  controls — a source that requires that is expected to fail, and the
+  failure is recorded, not retried automatically forever.
+- `make media-archive-inventory` is network-free and safe to run any time.
+  `make media-archive-backup` (with `ARCHIVE_ROOT=...` or `MEDIA_ARCHIVE_PATH`
+  set) downloads pending/failed candidates and is idempotent/resumable.
+  `uv run python -m scripts.media_archive verify --archive-root ...` is an
+  offline checksum audit.
+- Do not add GitHub Actions schedules, R2/S3 configuration, or Django
+  static-file storage for this tool — it is a manual/local maintenance
+  script by design.
+- Do not close issue #176 just because this tooling exists; close it only
+  after a real, durable backup run has actually completed.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ LEGACY_WORKER_DIR := workers/legacy-redirects
 LEGACY_WORKER_CANARY_NAME := palewire-legacy-redirects-canary
 LEGACY_WORKER_SAME_ZONE_CANARY_ROUTE := palewi.re/legacy-redirects-canary*
 
-.PHONY: help bootstrap ci-bootstrap check-tools check-wrangler cloudflare-check install hooks css css-dev serve check test lint typecheck django-check fmt archive-clips check-clip-archives worker-test worker-validate worker-canary-deploy worker-verify-canary worker-delete-canary worker-same-zone-canary-deploy worker-attach-same-zone-canary worker-verify-same-zone-canary worker-delete-same-zone-canary worker-route-plan worker-attach-routes worker-verify-production worker-detach-routes worker-delete legacy-worker-test legacy-worker-validate legacy-worker-canary-deploy legacy-worker-delete-canary legacy-worker-same-zone-canary-deploy legacy-worker-attach-same-zone-canary legacy-worker-verify-same-zone-canary legacy-worker-delete-same-zone-canary legacy-worker-route-plan legacy-worker-attach-routes legacy-worker-verify-production legacy-worker-detach-routes legacy-worker-delete
+.PHONY: help bootstrap ci-bootstrap check-tools check-wrangler cloudflare-check install hooks css css-dev serve check test lint typecheck django-check fmt archive-clips check-clip-archives media-archive-inventory media-archive-backup media-archive-verify worker-test worker-validate worker-canary-deploy worker-verify-canary worker-delete-canary worker-same-zone-canary-deploy worker-attach-same-zone-canary worker-verify-same-zone-canary worker-delete-same-zone-canary worker-route-plan worker-attach-routes worker-verify-production worker-detach-routes worker-delete legacy-worker-test legacy-worker-validate legacy-worker-canary-deploy legacy-worker-delete-canary legacy-worker-same-zone-canary-deploy legacy-worker-attach-same-zone-canary legacy-worker-verify-same-zone-canary legacy-worker-delete-same-zone-canary legacy-worker-route-plan legacy-worker-attach-routes legacy-worker-verify-production legacy-worker-detach-routes legacy-worker-delete
 
 help:
 	@echo "Available targets:"
@@ -35,6 +35,9 @@ help:
 	@echo "  fmt        Auto-format with Ruff"
 	@echo "  archive-clips  Archive clip URLs missing Wayback metadata"
 	@echo "  check-clip-archives  Confirm every clip has Wayback metadata"
+	@echo "  media-archive-inventory  List discovered talk/post media without downloading anything"
+	@echo "  media-archive-backup  Back up pending media to ARCHIVE_ROOT (or MEDIA_ARCHIVE_PATH)"
+	@echo "  media-archive-verify  Recompute checksums of already-archived media, offline"
 	@echo "  worker-test  Install locked Worker dependencies and run Worker tests"
 	@echo "  worker-validate  Type-check and dry-run the Worker without deploying"
 	@echo "  worker-canary-deploy  Deploy a route-free Worker canary after explicit confirmation"
@@ -119,6 +122,17 @@ archive-clips:
 
 check-clip-archives:
 	@"$$(command -v uv)" run python -m scripts.archive_clips check
+
+media-archive-inventory:
+	@"$$(command -v uv)" run python -m scripts.media_archive inventory
+
+media-archive-backup:
+	@test -n "$$ARCHIVE_ROOT$$MEDIA_ARCHIVE_PATH" || { echo "Set ARCHIVE_ROOT=/path/outside/repo (or export MEDIA_ARCHIVE_PATH) to a directory outside this repository." >&2; exit 1; }
+	@"$$(command -v uv)" run python -m scripts.media_archive backup $(if $(ARCHIVE_ROOT),--archive-root "$(ARCHIVE_ROOT)",)
+
+media-archive-verify:
+	@test -n "$$ARCHIVE_ROOT$$MEDIA_ARCHIVE_PATH" || { echo "Set ARCHIVE_ROOT=/path/outside/repo (or export MEDIA_ARCHIVE_PATH) to a directory outside this repository." >&2; exit 1; }
+	@"$$(command -v uv)" run python -m scripts.media_archive verify $(if $(ARCHIVE_ROOT),--archive-root "$(ARCHIVE_ROOT)",)
 
 worker-test:
 	npm --prefix "$(WORKER_DIR)" ci --ignore-scripts --no-audit --no-fund

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ available local ports, so multiple agents can run the site at the same time.
 | `DEBUG` | No | Set `false` to disable debug output |
 | `SAVEPAGENOW_ACCESS_KEY` | No | Internet Archive access key used by `make archive-clips` |
 | `SAVEPAGENOW_SECRET_KEY` | No | Internet Archive secret key used by `make archive-clips` |
+| `MEDIA_ARCHIVE_PATH` | No | Directory outside the repo where `make media-archive-backup`/`verify` store media and the manifest |
 
 ## Quality gate
 
@@ -100,6 +101,33 @@ The first command reuses an existing snapshot or creates one with the
 `SAVEPAGENOW_ACCESS_KEY` and `SAVEPAGENOW_SECRET_KEY` environment variables.
 It writes progress after every clip and supports resumable batches with
 `uv run python -m scripts.archive_clips archive --limit 10`.
+
+## Media archive (audio/video backup)
+
+`scripts/media_archive/` finds every playable audio/video source referenced
+by `coltrane/content/talks.yaml` and blog posts, then uses `yt-dlp` to save a
+durable copy to a directory of your choosing, entirely **outside** this
+repository (see issue #176). Read
+[`.github/skills/archive-media/SKILL.md`](.github/skills/archive-media/SKILL.md)
+for the full workflow. In short:
+
+```bash
+# 1. See what would be backed up. Network-free, no archive root needed.
+make media-archive-inventory
+
+# 2. Download pending media to your chosen external directory.
+ARCHIVE_ROOT=/absolute/path/outside/the/repo make media-archive-backup
+
+# 3. Offline checksum audit of what's already archived.
+uv run python -m scripts.media_archive verify --archive-root /absolute/path/outside/the/repo
+```
+
+`--archive-root` (or the `MEDIA_ARCHIVE_PATH` environment variable) must
+point outside this repository; the command refuses paths inside it. Runs are
+idempotent and resumable, and a JSON manifest inside the archive root tracks
+every source URL, checksum, size, and any failure so nothing is silently
+dropped. `ffmpeg` is only needed for sources that require it (YouTube, Vimeo)
+and is never installed automatically by `make bootstrap`.
 
 ## Blog post Markdown
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dev = [
     "ruff>=0.14",
     "savepagenow>=1.3.1",
     "ty>=0.0.10",
+    "yt-dlp>=2026.8.19",
 ]
 
 [tool.uv]

--- a/scripts/media_archive/__init__.py
+++ b/scripts/media_archive/__init__.py
@@ -1,0 +1,5 @@
+"""Preservation-only local backup of audio/video referenced by the site.
+
+See ``.github/skills/archive-media/SKILL.md`` for the operator workflow and
+``AGENTS.md`` for the project conventions this package follows.
+"""

--- a/scripts/media_archive/__main__.py
+++ b/scripts/media_archive/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for ``python -m scripts.media_archive``."""
+
+from scripts.media_archive.cli import cli
+
+if __name__ == "__main__":
+    cli()

--- a/scripts/media_archive/cli.py
+++ b/scripts/media_archive/cli.py
@@ -1,0 +1,274 @@
+"""Click commands for the preservation-only media archive.
+
+Commands:
+
+* ``inventory`` - discover candidates without downloading anything (dry run).
+* ``backup`` - download pending/failed candidates into ``--archive-root``.
+* ``verify`` - recompute checksums of already-downloaded files, offline.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import click
+
+from coltrane.content_loaders import ContentError, load_posts, load_talks
+from scripts.media_archive import manifest as manifest_mod
+from scripts.media_archive.discovery import MediaCandidate, discover_candidates
+from scripts.media_archive.downloader import DownloadError, download_candidate, ffmpeg_available
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_candidates(talks_path: Path | None, posts_path: Path | None) -> list[MediaCandidate]:
+    """Load talks and posts, then discover media candidates."""
+    try:
+        talks = load_talks(talks_path) if talks_path else load_talks()
+        posts = load_posts(posts_path) if posts_path else load_posts()
+    except ContentError as error:
+        raise click.ClickException(str(error)) from error
+    return discover_candidates(talks, posts)
+
+
+def _resolve_archive_root(value: Path | None) -> Path:
+    """Validate and normalize a user-selected archive root, outside the repository."""
+    if value is None:
+        raise click.ClickException(
+            "An archive root is required. Pass --archive-root or set the MEDIA_ARCHIVE_PATH "
+            "environment variable to a directory outside this repository."
+        )
+    resolved = value.expanduser().resolve()
+    if resolved == REPO_ROOT or REPO_ROOT in resolved.parents:
+        raise click.ClickException(
+            f"Refusing to store media under the repository at {REPO_ROOT}. Choose an external --archive-root."
+        )
+    return resolved
+
+
+def _talks_path_option() -> Any:
+    return click.option(
+        "--talks-path",
+        type=click.Path(path_type=Path, exists=True, dir_okay=False),
+        default=None,
+        help="Override the talks YAML path (defaults to coltrane/content/talks.yaml).",
+    )
+
+
+def _posts_path_option() -> Any:
+    return click.option(
+        "--posts-path",
+        type=click.Path(path_type=Path, exists=True, file_okay=False),
+        default=None,
+        help="Override the posts directory (defaults to coltrane/content/posts).",
+    )
+
+
+def _archive_root_option() -> Any:
+    return click.option(
+        "--archive-root",
+        "archive_root",
+        type=click.Path(path_type=Path, file_okay=False),
+        envvar="MEDIA_ARCHIVE_PATH",
+        default=None,
+        help="Directory outside the repository where media and the manifest are stored. "
+        "Can also be set with the MEDIA_ARCHIVE_PATH environment variable.",
+    )
+
+
+@click.group()
+def cli() -> None:
+    """Discover and preserve playable audio/video sources referenced by the site."""
+
+
+@cli.command()
+@_talks_path_option()
+@_posts_path_option()
+@click.option(
+    "--json-output",
+    "json_output_path",
+    type=click.Path(path_type=Path, dir_okay=False),
+    default=None,
+    help="Write the discovered candidates as JSON to this path.",
+)
+def inventory(talks_path: Path | None, posts_path: Path | None, json_output_path: Path | None) -> None:
+    """List discovered media candidates without downloading anything."""
+    candidates = _load_candidates(talks_path, posts_path)
+
+    talk_count = sum(1 for candidate in candidates if any(o.origin_type == "talk" for o in candidate.occurrences))
+    post_count = sum(1 for candidate in candidates if any(o.origin_type == "post" for o in candidate.occurrences))
+    by_kind: dict[str, int] = {}
+    for candidate in candidates:
+        by_kind[candidate.kind] = by_kind.get(candidate.kind, 0) + 1
+    total_occurrences = sum(len(candidate.occurrences) for candidate in candidates)
+
+    click.echo(f"Discovered {len(candidates)} unique media candidate(s) ({total_occurrences} occurrence(s)).")
+    click.echo(f"  Referenced by talks: {talk_count}")
+    click.echo(f"  Referenced by posts: {post_count}")
+    for kind in sorted(by_kind):
+        click.echo(f"  {kind}: {by_kind[kind]}")
+
+    if json_output_path is not None:
+        payload = [
+            {
+                "url": candidate.url,
+                "kind": candidate.kind,
+                "occurrences": [
+                    {
+                        "origin_type": occurrence.origin_type,
+                        "origin_id": occurrence.origin_id,
+                        "location": occurrence.location,
+                        "raw_url": occurrence.raw_url,
+                    }
+                    for occurrence in candidate.occurrences
+                ],
+            }
+            for candidate in candidates
+        ]
+        json_output_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        click.echo(f"Wrote candidate JSON to {json_output_path}")
+
+
+@cli.command()
+@_archive_root_option()
+@_talks_path_option()
+@_posts_path_option()
+@click.option("--limit", type=click.IntRange(min=1), default=None, help="Process at most this many candidates.")
+@click.option(
+    "--delay", type=click.FloatRange(min=0), default=1.0, show_default=True, help="Seconds between downloads."
+)
+@click.option(
+    "--force/--no-force",
+    default=False,
+    help="Re-download and overwrite entries already marked successful.",
+)
+@click.option(
+    "--retry-failed/--no-retry-failed",
+    default=True,
+    show_default=True,
+    help="Retry candidates that previously failed.",
+)
+def backup(
+    archive_root: Path | None,
+    talks_path: Path | None,
+    posts_path: Path | None,
+    limit: int | None,
+    delay: float,
+    force: bool,
+    retry_failed: bool,
+) -> None:
+    """Download pending (and, by default, previously failed) media into --archive-root."""
+    resolved_root = _resolve_archive_root(archive_root)
+    candidates = _load_candidates(talks_path, posts_path)
+    manifest = manifest_mod.load_manifest(resolved_root)
+    manifest = manifest_mod.sync_candidates(manifest, candidates)
+    manifest_mod.write_manifest(resolved_root, manifest)
+
+    def needs_attempt(entry: manifest_mod.ManifestEntry) -> bool:
+        if force:
+            return True
+        if entry.status == manifest_mod.STATUS_SUCCESS:
+            return False
+        if entry.status == manifest_mod.STATUS_FAILED and not retry_failed:
+            return False
+        return True
+
+    pending_urls = [candidate.url for candidate in candidates if needs_attempt(manifest.entries[candidate.url])]
+    if limit is not None:
+        pending_urls = pending_urls[:limit]
+
+    if not pending_urls:
+        click.echo("Nothing to back up. Every candidate is already marked successful.")
+        return
+
+    if any(manifest.entries[url].kind != "direct" for url in pending_urls) and not ffmpeg_available():
+        click.echo(
+            "Warning: ffmpeg was not found on PATH. Downloads that require merging separate "
+            "audio/video streams (YouTube, Vimeo) will fail until ffmpeg is installed.",
+            err=True,
+        )
+
+    successes = 0
+    failures = 0
+    for index, url in enumerate(pending_urls, start=1):
+        entry = manifest.entries[url]
+        click.echo(f"[{index}/{len(pending_urls)}] {entry.kind}: {url}")
+        entry.attempts += 1
+        outcome = None
+        try:
+            outcome = download_candidate(url, entry.kind, resolved_root)
+        except DownloadError as error:
+            entry.status = manifest_mod.STATUS_FAILED
+            entry.error = str(error)
+            click.echo(f"  failed: {error}")
+            failures += 1
+        if outcome is not None:
+            if outcome.status == "success":
+                entry.status = manifest_mod.STATUS_SUCCESS
+                entry.extractor = outcome.extractor
+                entry.media_id = outcome.media_id
+                entry.output_filename = outcome.output_filename
+                entry.size_bytes = outcome.size_bytes
+                assert outcome.output_filename is not None
+                entry.sha256 = manifest_mod.sha256_file(resolved_root / outcome.output_filename)
+                entry.info_json_path = outcome.info_json_path
+                entry.error = None
+                click.echo(f"  success: {outcome.output_filename} ({outcome.size_bytes} bytes)")
+                successes += 1
+            else:
+                entry.status = manifest_mod.STATUS_FAILED
+                entry.error = outcome.error
+                click.echo(f"  failed: {outcome.error}")
+                failures += 1
+        entry.updated_at = manifest_mod.current_timestamp()
+        # Write after every item so progress survives an interruption.
+        manifest_mod.write_manifest(resolved_root, manifest)
+        if index < len(pending_urls):
+            time.sleep(delay)
+
+    click.echo(f"\nDone: {successes} succeeded, {failures} failed.")
+    if failures:
+        raise click.ClickException(f"{failures} candidate(s) failed to back up. See the manifest for details.")
+
+
+@cli.command()
+@_archive_root_option()
+def verify(archive_root: Path | None) -> None:
+    """Offline verification: recompute checksums of already-downloaded files."""
+    resolved_root = _resolve_archive_root(archive_root)
+    manifest = manifest_mod.load_manifest(resolved_root)
+
+    successful_entries = [entry for entry in manifest.entries.values() if entry.status == manifest_mod.STATUS_SUCCESS]
+    if not successful_entries:
+        click.echo("No successfully archived media to verify yet.")
+        return
+
+    missing = 0
+    mismatched = 0
+    verified = 0
+    for entry in successful_entries:
+        if not entry.output_filename:
+            continue
+        file_path = resolved_root / entry.output_filename
+        if not file_path.exists():
+            click.echo(f"MISSING  {entry.output_filename} ({entry.source_url})")
+            missing += 1
+            continue
+        actual_sha256 = manifest_mod.sha256_file(file_path)
+        actual_size = file_path.stat().st_size
+        if actual_sha256 != entry.sha256 or actual_size != entry.size_bytes:
+            click.echo(f"MISMATCH {entry.output_filename} ({entry.source_url})")
+            mismatched += 1
+            continue
+        verified += 1
+
+    click.echo(f"\nVerified {verified} file(s); {missing} missing; {mismatched} mismatched.")
+    if missing or mismatched:
+        raise click.ClickException(f"{missing + mismatched} file(s) failed verification.")
+
+
+if __name__ == "__main__":
+    cli()

--- a/scripts/media_archive/discovery.py
+++ b/scripts/media_archive/discovery.py
@@ -1,0 +1,280 @@
+"""Discover playable audio/video sources in talks and blog posts.
+
+This module never downloads or fetches anything over the network. It only
+parses already-loaded content (:mod:`coltrane.content_loaders`) and applies
+conservative pattern matching to decide whether a URL is a playable media
+source worth preserving.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import parse_qs, unquote, urljoin, urlsplit
+
+from bs4 import BeautifulSoup
+
+from coltrane.content_loaders import MarkdownPost, Talk
+
+# ---------------------------------------------------------------------------
+# Known media file extensions and hosts
+# ---------------------------------------------------------------------------
+
+# File extensions that identify a direct, playable media file regardless of
+# the host that serves it (self-hosted clips, S3 buckets, CDNs, and so on).
+DIRECT_MEDIA_EXTENSIONS = frozenset(
+    {
+        ".mp4",
+        ".m4v",
+        ".mov",
+        ".webm",
+        ".mkv",
+        ".avi",
+        ".mp3",
+        ".m4a",
+        ".wav",
+        ".ogg",
+        ".oga",
+        ".flac",
+        ".aac",
+        ".wma",
+    }
+)
+
+_VIMEO_WATCH_RE = re.compile(r"^https?://(?:www\.)?vimeo\.com/(\d+)")
+_VIMEO_PLAYER_RE = re.compile(r"^https?://player\.vimeo\.com/video/(\d+)")
+_YOUTUBE_WATCH_RE = re.compile(
+    r"^https?://(?:www\.|m\.)?(?:youtube\.com|youtube-nocookie\.com)/watch\?(?:.*&)?v=([\w-]{6,})"
+)
+_YOUTUBE_EMBED_RE = re.compile(r"^https?://(?:www\.)?(?:youtube\.com|youtube-nocookie\.com)/embed/([\w-]{6,})")
+_YOUTUBE_SHORT_RE = re.compile(r"^https?://youtu\.be/([\w-]{6,})")
+_SOUNDCLOUD_TRACK_RE = re.compile(r"^https?://(?:www\.)?soundcloud\.com/[^/?#]+/[^/?#]+")
+_SOUNDCLOUD_PLAYER_RE = re.compile(r"^https?://w\.soundcloud\.com/player/")
+
+KIND_DIRECT = "direct"
+KIND_YOUTUBE = "youtube"
+KIND_VIMEO = "vimeo"
+KIND_SOUNDCLOUD = "soundcloud"
+KIND_UNKNOWN = "unknown"
+
+# The site's canonical origin, used to resolve site-relative media links
+# (e.g. ``<a href="/media/mp3/clip.mp3">``) into absolute, downloadable URLs.
+SITE_BASE_URL = "https://palewi.re"
+
+
+# ---------------------------------------------------------------------------
+# Typed results
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MediaOccurrence:
+    """One place a media URL was found."""
+
+    origin_type: str  # "talk" | "post"
+    origin_id: str  # talk identifier or post slug
+    location: str  # e.g. "video_url", "video", "audio>source", "iframe", "a"
+    raw_url: str  # the exact string found in the source content
+
+
+@dataclass(frozen=True)
+class MediaCandidate:
+    """A deduplicated, playable media URL and every place it was found."""
+
+    url: str
+    kind: str
+    occurrences: tuple[MediaOccurrence, ...]
+
+
+# ---------------------------------------------------------------------------
+# URL classification
+# ---------------------------------------------------------------------------
+
+
+def normalize_url(url: str) -> str:
+    """Resolve protocol-relative and site-relative URLs; strip surrounding whitespace.
+
+    Protocol-relative URLs (``//host/path``) are given an ``https:`` scheme.
+    Site-relative paths (``/media/...``) are resolved against
+    :data:`SITE_BASE_URL` so they become downloadable absolute URLs, since
+    they only ever appear in this site's own content referring to media it
+    hosts itself.
+    """
+    stripped = url.strip()
+    if stripped.startswith("//"):
+        return f"https:{stripped}"
+    if stripped.startswith("/"):
+        return urljoin(f"{SITE_BASE_URL}/", stripped.lstrip("/"))
+    return stripped
+
+
+def _extension(url: str) -> str:
+    """Return the lowercase file extension of a URL's path, ignoring the query string."""
+    path = urlsplit(url).path
+    if "." not in path:
+        return ""
+    return "." + path.rsplit(".", 1)[-1].lower()
+
+
+def classify_media_url(url: str) -> str | None:
+    """Classify a direct link or media-element ``src`` as a known playable kind.
+
+    Returns ``None`` when the URL does not look like playable media, such as
+    an ordinary webpage, an image, a social profile link, or a hosted
+    interactive.
+    """
+    normalized = normalize_url(url)
+    if _extension(normalized) in DIRECT_MEDIA_EXTENSIONS:
+        return KIND_DIRECT
+    if (
+        _YOUTUBE_WATCH_RE.match(normalized)
+        or _YOUTUBE_EMBED_RE.match(normalized)
+        or _YOUTUBE_SHORT_RE.match(normalized)
+    ):
+        return KIND_YOUTUBE
+    if _VIMEO_WATCH_RE.match(normalized) or _VIMEO_PLAYER_RE.match(normalized):
+        return KIND_VIMEO
+    if _SOUNDCLOUD_TRACK_RE.match(normalized):
+        return KIND_SOUNDCLOUD
+    return None
+
+
+def classify_iframe_url(url: str) -> tuple[str, str] | None:
+    """Classify an ``<iframe src>`` from a known media-host embed.
+
+    Returns ``(kind, canonical_url)`` for a recognized embed, resolving the
+    embed's player URL back to the canonical page for the underlying media.
+    Returns ``None`` for generic iframes (Google Slides, hosted interactives,
+    maps, and so on), which are never treated as media candidates.
+    """
+    normalized = normalize_url(url)
+    vimeo_match = _VIMEO_PLAYER_RE.match(normalized)
+    if vimeo_match:
+        return KIND_VIMEO, f"https://vimeo.com/{vimeo_match.group(1)}"
+    youtube_match = _YOUTUBE_EMBED_RE.match(normalized)
+    if youtube_match:
+        return KIND_YOUTUBE, f"https://www.youtube.com/watch?v={youtube_match.group(1)}"
+    if _SOUNDCLOUD_PLAYER_RE.match(normalized):
+        query = parse_qs(urlsplit(normalized).query)
+        track_urls = query.get("url")
+        if track_urls and track_urls[0]:
+            return KIND_SOUNDCLOUD, unquote(track_urls[0])
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+def _talk_origin_id(talk: Talk) -> str:
+    """Build a stable, human-readable identifier for a talk without a slug."""
+    return f"{talk.date.isoformat()} {talk.title}"
+
+
+def discover_talk_occurrence(talk: Talk) -> tuple[str, str, MediaOccurrence] | None:
+    """Return the ``(url, kind, occurrence)`` for a talk's video, if any.
+
+    Every non-empty ``video_url`` is preserved because the field's meaning
+    already guarantees it is a video link curated by the author. Unrecognized
+    hosts still get a candidate (``kind="unknown"``) so yt-dlp's own
+    site-detection can attempt the download.
+    """
+    if not talk.video_url:
+        return None
+    kind = classify_media_url(talk.video_url) or KIND_UNKNOWN
+    occurrence = MediaOccurrence(
+        origin_type="talk",
+        origin_id=_talk_origin_id(talk),
+        location="video_url",
+        raw_url=talk.video_url,
+    )
+    return talk.video_url, kind, occurrence
+
+
+def _attribute(tag: Any, name: str) -> str | None:
+    """Return a tag attribute as a plain string, or ``None`` if absent."""
+    value = tag.get(name)
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return "".join(value)
+    return str(value)
+
+
+def discover_post_occurrences(post: MarkdownPost) -> list[tuple[str, str, MediaOccurrence]]:
+    """Return every ``(url, kind, occurrence)`` found in one post's body."""
+    results: list[tuple[str, str, MediaOccurrence]] = []
+    soup = BeautifulSoup(post.body_markup, "html.parser")
+
+    for tag_name in ("video", "audio"):
+        for media_tag in soup.find_all(tag_name):
+            src = _attribute(media_tag, "src")
+            if src:
+                results.append(
+                    (src, classify_media_url(src) or KIND_DIRECT, MediaOccurrence("post", post.slug, tag_name, src))
+                )
+            for source_tag in media_tag.find_all("source"):
+                source_src = _attribute(source_tag, "src")
+                if source_src:
+                    results.append(
+                        (
+                            source_src,
+                            classify_media_url(source_src) or KIND_DIRECT,
+                            MediaOccurrence("post", post.slug, f"{tag_name}>source", source_src),
+                        )
+                    )
+
+    for iframe_tag in soup.find_all("iframe"):
+        src = _attribute(iframe_tag, "src")
+        if not src:
+            continue
+        classified = classify_iframe_url(src)
+        if classified is None:
+            continue
+        kind, canonical_url = classified
+        results.append((canonical_url, kind, MediaOccurrence("post", post.slug, "iframe", src)))
+
+    for anchor_tag in soup.find_all("a"):
+        href = _attribute(anchor_tag, "href")
+        if not href:
+            continue
+        kind = classify_media_url(href)
+        if kind is None:
+            continue
+        results.append((href, kind, MediaOccurrence("post", post.slug, "a", href)))
+
+    return results
+
+
+def discover_candidates(talks: Sequence[Talk], posts: Sequence[MarkdownPost]) -> list[MediaCandidate]:
+    """Discover every playable media URL across talks and posts, deduplicated.
+
+    Identical URLs are merged into a single :class:`MediaCandidate`, but every
+    occurrence (talk or post that referenced it) is retained. Discovery order
+    follows the order talks and posts are supplied in.
+    """
+    order: list[str] = []
+    kinds: dict[str, str] = {}
+    occurrences: dict[str, list[MediaOccurrence]] = {}
+
+    def record(url: str, kind: str, occurrence: MediaOccurrence) -> None:
+        normalized = normalize_url(url)
+        if normalized not in occurrences:
+            order.append(normalized)
+            kinds[normalized] = kind
+            occurrences[normalized] = []
+        occurrences[normalized].append(occurrence)
+
+    for talk in talks:
+        found = discover_talk_occurrence(talk)
+        if found is not None:
+            record(*found)
+
+    for post in posts:
+        for url, kind, occurrence in discover_post_occurrences(post):
+            record(url, kind, occurrence)
+
+    return [MediaCandidate(url=url, kind=kinds[url], occurrences=tuple(occurrences[url])) for url in order]

--- a/scripts/media_archive/downloader.py
+++ b/scripts/media_archive/downloader.py
@@ -1,0 +1,156 @@
+"""Download media candidates with yt-dlp as the primary extractor.
+
+This module never bypasses DRM, private access, login walls, or other
+publisher controls; it only invokes yt-dlp's standard public extraction
+path. Direct media files (plain ``.mp4``/``.mp3`` links, etc.) are handled by
+yt-dlp's generic extractor, so every candidate flows through the same code
+path regardless of host.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from scripts.media_archive.discovery import KIND_DIRECT
+
+# yt-dlp needs ffmpeg to merge separately downloaded video and audio streams,
+# which is common for YouTube and Vimeo. Direct files and most SoundCloud
+# tracks are single streams and never require it, so we only check when a
+# candidate's kind is likely to need merging.
+KINDS_REQUIRING_FFMPEG = frozenset({"youtube", "vimeo", "unknown"})
+
+_UNSAFE_FILENAME_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+class DownloadError(RuntimeError):
+    """Raised when a download cannot proceed (e.g. missing ffmpeg)."""
+
+
+class SupportsExtractInfo(Protocol):
+    """The subset of yt-dlp's ``YoutubeDL`` interface this module relies on."""
+
+    def __enter__(self) -> SupportsExtractInfo: ...
+
+    def __exit__(self, *exc_info: object) -> None: ...
+
+    def extract_info(self, url: str, download: bool = True) -> dict[str, Any]: ...
+
+
+def ffmpeg_available() -> bool:
+    """Return whether an ``ffmpeg`` binary is on ``PATH``."""
+    return shutil.which("ffmpeg") is not None
+
+
+def require_ffmpeg(kind: str) -> None:
+    """Raise :class:`DownloadError` if a kind needs ffmpeg and it is missing."""
+    if kind in KINDS_REQUIRING_FFMPEG and not ffmpeg_available():
+        raise DownloadError(
+            "ffmpeg is required to merge the separate audio and video streams "
+            f"yt-dlp downloads for '{kind}' sources. Install ffmpeg and retry."
+        )
+
+
+def _safe_dirname(kind: str) -> str:
+    """Return a filesystem-safe subdirectory name for a candidate kind."""
+    cleaned = _UNSAFE_FILENAME_RE.sub("-", kind).strip("-")
+    return cleaned or "other"
+
+
+def default_ydl_factory(options: dict[str, Any]) -> SupportsExtractInfo:
+    """Build the real yt-dlp client. Imported lazily so tests never need it installed at import time."""
+    import yt_dlp
+
+    return yt_dlp.YoutubeDL(options)
+
+
+@dataclass
+class DownloadOutcome:
+    """The result of attempting to download a single media candidate."""
+
+    status: str  # "success" | "failed"
+    extractor: str | None = None
+    media_id: str | None = None
+    output_filename: str | None = None
+    size_bytes: int | None = None
+    info_json_path: str | None = None
+    error: str | None = None
+
+
+def _resolve_output_path(ydl: SupportsExtractInfo, info: dict[str, Any], output_dir: Path) -> Path | None:
+    """Find the file yt-dlp actually wrote, which may differ from the template after post-processing."""
+    requested_downloads = info.get("requested_downloads")
+    if isinstance(requested_downloads, list) and requested_downloads:
+        filepath = requested_downloads[0].get("filepath") or requested_downloads[0].get("_filename")
+        if filepath:
+            return Path(filepath)
+    filepath = info.get("filepath") or info.get("_filename")
+    if filepath:
+        return Path(filepath)
+    prepare_filename = getattr(ydl, "prepare_filename", None)
+    if callable(prepare_filename):
+        try:
+            return Path(prepare_filename(info))
+        except Exception:  # pragma: no cover - defensive fallback only
+            return None
+    return None
+
+
+def download_candidate(
+    url: str,
+    kind: str,
+    archive_root: Path,
+    *,
+    ydl_factory: Any = default_ydl_factory,
+) -> DownloadOutcome:
+    """Download one media candidate with yt-dlp and report the outcome.
+
+    Never raises for ordinary extraction/download failures — those are
+    captured explicitly in the returned :class:`DownloadOutcome` so callers
+    can record them in the manifest instead of losing them. Only a missing
+    ffmpeg dependency raises :class:`DownloadError`, since that is a
+    fixable environment problem rather than a per-item failure.
+    """
+    require_ffmpeg(kind)
+    output_dir = archive_root / _safe_dirname(kind)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    options: dict[str, Any] = {
+        "outtmpl": str(output_dir / "%(id)s.%(ext)s"),
+        "writeinfojson": True,
+        "noplaylist": True,
+        "quiet": True,
+        "no_warnings": True,
+        "restrictfilenames": True,
+    }
+    if kind == KIND_DIRECT:
+        # Never let the generic extractor treat a direct file link as a
+        # webpage to crawl for other links.
+        options["force_generic_extractor"] = True
+
+    try:
+        with ydl_factory(options) as ydl:
+            info = ydl.extract_info(url, download=True)
+    except Exception as error:  # yt-dlp raises many different error types
+        return DownloadOutcome(status="failed", error=str(error))
+
+    if not isinstance(info, dict):
+        return DownloadOutcome(status="failed", error="yt-dlp returned no metadata for this URL")
+
+    output_path = _resolve_output_path(ydl, info, output_dir)
+    if output_path is None or not output_path.exists():
+        return DownloadOutcome(status="failed", error="yt-dlp reported success but the output file is missing")
+
+    info_json_path = output_path.with_suffix(".info.json")
+
+    return DownloadOutcome(
+        status="success",
+        extractor=info.get("extractor_key") or info.get("extractor"),
+        media_id=info.get("id"),
+        output_filename=str(output_path.relative_to(archive_root)),
+        size_bytes=output_path.stat().st_size,
+        info_json_path=str(info_json_path.relative_to(archive_root)) if info_json_path.exists() else None,
+    )

--- a/scripts/media_archive/manifest.py
+++ b/scripts/media_archive/manifest.py
@@ -1,0 +1,171 @@
+"""Atomic, durable manifest tracking every media archive attempt.
+
+The manifest is the single source of truth for idempotent, resumable
+downloads. It lives inside the archive root (never inside the Git
+repository) as ``manifest.json`` and is always rewritten atomically: a
+temporary file is written and then renamed over the target so a crash or
+interrupted process can never leave a half-written manifest behind.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.media_archive.discovery import MediaCandidate, MediaOccurrence
+
+MANIFEST_VERSION = 1
+MANIFEST_FILENAME = "manifest.json"
+
+STATUS_PENDING = "pending"
+STATUS_SUCCESS = "success"
+STATUS_FAILED = "failed"
+STATUS_SKIPPED = "skipped"
+
+_CHECKSUM_CHUNK_SIZE = 1024 * 1024
+
+
+def current_timestamp() -> str:
+    """Return the current UTC time as an ISO 8601 string.
+
+    This uses the standard library directly (not ``django.utils.timezone``)
+    so the archive CLI works standalone, without ``DJANGO_SETTINGS_MODULE``
+    configured, exactly like the rest of ``scripts/``.
+    """
+    return datetime.now(UTC).isoformat()
+
+
+@dataclass
+class ManifestEntry:
+    """One tracked media source and the outcome of the last attempt to back it up."""
+
+    source_url: str
+    kind: str
+    occurrences: list[dict[str, str]]
+    status: str = STATUS_PENDING
+    extractor: str | None = None
+    media_id: str | None = None
+    output_filename: str | None = None
+    size_bytes: int | None = None
+    sha256: str | None = None
+    info_json_path: str | None = None
+    attempts: int = 0
+    error: str | None = None
+    created_at: str = field(default_factory=current_timestamp)
+    updated_at: str = field(default_factory=current_timestamp)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ManifestEntry:
+        """Rebuild an entry from its JSON-serializable representation."""
+        known_fields = {f for f in cls.__dataclass_fields__}
+        return cls(**{key: value for key, value in data.items() if key in known_fields})
+
+
+@dataclass
+class Manifest:
+    """The full set of tracked media entries, keyed by source URL."""
+
+    entries: dict[str, ManifestEntry] = field(default_factory=dict)
+    version: int = MANIFEST_VERSION
+    updated_at: str = field(default_factory=current_timestamp)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation with sorted keys for stable diffs."""
+        return {
+            "version": self.version,
+            "updated_at": self.updated_at,
+            "entries": {url: self.entries[url].to_dict() for url in sorted(self.entries)},
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Manifest:
+        """Rebuild a manifest from its JSON-serializable representation."""
+        entries = {url: ManifestEntry.from_dict(entry) for url, entry in data.get("entries", {}).items()}
+        return cls(
+            entries=entries,
+            version=data.get("version", MANIFEST_VERSION),
+            updated_at=data.get("updated_at", current_timestamp()),
+        )
+
+
+class ManifestError(RuntimeError):
+    """Raised when a manifest file on disk is invalid."""
+
+
+def manifest_path(archive_root: Path) -> Path:
+    """Return the manifest path inside an archive root."""
+    return archive_root / MANIFEST_FILENAME
+
+
+def load_manifest(archive_root: Path) -> Manifest:
+    """Load the manifest from an archive root, or return an empty one."""
+    path = manifest_path(archive_root)
+    if not path.exists():
+        return Manifest()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise ManifestError(f"{path}: manifest is not valid JSON") from error
+    if not isinstance(raw, dict):
+        raise ManifestError(f"{path}: manifest must be a JSON object")
+    return Manifest.from_dict(raw)
+
+
+def write_manifest(archive_root: Path, manifest: Manifest) -> None:
+    """Atomically write the manifest, updating its top-level timestamp."""
+    archive_root.mkdir(parents=True, exist_ok=True)
+    manifest.updated_at = current_timestamp()
+    path = manifest_path(archive_root)
+    temporary_path = path.with_suffix(f"{path.suffix}.tmp")
+    temporary_path.write_text(json.dumps(manifest.to_dict(), indent=2, sort_keys=False) + "\n", encoding="utf-8")
+    temporary_path.replace(path)
+
+
+def sha256_file(path: Path) -> str:
+    """Compute the SHA-256 checksum of a file, reading it in fixed-size chunks."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(_CHECKSUM_CHUNK_SIZE):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def occurrence_to_dict(occurrence: MediaOccurrence) -> dict[str, str]:
+    """Serialize an occurrence for storage in the manifest."""
+    return {
+        "origin_type": occurrence.origin_type,
+        "origin_id": occurrence.origin_id,
+        "location": occurrence.location,
+        "raw_url": occurrence.raw_url,
+    }
+
+
+def sync_candidates(manifest: Manifest, candidates: list[MediaCandidate]) -> Manifest:
+    """Ensure every discovered candidate has a manifest entry.
+
+    Existing entries keep their download status and history; only their
+    ``kind`` and ``occurrences`` are refreshed to match the latest discovery
+    pass. New candidates are added as ``pending``. Nothing is ever deleted,
+    so the manifest retains a durable record even if content changes later.
+    """
+    for candidate in candidates:
+        occurrence_dicts = [occurrence_to_dict(occurrence) for occurrence in candidate.occurrences]
+        existing = manifest.entries.get(candidate.url)
+        if existing is None:
+            manifest.entries[candidate.url] = ManifestEntry(
+                source_url=candidate.url,
+                kind=candidate.kind,
+                occurrences=occurrence_dicts,
+            )
+        else:
+            existing.kind = candidate.kind
+            existing.occurrences = occurrence_dicts
+    return manifest

--- a/tests/test_media_archive_cli.py
+++ b/tests/test_media_archive_cli.py
@@ -1,0 +1,519 @@
+"""Tests for the media archive Click commands."""
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from scripts.media_archive import cli as cli_module
+from scripts.media_archive import downloader
+from scripts.media_archive import manifest as manifest_mod
+
+
+def write_talks(path: Path) -> None:
+    path.write_text(
+        "talks:\n"
+        "- title: A Talk\n"
+        "  venue: V\n"
+        "  location: L\n"
+        "  date: '2024-01-01'\n"
+        "  video_url: https://vimeo.com/123456\n",
+        encoding="utf-8",
+    )
+
+
+def write_posts(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "2024-01-01--example-post.md").write_text(
+        "---\n"
+        "title: Example post\n"
+        "slug: example-post\n"
+        'published_at: "2024-01-01T09:00:00-08:00"\n'
+        "---\n"
+        '<video src="https://example.com/clip.mp4"></video>\n',
+        encoding="utf-8",
+    )
+
+
+def run_inventory(tmp_path, extra_args=()):
+    talks_path = tmp_path / "talks.yaml"
+    posts_path = tmp_path / "posts"
+    write_talks(talks_path)
+    write_posts(posts_path)
+    runner = CliRunner()
+    args = ["inventory", "--talks-path", str(talks_path), "--posts-path", str(posts_path), *extra_args]
+    return runner.invoke(cli_module.cli, args)
+
+
+def test_inventory_reports_counts(tmp_path):
+    result = run_inventory(tmp_path)
+    assert result.exit_code == 0
+    assert "Discovered 2 unique media candidate(s)" in result.output
+    assert "Referenced by talks: 1" in result.output
+    assert "Referenced by posts: 1" in result.output
+
+
+def test_inventory_writes_json_output(tmp_path):
+    json_path = tmp_path / "candidates.json"
+    result = run_inventory(tmp_path, extra_args=["--json-output", str(json_path)])
+    assert result.exit_code == 0
+    import json
+
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert len(payload) == 2
+    assert {"url", "kind", "occurrences"} <= set(payload[0])
+
+
+def test_inventory_reports_content_errors_as_click_exception(tmp_path):
+    talks_path = tmp_path / "talks.yaml"
+    posts_path = tmp_path / "posts"
+    talks_path.write_text("talks:\n- venue: V\n  location: L\n  date: '2024-01-01'\n", encoding="utf-8")
+    posts_path.mkdir()
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        ["inventory", "--talks-path", str(talks_path), "--posts-path", str(posts_path)],
+    )
+
+    assert result.exit_code == 1
+
+
+def test_backup_requires_archive_root(tmp_path):
+    talks_path = tmp_path / "talks.yaml"
+    posts_path = tmp_path / "posts"
+    write_talks(talks_path)
+    write_posts(posts_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        ["backup", "--talks-path", str(talks_path), "--posts-path", str(posts_path)],
+    )
+
+    assert result.exit_code == 1
+    assert "An archive root is required" in result.output
+
+
+def test_backup_refuses_archive_root_inside_repository(tmp_path):
+    talks_path = tmp_path / "talks.yaml"
+    posts_path = tmp_path / "posts"
+    write_talks(talks_path)
+    write_posts(posts_path)
+    inside_repo_root = cli_module.REPO_ROOT / "some-archive-dir"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "backup",
+            "--archive-root",
+            str(inside_repo_root),
+            "--talks-path",
+            str(talks_path),
+            "--posts-path",
+            str(posts_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Refusing to store media under the repository" in result.output
+
+
+def _fake_download_success(url, kind, archive_root):
+    output_dir = archive_root / kind
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / "file.bin"
+    output_path.write_bytes(b"fake bytes")
+    return downloader.DownloadOutcome(
+        status="success",
+        extractor="Fake",
+        media_id="file",
+        output_filename=str(output_path.relative_to(archive_root)),
+        size_bytes=output_path.stat().st_size,
+    )
+
+
+def _fake_download_failure(url, kind, archive_root):
+    return downloader.DownloadOutcome(status="failed", error="boom")
+
+
+def test_backup_downloads_pending_candidates(tmp_path, monkeypatch):
+    talks_path = tmp_path / "talks.yaml"
+    posts_path = tmp_path / "posts"
+    write_talks(talks_path)
+    write_posts(posts_path)
+    archive_root = tmp_path / "archive"
+    monkeypatch.setattr(cli_module, "download_candidate", _fake_download_success)
+    monkeypatch.setattr(cli_module, "ffmpeg_available", lambda: True)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "backup",
+            "--archive-root",
+            str(archive_root),
+            "--talks-path",
+            str(talks_path),
+            "--posts-path",
+            str(posts_path),
+            "--delay",
+            "0",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "2 succeeded, 0 failed" in result.output
+    manifest = manifest_mod.load_manifest(archive_root)
+    assert len(manifest.entries) == 2
+    for entry in manifest.entries.values():
+        assert entry.status == manifest_mod.STATUS_SUCCESS
+        assert entry.sha256 is not None
+
+
+def test_backup_records_failures_and_exits_nonzero(tmp_path, monkeypatch):
+    talks_path = tmp_path / "talks.yaml"
+    posts_path = tmp_path / "posts"
+    write_talks(talks_path)
+    write_posts(posts_path)
+    archive_root = tmp_path / "archive"
+    monkeypatch.setattr(cli_module, "download_candidate", _fake_download_failure)
+    monkeypatch.setattr(cli_module, "ffmpeg_available", lambda: True)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "backup",
+            "--archive-root",
+            str(archive_root),
+            "--talks-path",
+            str(talks_path),
+            "--posts-path",
+            str(posts_path),
+            "--delay",
+            "0",
+        ],
+    )
+
+    assert result.exit_code == 1
+    manifest = manifest_mod.load_manifest(archive_root)
+    assert all(entry.status == manifest_mod.STATUS_FAILED for entry in manifest.entries.values())
+    assert all(entry.error == "boom" for entry in manifest.entries.values())
+
+
+def test_backup_skips_already_successful_entries(tmp_path, monkeypatch):
+    talks_path = tmp_path / "talks.yaml"
+    posts_path = tmp_path / "posts"
+    write_talks(talks_path)
+    write_posts(posts_path)
+    archive_root = tmp_path / "archive"
+
+    calls = []
+
+    def counting_download(url, kind, root):
+        calls.append(url)
+        return _fake_download_success(url, kind, root)
+
+    monkeypatch.setattr(cli_module, "download_candidate", counting_download)
+    monkeypatch.setattr(cli_module, "ffmpeg_available", lambda: True)
+    runner = CliRunner()
+    common_args = [
+        "backup",
+        "--archive-root",
+        str(archive_root),
+        "--talks-path",
+        str(talks_path),
+        "--posts-path",
+        str(posts_path),
+        "--delay",
+        "0",
+    ]
+
+    first = runner.invoke(cli_module.cli, common_args)
+    assert first.exit_code == 0
+    assert len(calls) == 2
+
+    second = runner.invoke(cli_module.cli, common_args)
+    assert second.exit_code == 0
+    assert "Nothing to back up" in second.output
+    assert len(calls) == 2  # no new calls
+
+
+def test_backup_force_redownloads_successful_entries(tmp_path, monkeypatch):
+    talks_path = tmp_path / "talks.yaml"
+    posts_path = tmp_path / "posts"
+    write_talks(talks_path)
+    write_posts(posts_path)
+    archive_root = tmp_path / "archive"
+    calls = []
+
+    def counting_download(url, kind, root):
+        calls.append(url)
+        return _fake_download_success(url, kind, root)
+
+    monkeypatch.setattr(cli_module, "download_candidate", counting_download)
+    monkeypatch.setattr(cli_module, "ffmpeg_available", lambda: True)
+    runner = CliRunner()
+    base_args = [
+        "backup",
+        "--archive-root",
+        str(archive_root),
+        "--talks-path",
+        str(talks_path),
+        "--posts-path",
+        str(posts_path),
+        "--delay",
+        "0",
+    ]
+
+    runner.invoke(cli_module.cli, base_args)
+    assert len(calls) == 2
+
+    runner.invoke(cli_module.cli, [*base_args, "--force"])
+    assert len(calls) == 4
+
+
+def test_backup_retry_failed_flag_controls_reattempts(tmp_path, monkeypatch):
+    talks_path = tmp_path / "talks.yaml"
+    posts_path = tmp_path / "posts"
+    write_talks(talks_path)
+    write_posts(posts_path)
+    archive_root = tmp_path / "archive"
+    monkeypatch.setattr(cli_module, "download_candidate", _fake_download_failure)
+    monkeypatch.setattr(cli_module, "ffmpeg_available", lambda: True)
+    runner = CliRunner()
+    base_args = [
+        "backup",
+        "--archive-root",
+        str(archive_root),
+        "--talks-path",
+        str(talks_path),
+        "--posts-path",
+        str(posts_path),
+        "--delay",
+        "0",
+    ]
+
+    runner.invoke(cli_module.cli, base_args)
+    no_retry_result = runner.invoke(cli_module.cli, [*base_args, "--no-retry-failed"])
+    assert no_retry_result.exit_code == 0
+    assert "Nothing to back up" in no_retry_result.output
+
+
+def test_backup_respects_limit(tmp_path, monkeypatch):
+    talks_path = tmp_path / "talks.yaml"
+    posts_path = tmp_path / "posts"
+    write_talks(talks_path)
+    write_posts(posts_path)
+    archive_root = tmp_path / "archive"
+    calls = []
+
+    def counting_download(url, kind, root):
+        calls.append(url)
+        return _fake_download_success(url, kind, root)
+
+    monkeypatch.setattr(cli_module, "download_candidate", counting_download)
+    monkeypatch.setattr(cli_module, "ffmpeg_available", lambda: True)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "backup",
+            "--archive-root",
+            str(archive_root),
+            "--talks-path",
+            str(talks_path),
+            "--posts-path",
+            str(posts_path),
+            "--delay",
+            "0",
+            "--limit",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert len(calls) == 1
+
+
+def test_backup_warns_when_ffmpeg_missing(tmp_path, monkeypatch):
+    talks_path = tmp_path / "talks.yaml"
+    posts_path = tmp_path / "posts"
+    write_talks(talks_path)
+    write_posts(posts_path)
+    archive_root = tmp_path / "archive"
+    monkeypatch.setattr(cli_module, "download_candidate", _fake_download_success)
+    monkeypatch.setattr(cli_module, "ffmpeg_available", lambda: False)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "backup",
+            "--archive-root",
+            str(archive_root),
+            "--talks-path",
+            str(talks_path),
+            "--posts-path",
+            str(posts_path),
+            "--delay",
+            "0",
+        ],
+    )
+
+    assert "ffmpeg was not found" in result.output
+
+
+def test_verify_reports_no_media_when_manifest_empty(tmp_path):
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir()
+
+    runner = CliRunner()
+    result = runner.invoke(cli_module.cli, ["verify", "--archive-root", str(archive_root)])
+
+    assert result.exit_code == 0
+    assert "No successfully archived media" in result.output
+
+
+def test_verify_passes_for_intact_file(tmp_path):
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir()
+    media_path = archive_root / "direct" / "file.bin"
+    media_path.parent.mkdir(parents=True)
+    media_path.write_bytes(b"hello world")
+
+    entry = manifest_mod.ManifestEntry(
+        source_url="https://example.com/clip.mp4",
+        kind="direct",
+        occurrences=[],
+        status=manifest_mod.STATUS_SUCCESS,
+        output_filename="direct/file.bin",
+        size_bytes=media_path.stat().st_size,
+        sha256=manifest_mod.sha256_file(media_path),
+        created_at=manifest_mod.current_timestamp(),
+        updated_at=manifest_mod.current_timestamp(),
+    )
+    manifest = manifest_mod.Manifest(entries={entry.source_url: entry})
+    manifest_mod.write_manifest(archive_root, manifest)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_module.cli, ["verify", "--archive-root", str(archive_root)])
+
+    assert result.exit_code == 0
+    assert "Verified 1 file(s); 0 missing; 0 mismatched." in result.output
+
+
+def test_verify_reports_missing_file(tmp_path):
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir()
+
+    entry = manifest_mod.ManifestEntry(
+        source_url="https://example.com/clip.mp4",
+        kind="direct",
+        occurrences=[],
+        status=manifest_mod.STATUS_SUCCESS,
+        output_filename="direct/missing.bin",
+        size_bytes=5,
+        sha256="deadbeef",
+        created_at=manifest_mod.current_timestamp(),
+        updated_at=manifest_mod.current_timestamp(),
+    )
+    manifest = manifest_mod.Manifest(entries={entry.source_url: entry})
+    manifest_mod.write_manifest(archive_root, manifest)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_module.cli, ["verify", "--archive-root", str(archive_root)])
+
+    assert result.exit_code == 1
+    assert "MISSING" in result.output
+
+
+def test_verify_reports_mismatched_checksum(tmp_path):
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir()
+    media_path = archive_root / "direct" / "file.bin"
+    media_path.parent.mkdir(parents=True)
+    media_path.write_bytes(b"hello world")
+
+    entry = manifest_mod.ManifestEntry(
+        source_url="https://example.com/clip.mp4",
+        kind="direct",
+        occurrences=[],
+        status=manifest_mod.STATUS_SUCCESS,
+        output_filename="direct/file.bin",
+        size_bytes=999,
+        sha256="not-the-real-hash",
+        created_at=manifest_mod.current_timestamp(),
+        updated_at=manifest_mod.current_timestamp(),
+    )
+    manifest = manifest_mod.Manifest(entries={entry.source_url: entry})
+    manifest_mod.write_manifest(archive_root, manifest)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_module.cli, ["verify", "--archive-root", str(archive_root)])
+
+    assert result.exit_code == 1
+    assert "MISMATCH" in result.output
+
+
+def test_verify_requires_archive_root():
+    runner = CliRunner()
+    result = runner.invoke(cli_module.cli, ["verify"])
+    assert result.exit_code == 1
+    assert "An archive root is required" in result.output
+
+
+def test_verify_skips_entries_without_output_filename(tmp_path):
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir()
+    entry = manifest_mod.ManifestEntry(
+        source_url="https://example.com/clip.mp4",
+        kind="direct",
+        occurrences=[],
+        status=manifest_mod.STATUS_SUCCESS,
+        output_filename=None,
+    )
+    manifest = manifest_mod.Manifest(entries={entry.source_url: entry})
+    manifest_mod.write_manifest(archive_root, manifest)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_module.cli, ["verify", "--archive-root", str(archive_root)])
+
+    assert result.exit_code == 0
+    assert "Verified 0 file(s); 0 missing; 0 mismatched." in result.output
+
+
+def _raise_download_error(url, kind, archive_root):
+    raise downloader.DownloadError("ffmpeg is required but missing")
+
+
+def test_backup_handles_download_error_raised_directly(tmp_path, monkeypatch):
+    talks_path = tmp_path / "talks.yaml"
+    posts_path = tmp_path / "posts"
+    write_talks(talks_path)
+    write_posts(posts_path)
+    archive_root = tmp_path / "archive"
+    monkeypatch.setattr(cli_module, "download_candidate", _raise_download_error)
+    monkeypatch.setattr(cli_module, "ffmpeg_available", lambda: True)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "backup",
+            "--archive-root",
+            str(archive_root),
+            "--talks-path",
+            str(talks_path),
+            "--posts-path",
+            str(posts_path),
+            "--delay",
+            "0",
+        ],
+    )
+
+    assert result.exit_code == 1
+    manifest = manifest_mod.load_manifest(archive_root)
+    assert all(entry.status == manifest_mod.STATUS_FAILED for entry in manifest.entries.values())
+    assert all("ffmpeg is required" in (entry.error or "") for entry in manifest.entries.values())

--- a/tests/test_media_archive_discovery.py
+++ b/tests/test_media_archive_discovery.py
@@ -1,0 +1,326 @@
+"""Tests for discovering playable media candidates in talks and posts."""
+
+import datetime
+
+from coltrane.content_loaders import MarkdownPost, Talk
+from scripts.media_archive.discovery import (
+    KIND_DIRECT,
+    KIND_SOUNDCLOUD,
+    KIND_UNKNOWN,
+    KIND_VIMEO,
+    KIND_YOUTUBE,
+    classify_iframe_url,
+    classify_media_url,
+    discover_candidates,
+    discover_post_occurrences,
+    discover_talk_occurrence,
+    normalize_url,
+)
+
+
+def make_post(slug: str, body_markup: str) -> MarkdownPost:
+    return MarkdownPost(
+        title=slug,
+        slug=slug,
+        published_at=datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC),
+        body_markup=body_markup,
+    )
+
+
+def make_talk(title: str, video_url: str = "") -> Talk:
+    return Talk(title=title, venue="Venue", location="City", date=datetime.date(2024, 1, 1), video_url=video_url)
+
+
+# ---------------------------------------------------------------------------
+# normalize_url
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_url_resolves_protocol_relative():
+    assert normalize_url("//example.com/video.mp4") == "https://example.com/video.mp4"
+
+
+def test_normalize_url_strips_whitespace():
+    assert normalize_url("  https://example.com/video.mp4  ") == "https://example.com/video.mp4"
+
+
+def test_normalize_url_resolves_site_relative_path():
+    assert normalize_url("/media/mp3/clip.mp3") == "https://palewi.re/media/mp3/clip.mp3"
+
+
+# ---------------------------------------------------------------------------
+# classify_media_url
+# ---------------------------------------------------------------------------
+
+
+def test_classify_direct_media_extension():
+    assert classify_media_url("https://palewire.s3.amazonaws.com/tour/9track.mp4") == KIND_DIRECT
+    assert classify_media_url("//palewire.s3.amazonaws.com/tour/9track.mp4") == KIND_DIRECT
+
+
+def test_classify_direct_audio_extension():
+    assert classify_media_url("https://example.com/clip.mp3") == KIND_DIRECT
+
+
+def test_classify_youtube_watch_url():
+    assert classify_media_url("http://www.youtube.com/watch?v=iOCT8B9WyKw") == KIND_YOUTUBE
+    assert classify_media_url("https://www.youtube.com/watch?v=iOCT8B9WyKw&feature=player_embedded") == KIND_YOUTUBE
+
+
+def test_classify_youtube_short_url():
+    assert classify_media_url("https://youtu.be/iOCT8B9WyKw") == KIND_YOUTUBE
+
+
+def test_classify_vimeo_watch_url():
+    assert classify_media_url("https://vimeo.com/1187819115/4fcb0378ca?share=copy") == KIND_VIMEO
+
+
+def test_classify_soundcloud_track_url():
+    assert classify_media_url("https://soundcloud.com/ire-nicar/a-conversation-with-ben-welsh") == KIND_SOUNDCLOUD
+
+
+def test_classify_excludes_soundcloud_bare_profile():
+    assert classify_media_url("https://soundcloud.com/ire-nicar") is None
+
+
+def test_classify_excludes_google_slides():
+    assert classify_media_url("https://docs.google.com/presentation/d/abc123/edit") is None
+
+
+def test_classify_excludes_ordinary_webpage():
+    assert classify_media_url("https://www.ire.org/") is None
+
+
+def test_classify_excludes_image():
+    assert classify_media_url("https://example.com/photo.jpg") is None
+
+
+def test_classify_excludes_social_profile_link():
+    assert classify_media_url("https://twitter.com/palewire") is None
+    assert classify_media_url("https://www.linkedin.com/in/example") is None
+
+
+def test_classify_excludes_youtube_channel_link():
+    assert classify_media_url("https://www.youtube.com/@somechannel") is None
+
+
+# ---------------------------------------------------------------------------
+# classify_iframe_url
+# ---------------------------------------------------------------------------
+
+
+def test_classify_iframe_vimeo_player():
+    result = classify_iframe_url("https://player.vimeo.com/video/214875675?title=0&byline=0")
+    assert result == (KIND_VIMEO, "https://vimeo.com/214875675")
+
+
+def test_classify_iframe_youtube_embed():
+    result = classify_iframe_url("https://www.youtube.com/embed/iOCT8B9WyKw")
+    assert result == (KIND_YOUTUBE, "https://www.youtube.com/watch?v=iOCT8B9WyKw")
+
+
+def test_classify_iframe_soundcloud_player():
+    src = (
+        "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/2099172090"
+        "&color=%23ff5500&auto_play=false"
+    )
+    result = classify_iframe_url(src)
+    assert result == (KIND_SOUNDCLOUD, "https://api.soundcloud.com/tracks/2099172090")
+
+
+def test_classify_iframe_generic_returns_none():
+    assert classify_iframe_url("https://docs.google.com/presentation/d/abc123/embed") is None
+    assert classify_iframe_url("https://palewi.re/some/hosted/interactive/") is None
+
+
+# ---------------------------------------------------------------------------
+# discover_talk_occurrence
+# ---------------------------------------------------------------------------
+
+
+def test_discover_talk_occurrence_with_video():
+    talk = make_talk("A Talk", video_url="https://vimeo.com/1187819115/4fcb0378ca?share=copy")
+    result = discover_talk_occurrence(talk)
+    assert result is not None
+    url, kind, occurrence = result
+    assert url == talk.video_url
+    assert kind == KIND_VIMEO
+    assert occurrence.origin_type == "talk"
+    assert occurrence.location == "video_url"
+    assert occurrence.raw_url == talk.video_url
+
+
+def test_discover_talk_occurrence_without_video_returns_none():
+    talk = make_talk("No Video")
+    assert discover_talk_occurrence(talk) is None
+
+
+def test_discover_talk_occurrence_unknown_host_still_included():
+    talk = make_talk("Odd Host", video_url="https://example-video-host.test/watch/123")
+    result = discover_talk_occurrence(talk)
+    assert result is not None
+    url, kind, occurrence = result
+    assert kind == KIND_UNKNOWN
+    assert url == talk.video_url
+
+
+# ---------------------------------------------------------------------------
+# discover_post_occurrences
+# ---------------------------------------------------------------------------
+
+
+def test_discover_post_video_tag_with_source():
+    post = make_post(
+        "video-post",
+        '<video playsinline poster="//example.com/poster.jpg" controls>'
+        '<source src="//example.com/clip.mp4" type="video/mp4"></video>',
+    )
+    results = discover_post_occurrences(post)
+    assert len(results) == 1
+    url, kind, occurrence = results[0]
+    assert url == "//example.com/clip.mp4"
+    assert kind == KIND_DIRECT
+    assert occurrence.location == "video>source"
+    assert occurrence.origin_id == "video-post"
+
+
+def test_discover_post_video_src_attribute_direct():
+    post = make_post("video-src", '<video src="//example.com/clip.mp4" controls></video>')
+    results = discover_post_occurrences(post)
+    assert len(results) == 1
+    assert results[0][0] == "//example.com/clip.mp4"
+    assert results[0][2].location == "video"
+
+
+def test_discover_post_audio_tag_with_source():
+    post = make_post(
+        "audio-post", '<audio controls><source src="https://example.com/clip.mp3" type="audio/mp3"></audio>'
+    )
+    results = discover_post_occurrences(post)
+    assert len(results) == 1
+    assert results[0][1] == KIND_DIRECT
+    assert results[0][2].location == "audio>source"
+
+
+def test_discover_post_ignores_picture_sources():
+    post = make_post(
+        "picture-post",
+        '<picture><source type="image/webp" srcset="/static/img/example.webp">'
+        '<source type="image/png" srcset="/static/img/example.png"></picture>',
+    )
+    assert discover_post_occurrences(post) == []
+
+
+def test_discover_post_vimeo_iframe_embed():
+    post = make_post(
+        "vimeo-post",
+        "<div class='embed-container'><iframe src='https://player.vimeo.com/video/214875675?title=0'></iframe></div>",
+    )
+    results = discover_post_occurrences(post)
+    assert len(results) == 1
+    url, kind, occurrence = results[0]
+    assert url == "https://vimeo.com/214875675"
+    assert kind == KIND_VIMEO
+    assert occurrence.location == "iframe"
+    assert occurrence.raw_url == "https://player.vimeo.com/video/214875675?title=0"
+
+
+def test_discover_post_soundcloud_iframe_and_link():
+    body = (
+        '<iframe src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/2099172090">'
+        "</iframe>"
+        '<a href="https://soundcloud.com/ire-nicar/a-conversation-with-ben-welsh">the podcast</a>'
+    )
+    post = make_post("soundcloud-post", body)
+    results = discover_post_occurrences(post)
+    urls = {result[0] for result in results}
+    assert "https://api.soundcloud.com/tracks/2099172090" in urls
+    assert "https://soundcloud.com/ire-nicar/a-conversation-with-ben-welsh" in urls
+
+
+def test_discover_post_youtube_link():
+    post = make_post(
+        "youtube-post",
+        '<a href="https://www.youtube.com/watch?v=iOCT8B9WyKw">Tweeg</a>',
+    )
+    results = discover_post_occurrences(post)
+    assert len(results) == 1
+    assert results[0][1] == KIND_YOUTUBE
+    assert results[0][2].location == "a"
+
+
+def test_discover_post_excludes_ordinary_links():
+    post = make_post(
+        "ordinary-post",
+        '<a href="http://www.mattwaite.com/2008/01/02/data-ghettos/">data ghettos</a>'
+        '<a href="https://twitter.com/palewire">Twitter</a>'
+        '<img src="https://example.com/photo.jpg">'
+        '<iframe src="https://docs.google.com/presentation/d/abc/embed"></iframe>',
+    )
+    assert discover_post_occurrences(post) == []
+
+
+def test_discover_post_ignores_tags_missing_src_or_href():
+    post = make_post(
+        "no-attrs-post",
+        "<video></video><iframe></iframe><a>no href here</a>",
+    )
+    assert discover_post_occurrences(post) == []
+
+
+def test_attribute_helper_joins_multivalued_attribute():
+    from bs4 import BeautifulSoup
+
+    from scripts.media_archive.discovery import _attribute
+
+    soup = BeautifulSoup('<video class="a b"></video>', "html.parser")
+    tag = soup.find("video")
+    assert _attribute(tag, "class") == "ab"
+    assert _attribute(tag, "missing") is None
+
+
+# ---------------------------------------------------------------------------
+# discover_candidates
+# ---------------------------------------------------------------------------
+
+
+def test_discover_candidates_deduplicates_and_retains_occurrences():
+    talk = make_talk("Talk", video_url="https://example.com/clip.mp4")
+    post_one = make_post("post-one", '<video src="https://example.com/clip.mp4"></video>')
+    post_two = make_post("post-two", '<video src="https://example.com/clip.mp4"></video>')
+
+    candidates = discover_candidates([talk], [post_one, post_two])
+
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.url == "https://example.com/clip.mp4"
+    assert len(candidate.occurrences) == 3
+    origin_types = [occurrence.origin_type for occurrence in candidate.occurrences]
+    assert origin_types == ["talk", "post", "post"]
+
+
+def test_discover_candidates_preserves_discovery_order():
+    talk = make_talk("Talk", video_url="https://example.com/first.mp4")
+    post = make_post("post", '<video src="https://example.com/second.mp4"></video>')
+
+    candidates = discover_candidates([talk], [post])
+
+    assert [candidate.url for candidate in candidates] == [
+        "https://example.com/first.mp4",
+        "https://example.com/second.mp4",
+    ]
+
+
+def test_discover_candidates_empty_inputs():
+    assert discover_candidates([], []) == []
+
+
+def test_discover_candidates_resolves_site_relative_links_to_absolute_urls():
+    post = make_post("relative-link-post", '<a href="/media/mp3/clip.mp3">clip</a>')
+
+    candidates = discover_candidates([], [post])
+
+    assert len(candidates) == 1
+    assert candidates[0].url == "https://palewi.re/media/mp3/clip.mp3"
+    assert candidates[0].kind == KIND_DIRECT
+    assert candidates[0].occurrences[0].raw_url == "/media/mp3/clip.mp3"

--- a/tests/test_media_archive_downloader.py
+++ b/tests/test_media_archive_downloader.py
@@ -1,0 +1,198 @@
+"""Tests for the yt-dlp download wrapper."""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.media_archive import downloader
+
+
+class FakeYoutubeDL:
+    """A minimal stand-in for yt_dlp.YoutubeDL that never touches the network."""
+
+    def __init__(self, options, *, info=None, error=None, write_file=True, write_info_json=False):
+        self.options = options
+        self._info = info
+        self._error = error
+        self._write_file = write_file
+        self._write_info_json = write_info_json
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def extract_info(self, url, download=True):
+        if self._error is not None:
+            raise self._error
+        if self._write_file and self._info is not None:
+            output_path = Path(
+                self.options["outtmpl"].replace("%(id)s", self._info["id"]).replace("%(ext)s", self._info["ext"])
+            )
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(b"fake media bytes")
+            if self._write_info_json:
+                output_path.with_suffix(".info.json").write_text("{}", encoding="utf-8")
+        return self._info
+
+    def prepare_filename(self, info):
+        return self.options["outtmpl"].replace("%(id)s", info["id"]).replace("%(ext)s", info["ext"])
+
+
+def make_factory(**kwargs):
+    def factory(options):
+        return FakeYoutubeDL(options, **kwargs)
+
+    return factory
+
+
+def test_ffmpeg_available_reflects_shutil_which(monkeypatch):
+    monkeypatch.setattr(downloader.shutil, "which", lambda name: "/usr/bin/ffmpeg")
+    assert downloader.ffmpeg_available() is True
+    monkeypatch.setattr(downloader.shutil, "which", lambda name: None)
+    assert downloader.ffmpeg_available() is False
+
+
+def test_require_ffmpeg_raises_for_kinds_that_need_it(monkeypatch):
+    monkeypatch.setattr(downloader, "ffmpeg_available", lambda: False)
+    with pytest.raises(downloader.DownloadError, match="ffmpeg"):
+        downloader.require_ffmpeg("youtube")
+    with pytest.raises(downloader.DownloadError):
+        downloader.require_ffmpeg("vimeo")
+    with pytest.raises(downloader.DownloadError):
+        downloader.require_ffmpeg("unknown")
+
+
+def test_require_ffmpeg_skips_kinds_that_do_not_need_it(monkeypatch):
+    monkeypatch.setattr(downloader, "ffmpeg_available", lambda: False)
+    downloader.require_ffmpeg("direct")
+    downloader.require_ffmpeg("soundcloud")
+
+
+def test_require_ffmpeg_passes_when_available(monkeypatch):
+    monkeypatch.setattr(downloader, "ffmpeg_available", lambda: True)
+    downloader.require_ffmpeg("youtube")
+
+
+def test_download_candidate_success_direct(tmp_path, monkeypatch):
+    monkeypatch.setattr(downloader, "ffmpeg_available", lambda: True)
+    factory = make_factory(info={"id": "abc123", "ext": "mp4", "extractor_key": "Generic"})
+
+    outcome = downloader.download_candidate("https://example.com/clip.mp4", "direct", tmp_path, ydl_factory=factory)
+
+    assert outcome.status == "success"
+    assert outcome.media_id == "abc123"
+    assert outcome.extractor == "Generic"
+    assert outcome.output_filename == "direct/abc123.mp4"
+    assert outcome.size_bytes == len(b"fake media bytes")
+    assert (tmp_path / "direct" / "abc123.mp4").exists()
+
+
+def test_download_candidate_success_youtube_requires_ffmpeg(tmp_path, monkeypatch):
+    monkeypatch.setattr(downloader, "ffmpeg_available", lambda: False)
+    factory = make_factory(info={"id": "abc123", "ext": "mp4"})
+
+    with pytest.raises(downloader.DownloadError):
+        downloader.download_candidate(
+            "https://www.youtube.com/watch?v=abc123", "youtube", tmp_path, ydl_factory=factory
+        )
+
+
+def test_download_candidate_uses_requested_downloads_filepath(tmp_path, monkeypatch):
+    monkeypatch.setattr(downloader, "ffmpeg_available", lambda: True)
+    output_dir = tmp_path / "youtube"
+    output_dir.mkdir(parents=True)
+    real_path = output_dir / "abc123.mp4"
+    real_path.write_bytes(b"12345")
+    info = {
+        "id": "abc123",
+        "ext": "mp4",
+        "extractor_key": "Youtube",
+        "requested_downloads": [{"filepath": str(real_path)}],
+    }
+    factory = make_factory(info=info, write_file=False)
+
+    outcome = downloader.download_candidate(
+        "https://www.youtube.com/watch?v=abc123", "youtube", tmp_path, ydl_factory=factory
+    )
+
+    assert outcome.status == "success"
+    assert outcome.output_filename == "youtube/abc123.mp4"
+    assert outcome.size_bytes == 5
+
+
+def test_download_candidate_records_info_json_when_present(tmp_path, monkeypatch):
+    monkeypatch.setattr(downloader, "ffmpeg_available", lambda: True)
+    factory = make_factory(info={"id": "abc123", "ext": "mp4", "extractor_key": "Generic"}, write_info_json=True)
+
+    outcome = downloader.download_candidate("https://example.com/clip.mp4", "direct", tmp_path, ydl_factory=factory)
+
+    assert outcome.info_json_path == "direct/abc123.info.json"
+
+
+def test_download_candidate_failure_from_extractor_exception(tmp_path, monkeypatch):
+    monkeypatch.setattr(downloader, "ffmpeg_available", lambda: True)
+    factory = make_factory(error=RuntimeError("network unreachable"))
+
+    outcome = downloader.download_candidate("https://example.com/clip.mp4", "direct", tmp_path, ydl_factory=factory)
+
+    assert outcome.status == "failed"
+    assert outcome.error is not None
+    assert "network unreachable" in outcome.error
+
+
+def test_download_candidate_failure_when_info_not_dict(tmp_path, monkeypatch):
+    monkeypatch.setattr(downloader, "ffmpeg_available", lambda: True)
+    factory = make_factory(info=None, write_file=False)
+
+    outcome = downloader.download_candidate("https://example.com/clip.mp4", "direct", tmp_path, ydl_factory=factory)
+
+    assert outcome.status == "failed"
+    assert outcome.error is not None
+    assert "no metadata" in outcome.error
+
+
+def test_download_candidate_failure_when_file_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(downloader, "ffmpeg_available", lambda: True)
+    factory = make_factory(info={"id": "abc123", "ext": "mp4"}, write_file=False)
+
+    outcome = downloader.download_candidate("https://example.com/clip.mp4", "direct", tmp_path, ydl_factory=factory)
+
+    assert outcome.status == "failed"
+    assert outcome.error is not None
+    assert "output file is missing" in outcome.error
+
+
+def test_default_ydl_factory_builds_real_client(tmp_path):
+    client = downloader.default_ydl_factory({"quiet": True})
+    assert hasattr(client, "extract_info")
+
+
+def test_resolve_output_path_uses_top_level_filepath(tmp_path):
+    ydl = FakeYoutubeDL({"outtmpl": str(tmp_path / "%(id)s.%(ext)s")})
+    info = {"id": "abc", "ext": "mp4", "filepath": str(tmp_path / "abc.mp4")}
+    result = downloader._resolve_output_path(ydl, info, tmp_path)
+    assert result == Path(tmp_path / "abc.mp4")
+
+
+def test_resolve_output_path_falls_back_to_prepare_filename(tmp_path):
+    ydl = FakeYoutubeDL({"outtmpl": str(tmp_path / "%(id)s.%(ext)s")})
+    info = {"id": "abc", "ext": "mp4"}
+    result = downloader._resolve_output_path(ydl, info, tmp_path)
+    assert result == Path(tmp_path / "abc.mp4")
+
+
+def test_resolve_output_path_returns_none_without_prepare_filename(tmp_path):
+    class NoPrepare:
+        def __enter__(self) -> "NoPrepare":
+            return self
+
+        def __exit__(self, *exc_info: object) -> None:
+            return None
+
+        def extract_info(self, url: str, download: bool = True) -> dict[str, object]:
+            return {}
+
+    info = {"id": "abc", "ext": "mp4"}
+    assert downloader._resolve_output_path(NoPrepare(), info, tmp_path) is None

--- a/tests/test_media_archive_manifest.py
+++ b/tests/test_media_archive_manifest.py
@@ -1,0 +1,177 @@
+"""Tests for the atomic media archive manifest."""
+
+import hashlib
+import json
+
+from scripts.media_archive.discovery import MediaCandidate, MediaOccurrence
+from scripts.media_archive.manifest import (
+    STATUS_PENDING,
+    STATUS_SUCCESS,
+    Manifest,
+    ManifestEntry,
+    ManifestError,
+    load_manifest,
+    manifest_path,
+    occurrence_to_dict,
+    sha256_file,
+    sync_candidates,
+    write_manifest,
+)
+
+
+def make_candidate(url: str, kind: str = "direct") -> MediaCandidate:
+    return MediaCandidate(
+        url=url,
+        kind=kind,
+        occurrences=(MediaOccurrence("post", "example-post", "video", url),),
+    )
+
+
+def test_manifest_entry_round_trips_through_dict():
+    entry = ManifestEntry(source_url="https://example.com/a.mp4", kind="direct", occurrences=[])
+    entry.status = STATUS_SUCCESS
+    entry.size_bytes = 123
+    restored = ManifestEntry.from_dict(entry.to_dict())
+    assert restored == entry
+
+
+def test_manifest_entry_from_dict_ignores_unknown_fields():
+    restored = ManifestEntry.from_dict(
+        {"source_url": "https://example.com/a.mp4", "kind": "direct", "occurrences": [], "future_field": "x"}
+    )
+    assert restored.source_url == "https://example.com/a.mp4"
+
+
+def test_manifest_round_trips_and_sorts_entries():
+    manifest = Manifest()
+    manifest.entries["https://b.example.com"] = ManifestEntry(
+        source_url="https://b.example.com", kind="direct", occurrences=[]
+    )
+    manifest.entries["https://a.example.com"] = ManifestEntry(
+        source_url="https://a.example.com", kind="direct", occurrences=[]
+    )
+
+    data = manifest.to_dict()
+
+    assert list(data["entries"].keys()) == ["https://a.example.com", "https://b.example.com"]
+    restored = Manifest.from_dict(data)
+    assert set(restored.entries) == {"https://a.example.com", "https://b.example.com"}
+
+
+def test_manifest_from_dict_defaults_missing_entries():
+    restored = Manifest.from_dict({})
+    assert restored.entries == {}
+    assert restored.version == 1
+
+
+def test_load_manifest_missing_file_returns_empty(tmp_path):
+    manifest = load_manifest(tmp_path)
+    assert manifest.entries == {}
+
+
+def test_load_manifest_invalid_json_raises(tmp_path):
+    manifest_path(tmp_path).write_text("not json", encoding="utf-8")
+    try:
+        load_manifest(tmp_path)
+        raise AssertionError("expected ManifestError")
+    except ManifestError as error:
+        assert "not valid JSON" in str(error)
+
+
+def test_load_manifest_non_object_raises(tmp_path):
+    manifest_path(tmp_path).write_text("[1, 2, 3]", encoding="utf-8")
+    try:
+        load_manifest(tmp_path)
+        raise AssertionError("expected ManifestError")
+    except ManifestError as error:
+        assert "must be a JSON object" in str(error)
+
+
+def test_write_manifest_is_atomic_and_readable(tmp_path):
+    manifest = Manifest()
+    manifest.entries["https://example.com/a.mp4"] = ManifestEntry(
+        source_url="https://example.com/a.mp4", kind="direct", occurrences=[]
+    )
+
+    write_manifest(tmp_path, manifest)
+
+    assert manifest_path(tmp_path).exists()
+    assert not (tmp_path / "manifest.json.tmp").exists()
+    reloaded = load_manifest(tmp_path)
+    assert "https://example.com/a.mp4" in reloaded.entries
+    data = json.loads(manifest_path(tmp_path).read_text(encoding="utf-8"))
+    assert data["version"] == 1
+
+
+def test_write_manifest_creates_archive_root(tmp_path):
+    archive_root = tmp_path / "nested" / "archive"
+    write_manifest(archive_root, Manifest())
+    assert archive_root.is_dir()
+    assert manifest_path(archive_root).exists()
+
+
+def test_sha256_file_matches_known_digest(tmp_path):
+    path = tmp_path / "file.bin"
+    path.write_bytes(b"hello world")
+    assert sha256_file(path) == hashlib.sha256(b"hello world").hexdigest()
+
+
+def test_sha256_file_reads_in_chunks_for_large_file(tmp_path):
+    payload = b"x" * (2 * 1024 * 1024 + 17)
+    path = tmp_path / "big.bin"
+    path.write_bytes(payload)
+    assert sha256_file(path) == hashlib.sha256(payload).hexdigest()
+
+
+def test_occurrence_to_dict():
+    occurrence = MediaOccurrence("post", "slug", "video", "https://example.com/a.mp4")
+    assert occurrence_to_dict(occurrence) == {
+        "origin_type": "post",
+        "origin_id": "slug",
+        "location": "video",
+        "raw_url": "https://example.com/a.mp4",
+    }
+
+
+def test_sync_candidates_adds_new_pending_entries():
+    manifest = Manifest()
+    candidate = make_candidate("https://example.com/a.mp4")
+
+    sync_candidates(manifest, [candidate])
+
+    entry = manifest.entries["https://example.com/a.mp4"]
+    assert entry.status == STATUS_PENDING
+    assert entry.kind == "direct"
+    assert entry.occurrences == [occurrence_to_dict(candidate.occurrences[0])]
+
+
+def test_sync_candidates_preserves_existing_status_and_history():
+    manifest = Manifest()
+    candidate = make_candidate("https://example.com/a.mp4")
+    sync_candidates(manifest, [candidate])
+    manifest.entries["https://example.com/a.mp4"].status = STATUS_SUCCESS
+    manifest.entries["https://example.com/a.mp4"].sha256 = "deadbeef"
+
+    updated_candidate = MediaCandidate(
+        url="https://example.com/a.mp4",
+        kind="direct",
+        occurrences=(MediaOccurrence("post", "second-post", "video", "https://example.com/a.mp4"),),
+    )
+    sync_candidates(manifest, [updated_candidate])
+
+    entry = manifest.entries["https://example.com/a.mp4"]
+    assert entry.status == STATUS_SUCCESS
+    assert entry.sha256 == "deadbeef"
+    assert entry.occurrences == [occurrence_to_dict(updated_candidate.occurrences[0])]
+
+
+def test_sync_candidates_does_not_remove_stale_entries():
+    manifest = Manifest()
+    manifest.entries["https://stale.example.com/a.mp4"] = ManifestEntry(
+        source_url="https://stale.example.com/a.mp4", kind="direct", occurrences=[]
+    )
+
+    sync_candidates(manifest, [make_candidate("https://example.com/a.mp4")])
+
+    assert "https://stale.example.com/a.mp4" in manifest.entries
+    assert "https://example.com/a.mp4" in manifest.entries

--- a/uv.lock
+++ b/uv.lock
@@ -452,6 +452,7 @@ dev = [
     { name = "ruff" },
     { name = "savepagenow" },
     { name = "ty" },
+    { name = "yt-dlp" },
 ]
 
 [package.metadata]
@@ -477,6 +478,7 @@ dev = [
     { name = "ruff", specifier = ">=0.14" },
     { name = "savepagenow", specifier = ">=1.3.1" },
     { name = "ty", specifier = ">=0.0.10" },
+    { name = "yt-dlp", specifier = ">=2026.8.19" },
 ]
 
 [[package]]
@@ -772,4 +774,13 @@ wheels = [
 [package.optional-dependencies]
 brotli = [
     { name = "brotli" },
+]
+
+[[package]]
+name = "yt-dlp"
+version = "2026.8.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/e0/832fa4ca334b766a06933a196066edc3dba37cdb6f14cd98d59bcc69a4b4/yt_dlp-2026.8.19.tar.gz", hash = "sha256:9e213e48cea35c66b378e4447903f118f6392a5fa380a2b6d7070ec86f4e0af1", size = 3052025, upload-time = "2026-08-19T23:48:59.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/8cd1613f56eed7ceb64fbd4df3f1c01246bfb098e6f398228bafda22b80b/yt_dlp-2026.8.19-py3-none-any.whl", hash = "sha256:1d57897e94c6665a0a6f9bc54b34e584284e32c034ffab3a7df25d8f7b24eedf", size = 3185533, upload-time = "2026-08-19T23:48:56.925Z" },
 ]


### PR DESCRIPTION
## Summary

Adds a preservation-only local backup tool for the audio/video referenced by `coltrane/content/talks.yaml` and blog posts under `coltrane/content/posts/`, per #176 ("Back up video embeds locally"). This is maintenance tooling, not a deployed feature: no Actions schedules, no cloud storage config, no Django static-file storage.

**This does not close #176.** Closing should wait until a real, durable backup run has actually completed against a permanent external archive location.

## What it does

- **Discovery** (`scripts/media_archive/discovery.py`): parses `talks.yaml` and every post's rendered body for `<video>`/`<audio>`/`<source>` tags, known media-host embeds (YouTube, Vimeo, SoundCloud iframes), talk `video_url` values, and direct media links/anchors. Deduplicates identical URLs while retaining every occurrence. Excludes Google Slides, generic iframes, hosted interactives, images, social profile links, and ordinary webpages.
- **Manifest** (`scripts/media_archive/manifest.py`): an atomic (temp-file + rename), durable JSON manifest recording source URL, every occurrence, extractor/media identity, status, output filename, size, SHA-256, yt-dlp `.info.json` path, timestamps, and explicit failure details. Entries are never deleted.
- **Downloader** (`scripts/media_archive/downloader.py`): wraps `yt-dlp` (added as a `dev` dependency group package). Never bypasses DRM, private access, or login requirements — such sources simply fail, with the error captured. `ffmpeg` is only required for kinds that need stream muxing (YouTube/Vimeo/unrecognized), and is intentionally **not** added to `make bootstrap`.
- **CLI** (`scripts/media_archive/cli.py`): typed Click commands — `inventory` (network-free dry run), `backup` (idempotent/resumable; writes the manifest after every item; supports `--force`, `--retry-failed`/`--no-retry-failed`, `--limit`, `--delay`), and `verify` (offline checksum audit). All three refuse to use an archive root inside the repository; `--archive-root`/`MEDIA_ARCHIVE_PATH` must point outside it.
- **Docs**: new `.github/skills/archive-media/SKILL.md`, `AGENTS.md` guidance, and a `README.md` section + `MEDIA_ARCHIVE_PATH` env var entry.
- **Makefile**: `media-archive-inventory`, `media-archive-backup` (`ARCHIVE_ROOT=...`), `media-archive-verify` targets.

## Tests

83 new network-free tests (discovery/exclusion/dedup rules, archive-root validation, atomic manifest writes, checksums, idempotency, verify, and failure handling), at 99–100% coverage for the new package. `make check` (lint, format, ty, Django check, clip-archive check, full pytest suite) passes with 92.69% total coverage (284 passed, 2 skipped).

## Real validation performed (and cleaned up)

- `uv run python -m scripts.media_archive inventory` against this repo's actual content currently discovers **57 unique media candidates (58 occurrences)**: **38 from talks, 19 from posts** — broken down by kind as `youtube: 33`, `unknown: 10`, `vimeo: 7`, `direct: 5`, `soundcloud: 2`.
- A live end-to-end run against a small real S3-hosted `.mp4` confirmed real `yt-dlp` download, atomic manifest write with correct SHA-256/size, idempotent skip-on-rerun, and offline `verify` all work.
- A live failure-path run against a now-404'd media link confirmed errors are captured explicitly (not swallowed) and the command exits non-zero.
- All temporary archive roots and downloaded files from validation were deleted before committing; nothing under `--archive-root` is part of this PR.

First real backup command for a maintainer to run:

```bash
ARCHIVE_ROOT=/absolute/path/outside/the/repo make media-archive-backup
```

Related to #176 (intentionally not closing it — see note above).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
