### PR TITLE
Add Cloudflare monitoring and recovery runbook

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,3 +127,4 @@ jobs:
           scripts/verify-static-site.sh
           scripts/verify-worker-endpoints.sh
           scripts/verify-legacy-redirects.sh
+          scripts/verify-legacy-domains.sh

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -1,11 +1,14 @@
-name: Smoke test
+name: Production smoke test
 
-# Automatic: fires after Heroku reports a successful production deployment.
-# Manual: run via Actions UI with an optional URL override.
+# Automatic: runs after the CI workflow has deployed the static Worker.
+# Scheduled and manual runs provide ongoing coverage between deployments.
 on:
-  deployment_status:
-  repository_dispatch:
-    types: [heroku_deploy]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  schedule:
+    - cron: "0 13 * * *"
   workflow_dispatch:
     inputs:
       base_url:
@@ -20,13 +23,16 @@ jobs:
   smoke:
     name: Smoke test production
     if: >
-      github.event_name != 'deployment_status' ||
-      (github.event.deployment_status.state == 'success' &&
-      github.event.deployment.environment == 'palewire')
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     env:
       BASE_URL: ${{ github.event.inputs.base_url || 'https://palewi.re' }}
+      CURL_MAX_TIME: "20"
+      WORKER_MARKER_ATTEMPTS: "2"
+      WORKER_MARKER_WAIT_SECONDS: "5"
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -39,71 +45,9 @@ jobs:
       - name: Install legacy redirect verifier dependencies
         run: uv sync --locked --no-dev
 
-      - name: Health check (with retries)
+      - name: Verify production endpoints
         run: |
-          echo "Testing health endpoint: $BASE_URL/health/"
-          health_ok=false
-          for i in 1 2 3; do
-            response=$(curl --silent --max-time 20 --write-out "\n%{http_code}" "$BASE_URL/health/" || true)
-            http_code=$(printf '%s\n' "$response" | tail -1)
-            body=$(printf '%s\n' "$response" | sed '$d')
-            echo "Attempt $i — HTTP $http_code — $body"
-            if [ "$http_code" = "200" ]; then
-              if printf '%s' "$body" | python3 -c "import sys,json; assert json.load(sys.stdin) == {'status': 'ok'}" 2>/dev/null; then
-                echo "✅ Health check passed"
-                health_ok=true
-                break
-              fi
-            fi
-            if [ "$i" -lt 3 ]; then sleep 30; fi
-          done
-          if [ "$health_ok" != "true" ]; then
-            echo "❌ Health check failed after retries (last HTTP $http_code)"
-            exit 1
-          fi
-
-      - name: Mastodon discovery Worker (with propagation retries)
-        run: |
-          BASE_URL="$BASE_URL" \
-          CURL_MAX_TIME=20 \
-          WORKER_MARKER_ATTEMPTS=4 \
-          WORKER_MARKER_WAIT_SECONDS=15 \
+          scripts/verify-static-site.sh
           scripts/verify-worker-endpoints.sh
-
-      - name: Legacy redirect Worker (with propagation retries)
-        run: |
-          BASE_URL="$BASE_URL" \
-          CURL_MAX_TIME=20 \
-          WORKER_MARKER_ATTEMPTS=4 \
-          WORKER_MARKER_WAIT_SECONDS=15 \
           scripts/verify-legacy-redirects.sh
-
-      - name: Bio page (with retries)
-        run: |
-          echo "Testing bio page: $BASE_URL/who-is-ben-welsh/"
-          bio_ok=false
-          for i in 1 2 3; do
-            code=$(curl --silent --max-time 20 -o /dev/null -w "%{http_code}" "$BASE_URL/who-is-ben-welsh/" || true)
-            echo "Attempt $i — HTTP $code"
-            if [ "$code" = "200" ]; then
-              bio_ok=true
-              break
-            fi
-            if [ "$i" -lt 3 ]; then sleep 10; fi
-          done
-          [ "$bio_ok" = "true" ] && echo "✅ Bio page OK" || { echo "❌ Bio page failed after retries (last HTTP $code)"; exit 1; }
-
-      - name: Root redirect (with retries)
-        run: |
-          echo "Testing root redirect: $BASE_URL/"
-          redirect_ok=false
-          for i in 1 2 3; do
-            code=$(curl --silent --max-time 20 -o /dev/null -w "%{http_code}" "$BASE_URL/" || true)
-            echo "Attempt $i — HTTP $code"
-            if [ "$code" = "301" ] || [ "$code" = "302" ]; then
-              redirect_ok=true
-              break
-            fi
-            if [ "$i" -lt 3 ]; then sleep 10; fi
-          done
-          [ "$redirect_ok" = "true" ] && echo "✅ Root redirect OK" || { echo "❌ Root redirect failed after retries (last HTTP $code)"; exit 1; }
+          scripts/verify-legacy-domains.sh

--- a/docs/cloudflare-recovery.md
+++ b/docs/cloudflare-recovery.md
@@ -1,0 +1,91 @@
+# Cloudflare recovery
+
+Production is served by the `palewire-static-site` Cloudflare Worker. Its
+routes cover `palewi.re`, `www.palewi.re`, `palewire.com`, and
+`www.palewire.com`. The Mastodon discovery and legacy redirect Workers have
+more-specific routes and must remain in place.
+
+## Detect a problem
+
+The **CI** workflow verifies the deployment after it publishes the Worker.
+The **Production smoke test** workflow repeats the same focused checks daily
+and can be started from **Actions → Production smoke test → Run workflow**.
+The manual `base_url` input is useful for testing another endpoint with the
+same production routes.
+
+The checks cover the canonical pages, `/health/`, CSS and image assets, the
+feed, sitemap, robots file, 404 page, Mastodon discovery endpoints, legacy
+redirect paths, and both `palewire.com` redirect hosts.
+
+## Roll back a Worker release
+
+1. Open the failed CI or smoke run and note the first bad deployment. From a
+   checkout of this repository, identify the last known-good commit with
+   `git log --oneline`.
+2. List deployed Worker versions and roll back the bad version:
+
+   ```bash
+   cd workers/static-site
+   npm ci --ignore-scripts --no-audit --no-fund
+   npm exec -- wrangler versions list
+   npm exec -- wrangler rollback <version-id>
+   ```
+
+3. Verify the public service from the repository root:
+
+   ```bash
+   BASE_URL=https://palewi.re scripts/verify-static-site.sh
+   BASE_URL=https://palewi.re scripts/verify-worker-endpoints.sh
+   BASE_URL=https://palewi.re scripts/verify-legacy-redirects.sh
+   scripts/verify-legacy-domains.sh
+   ```
+
+4. If the version list does not contain the known-good release, check out its
+   commit and redeploy the static Worker:
+
+   ```bash
+   git switch --detach <known-good-commit>
+   make bake
+   npm --prefix workers/static-site ci --ignore-scripts --no-audit --no-fund
+   (cd workers/static-site && npm exec -- wrangler deploy --env="" --strict)
+   ```
+
+   Re-run all four verification commands after the redeploy. Return to the
+   normal branch when the recovery is complete.
+
+## Check Cloudflare DNS and routes
+
+In the Cloudflare dashboard, confirm that both `palewi.re` and
+`palewire.com` are active zones, and that the four production hostnames have
+proxied DNS records. Under **Workers & Pages → Overview → Routes**, confirm
+that `palewire-static-site` owns the four `/*` routes in
+`workers/static-site/wrangler.jsonc`. Confirm that the more-specific
+Mastodon and legacy redirect routes still point to their respective Workers.
+
+Use `curl -sS -D - -o /dev/null` against each hostname while checking; do not
+follow redirects. The canonical host should serve the site, the two legacy
+hosts should return `301` to `https://palewi.re/`, and `www.palewi.re` should
+return a `301` to the equivalent canonical path.
+
+## Locate and validate the private database archive
+
+The final Heroku PostgreSQL dump is preserved privately in
+`palewire/palewi.re-archive`; it is not part of this repository. The retirement
+notes identify `database/production-postgres-b1232.dump`, with its SHA-256
+entry in `checksums.sha256`. Heroku credentials and connection strings are
+intentionally absent.
+
+With GitHub authentication already configured, clone or open that private
+repository outside this checkout. Then validate it without connecting to a
+database:
+
+```bash
+cd /path/to/palewi.re-archive
+sha256sum -c checksums.sha256
+pg_restore --version
+pg_restore --list database/production-postgres-b1232.dump > /dev/null
+```
+
+The recorded validation used `pg_restore 18.2`. Keep the archive outside this
+repository and never add credentials, connection strings, or the dump to a
+commit.

--- a/scripts/verify-legacy-domains.sh
+++ b/scripts/verify-legacy-domains.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+set -eu
+
+timeout=${CURL_MAX_TIME:-20}
+legacy_hosts=${LEGACY_HOSTS:-"palewire.com www.palewire.com"}
+
+case "$timeout" in
+  *[!0-9]*|"") echo "CURL_MAX_TIME must be a positive integer." >&2; exit 1 ;;
+esac
+if [ "$timeout" -eq 0 ]; then
+  echo "CURL_MAX_TIME must be a positive integer." >&2
+  exit 1
+fi
+
+headers_file=$(mktemp "${TMPDIR:-/tmp}/palewire-legacy-domain-headers.XXXXXX")
+cleanup() {
+  rm -f "$headers_file"
+}
+trap cleanup EXIT HUP INT TERM
+
+verify_redirect() {
+  host=$1
+  path=$2
+  expected_location=$3
+  status=$(curl --silent --show-error --max-time "$timeout" \
+    --dump-header "$headers_file" --output /dev/null --write-out '%{http_code}' \
+    "https://${host}${path}") || {
+    echo "${host}${path}: request failed." >&2
+    return 1
+  }
+  location=$(awk 'tolower($1) == "location:" { sub(/\r$/, ""); print substr($0, 11); exit }' "$headers_file")
+  if [ "$status" != "301" ] || [ "$location" != "$expected_location" ]; then
+    echo "${host}${path}: expected HTTP 301 Location ${expected_location}, received ${status} ${location}." >&2
+    return 1
+  fi
+  echo "${host}${path}: HTTP 301 ${location}"
+}
+
+for host in $legacy_hosts; do
+  case "$host" in
+    *[!A-Za-z0-9.-]*|"") echo "LEGACY_HOSTS contains an invalid host." >&2; exit 1 ;;
+  esac
+  verify_redirect "$host" "/" "https://palewi.re/"
+  verify_redirect "$host" "/who-is-ben-welsh/" "https://palewi.re/who-is-ben-welsh/"
+done
+
+echo "legacy domain verification passed"

--- a/scripts/verify-static-site.sh
+++ b/scripts/verify-static-site.sh
@@ -36,6 +36,9 @@ grep -Fq '{"status":"ok"}' "$body_file"
 request "/who-is-ben-welsh/" 200
 grep -Fq '<link rel="canonical" href="https://palewi.re/who-is-ben-welsh/"' "$body_file"
 request "/posts/" 200
+request "/work/" 200
+request "/talks/" 200
+request "/docs/" 200
 request "/sitemap.xml" 200
 grep -Fq '<sitemapindex' "$body_file"
 request "/robots.txt" 200
@@ -43,6 +46,10 @@ request "/this-page-does-not-exist/" 404
 grep -Fq 'id="error-heading">404<' "$body_file"
 request "/feeds/posts/" 200
 grep -Fiq 'content-type: application/rss+xml; charset=utf-8' "$headers_file"
+request "/static/styles.css" 200
+test -s "$body_file"
+request "/static/favicon.ico" 200
+test -s "$body_file"
 request "/" 302
 grep -Fiq 'location: /who-is-ben-welsh/' "$headers_file"
 request "/favicon.ico" 302


### PR DESCRIPTION
## Summary

Closes #403.

- Replace obsolete Heroku smoke triggers with post-CI-deployment, daily, and manual GitHub Actions checks.
- Extend static verification to cover canonical pages and direct CSS/favicon assets.
- Add production checks for both palewire.com redirect hosts.
- Document Cloudflare Worker rollback/redeploy, DNS and route checks, endpoint verification, and private archive validation.

## Testing

- `make check`
- Production verifier scripts against `https://palewi.re`, `palewire.com`, and `www.palewire.com`