### PR TITLE
Route legacy domain through Cloudflare

### DIFF
--- a/workers/static-site/tests/index.test.ts
+++ b/workers/static-site/tests/index.test.ts
@@ -30,10 +30,14 @@ describe("static site Worker", () => {
   });
 
   it("redirects sibling domains to the canonical host", async () => {
-    const response = await handleRequest(request("/posts/?source=test", "www.palewi.re"), { ASSETS: assets });
+    const hosts = ["www.palewi.re", "palewire.com", "www.palewire.com"];
 
-    expect(response.status).toBe(301);
-    expect(response.headers.get("location")).toBe("https://palewi.re/posts/?source=test");
+    for (const host of hosts) {
+      const response = await handleRequest(request("/posts/?source=test", host), { ASSETS: assets });
+
+      expect(response.status).toBe(301);
+      expect(response.headers.get("location")).toBe("https://palewi.re/posts/?source=test");
+    }
   });
 
   it("keeps the health check available without fetching an asset", async () => {

--- a/workers/static-site/wrangler.jsonc
+++ b/workers/static-site/wrangler.jsonc
@@ -13,6 +13,14 @@
     {
       "pattern": "www.palewi.re/*",
       "zone_name": "palewi.re"
+    },
+    {
+      "pattern": "palewire.com/*",
+      "zone_name": "palewire.com"
+    },
+    {
+      "pattern": "www.palewire.com/*",
+      "zone_name": "palewire.com"
     }
   ],
   "assets": {


### PR DESCRIPTION
## Summary
- route `palewire.com` and `www.palewire.com` to the static Worker
- redirect both hosts to `https://palewi.re` while preserving paths and query strings
- cover all sibling hosts in the Worker test

## Verification
- `make static-worker-test static-worker-validate`
- `make check`
- production redirects verified for both legacy hosts