### PR TITLE
Add safe post authoring workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ help:
 	@echo "  css-dev    Build expanded CSS with a source map"
 	@echo "  bake       Build static site files in dist/"
 	@echo "  serve      Start the development server"
-	@echo "  new-post  Create a public post (requires TITLE and PUBLISHED_AT)"
+	@echo "  new-post  Create a public post interactively"
 	@echo "  check      Run the same lint, type, Django, and test checks as CI"
 	@echo "  test       Run tests only"
 	@echo "  lint       Run Ruff linter and format check"
@@ -110,9 +110,7 @@ serve: css-dev
 	@"$$(command -v uv)" run python -m scripts.worktree serve
 
 new-post:
-	@test -n "$(TITLE)" || { echo "Set TITLE to the published post title." >&2; exit 1; }
-	@test -n "$(PUBLISHED_AT)" || { echo "Set PUBLISHED_AT to an ISO 8601 Los Angeles datetime with its correct UTC offset." >&2; exit 1; }
-	@"$$(command -v uv)" run python -m scripts.new_post --title "$(TITLE)" --published-at "$(PUBLISHED_AT)"
+	@"$$(command -v uv)" run python -m scripts.new_post
 
 check: lint typecheck django-check check-clip-archives test
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ LEGACY_WORKER_SAME_ZONE_CANARY_ROUTE := palewi.re/legacy-redirects-canary*
 STATIC_WORKER_DIR := workers/static-site
 STATIC_WORKER_PREVIEW_NAME := palewire-static-site-preview
 
-.PHONY: help bootstrap ci-bootstrap check-tools check-wrangler cloudflare-check install hooks css css-dev bake serve check test lint typecheck django-check fmt archive-clips check-clip-archives media-archive-inventory media-archive-backup media-archive-verify static-worker-test static-worker-validate static-worker-preview-deploy static-worker-deploy static-worker-verify worker-test worker-validate worker-canary-deploy worker-verify-canary worker-delete-canary worker-same-zone-canary-deploy worker-attach-same-zone-canary worker-verify-same-zone-canary worker-delete-same-zone-canary worker-route-plan worker-attach-routes worker-verify-production worker-detach-routes worker-delete legacy-worker-test legacy-worker-validate legacy-worker-canary-deploy legacy-worker-delete-canary legacy-worker-same-zone-canary-deploy legacy-worker-attach-same-zone-canary legacy-worker-verify-same-zone-canary legacy-worker-delete-same-zone-canary legacy-worker-route-plan legacy-worker-attach-routes legacy-worker-verify-production legacy-worker-detach-routes legacy-worker-delete
+.PHONY: help bootstrap ci-bootstrap check-tools check-wrangler cloudflare-check install hooks css css-dev bake serve new-post check test lint typecheck django-check fmt archive-clips check-clip-archives media-archive-inventory media-archive-backup media-archive-verify static-worker-test static-worker-validate static-worker-preview-deploy static-worker-deploy static-worker-verify worker-test worker-validate worker-canary-deploy worker-verify-canary worker-delete-canary worker-same-zone-canary-deploy worker-attach-same-zone-canary worker-verify-same-zone-canary worker-delete-same-zone-canary worker-route-plan worker-attach-routes worker-verify-production worker-detach-routes worker-delete legacy-worker-test legacy-worker-validate legacy-worker-canary-deploy legacy-worker-delete-canary legacy-worker-same-zone-canary-deploy legacy-worker-attach-same-zone-canary legacy-worker-verify-same-zone-canary legacy-worker-delete-same-zone-canary legacy-worker-route-plan legacy-worker-attach-routes legacy-worker-verify-production legacy-worker-detach-routes legacy-worker-delete
 
 help:
 	@echo "Available targets:"
@@ -31,6 +31,7 @@ help:
 	@echo "  css-dev    Build expanded CSS with a source map"
 	@echo "  bake       Build static site files in dist/"
 	@echo "  serve      Start the development server"
+	@echo "  new-post  Create a public post (requires TITLE and PUBLISHED_AT)"
 	@echo "  check      Run the same lint, type, Django, and test checks as CI"
 	@echo "  test       Run tests only"
 	@echo "  lint       Run Ruff linter and format check"
@@ -107,6 +108,11 @@ bake: css
 
 serve: css-dev
 	@"$$(command -v uv)" run python -m scripts.worktree serve
+
+new-post:
+	@test -n "$(TITLE)" || { echo "Set TITLE to the published post title." >&2; exit 1; }
+	@test -n "$(PUBLISHED_AT)" || { echo "Set PUBLISHED_AT to an ISO 8601 Los Angeles datetime with its correct UTC offset." >&2; exit 1; }
+	@"$$(command -v uv)" run python -m scripts.new_post --title "$(TITLE)" --published-at "$(PUBLISHED_AT)"
 
 check: lint typecheck django-check check-clip-archives test
 

--- a/README.md
+++ b/README.md
@@ -133,18 +133,24 @@ Public posts in `coltrane/content/posts/` are one `.md` file each. Git and a
 merged pull request are the publishing workflow; do not add drafts or a status
 field to this repository.
 
-1. Create the post from its title and Los Angeles publication time. Supply the
-   offset that applies at that local time (`-08:00` in standard time, `-07:00`
-   in daylight time).
+1. Create the post from its title and Los Angeles publication time. The command
+   prompts directly for both values, so punctuation and dollar signs in titles
+   are preserved. Supply the offset that applies at that local time (`-08:00`
+   in standard time, `-07:00` in daylight time).
 
    ```bash
-   make new-post TITLE="Example post" PUBLISHED_AT="2026-08-24T09:00:00-07:00"
+   make new-post
    ```
 
    The command creates `YYYY-MM-DD--slug.md`, generates the required front
    matter, checks for existing files, duplicate slugs, and duplicate public
    URLs, then prints the new path. It never overwrites a post. It rejects an
    invalid date, missing offset, or a time that is not valid in Los Angeles.
+   For a scripted command, pass the values directly with shell-safe quoting:
+
+   ```bash
+   uv run python -m scripts.new_post --title 'Example post: $5' --published-at '2026-08-24T09:00:00-07:00'
+   ```
 
 2. Edit the new file. Keep the body as raw HTML, including any
    `<pre lang="...">` code blocks. The command's placeholder is deliberately

--- a/README.md
+++ b/README.md
@@ -127,33 +127,44 @@ every source URL, checksum, size, and any failure so nothing is silently
 dropped. `ffmpeg` is only needed for sources that require it (YouTube, Vimeo)
 and is never installed automatically by `make bootstrap`.
 
-## Blog post Markdown
+## Blog post authoring
 
-Public posts in `coltrane/content/posts/` are one `.md` file each. Their YAML
-front matter requires `title`, `slug`, and `published_at`; the datetime must
-use the Los Angeles offset. `repr_image` and `wordpress_id` are optional.
-Keep the body as raw HTML, including any `<pre lang="...">` code blocks. Do
-not add drafts or a status field. The filename format is
-`YYYY-MM-DD--slug.md`, and `posts-manifest.json` is the checked-in public
-fingerprint generated during the production export.
+Public posts in `coltrane/content/posts/` are one `.md` file each. Git and a
+merged pull request are the publishing workflow; do not add drafts or a status
+field to this repository.
 
-To author a post, create a file with this shape:
+1. Create the post from its title and Los Angeles publication time. Supply the
+   offset that applies at that local time (`-08:00` in standard time, `-07:00`
+   in daylight time).
 
-```markdown
----
-title: Example post
-slug: example-post
-published_at: "2026-08-24T09:00:00-07:00"
-repr_image: "https://example.com/image.jpg" # optional
-wordpress_id: 123 # optional legacy ID
----
-<p>Write the published body as raw HTML.</p>
-```
+   ```bash
+   make new-post TITLE="Example post" PUBLISHED_AT="2026-08-24T09:00:00-07:00"
+   ```
+
+   The command creates `YYYY-MM-DD--slug.md`, generates the required front
+   matter, checks for existing files, duplicate slugs, and duplicate public
+   URLs, then prints the new path. It never overwrites a post. It rejects an
+   invalid date, missing offset, or a time that is not valid in Los Angeles.
+
+2. Edit the new file. Keep the body as raw HTML, including any
+   `<pre lang="...">` code blocks. The command's placeholder is deliberately
+   raw HTML. `repr_image` and `wordpress_id` are optional legacy fields.
+
+3. Validate and preview the post locally.
+
+   ```bash
+   make check
+   make serve
+   # Open the printed URL, then visit /posts/ or the new post URL.
+   make bake
+   ```
+
+4. Commit the new Markdown file, push the branch, and open a pull request.
+   Merging that pull request to `main` publishes the post.
 
 Only files in this directory are public. Drafts belong in a private workspace,
-not this repository. Run `make serve`, open the printed local URL, and visit
-`/posts/` or the post's date-based URL to preview it. Run `make check` before
-committing to validate the front matter, public URL inventory, and rendering.
+not this repository. `posts-manifest.json` is the checked-in public fingerprint
+from the historical export; do not edit it for new posts.
 
 ## Deployment
 

--- a/coltrane/content_loaders.py
+++ b/coltrane/content_loaders.py
@@ -215,6 +215,11 @@ def _optional_http_url(record: dict, field_name: str, path: str, title: str) -> 
 def _require_los_angeles_datetime(record: dict, field_name: str, path: str) -> datetime.datetime:
     """Return an ISO datetime expressed in the Los Angeles timezone."""
     value = _require_str(record, field_name, path)
+    return parse_los_angeles_datetime(value, field_name, path)
+
+
+def parse_los_angeles_datetime(value: str, field_name: str, path: str) -> datetime.datetime:
+    """Validate an ISO datetime expressed in the Los Angeles timezone."""
     try:
         parsed = datetime.datetime.fromisoformat(value)
     except ValueError as error:

--- a/scripts/new_post.py
+++ b/scripts/new_post.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import fcntl
 import os
 import re
 import tempfile
 import unicodedata
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 
@@ -70,6 +73,21 @@ def write_new_file(destination: Path, content: str) -> None:
             temporary_path.unlink(missing_ok=True)
 
 
+@contextmanager
+def lock_posts_directory(posts_path: Path) -> Iterator[None]:
+    """Hold an interprocess lock on the posts directory."""
+    descriptor = os.open(posts_path, os.O_RDONLY)
+    locked = False
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        locked = True
+        yield
+    finally:
+        if locked:
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
 def create_post(title: str, published_at_value: str, posts_path: Path = DEFAULT_POSTS_PATH) -> Path:
     """Validate and create a new public Markdown post."""
     title = title.strip()
@@ -81,26 +99,29 @@ def create_post(title: str, published_at_value: str, posts_path: Path = DEFAULT_
         raise PostAuthoringError("title must contain letters or numbers that can form a URL-safe slug")
 
     published_at = parse_los_angeles_datetime(published_at_value, "published_at", "post authoring")
-    destination = posts_path / f"{published_at:%Y-%m-%d}--{slug}.md"
-    if destination.exists():
-        raise PostAuthoringError(f"{destination}: destination already exists")
-
-    posts = load_posts(posts_path)
     url = post_url(published_at, slug)
-    if any(post.get_absolute_url() == url for post in posts):
-        raise PostAuthoringError(f"duplicate public URL '{url}'")
-    if any(post.slug == slug for post in posts):
-        raise PostAuthoringError(f"duplicate post slug '{slug}'")
+    content = post_content(title, slug, published_at.isoformat())
+    with lock_posts_directory(posts_path):
+        destination = posts_path / f"{published_at:%Y-%m-%d}--{slug}.md"
+        if destination.exists():
+            raise PostAuthoringError(f"{destination}: destination already exists")
 
-    write_new_file(destination, post_content(title, slug, published_at.isoformat()))
+        posts = load_posts(posts_path)
+        if any(post.get_absolute_url() == url for post in posts):
+            raise PostAuthoringError(f"duplicate public URL '{url}'")
+        if any(post.slug == slug for post in posts):
+            raise PostAuthoringError(f"duplicate post slug '{slug}'")
+
+        write_new_file(destination, content)
     return destination
 
 
 @click.command()
-@click.option("--title", required=True, help="Published post title.")
+@click.option("--title", required=True, prompt="Title", help="Published post title.")
 @click.option(
     "--published-at",
     required=True,
+    prompt="Published at",
     help="Los Angeles publication time as ISO 8601 with its correct UTC offset.",
 )
 @click.option(

--- a/scripts/new_post.py
+++ b/scripts/new_post.py
@@ -1,0 +1,125 @@
+"""Create a valid, file-backed public blog post."""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+import unicodedata
+from datetime import datetime
+from pathlib import Path
+
+import click
+import yaml
+
+from coltrane.content_loaders import ContentError, load_posts, parse_los_angeles_datetime
+
+DEFAULT_POSTS_PATH = Path(__file__).resolve().parents[1] / "coltrane" / "content" / "posts"
+BODY_PLACEHOLDER = """<!-- Replace this placeholder with the published post body in raw HTML. -->
+<p>Write your post body as raw HTML.</p>
+"""
+
+
+class PostAuthoringError(ValueError):
+    """Raised when a new post would be invalid or conflict with published content."""
+
+
+def slugify(title: str) -> str:
+    """Return an ASCII URL-safe slug generated from a post title."""
+    normalized = unicodedata.normalize("NFKD", title)
+    ascii_title = normalized.encode("ascii", "ignore").decode().lower()
+    return "-".join(re.findall(r"[a-z0-9]+", ascii_title))
+
+
+def post_url(published_at: datetime, slug: str) -> str:
+    """Return the public URL for a date and slug."""
+    return f"/posts/{published_at:%Y}/{published_at:%m}/{published_at:%d}/{slug}/"
+
+
+def post_content(title: str, slug: str, published_at: str) -> str:
+    """Render front matter and the raw-HTML body placeholder."""
+    front_matter = yaml.safe_dump(
+        {"title": title, "slug": slug, "published_at": published_at},
+        allow_unicode=True,
+        default_flow_style=False,
+        sort_keys=False,
+    )
+    return f"---\n{front_matter}---\n{BODY_PLACEHOLDER}"
+
+
+def write_new_file(destination: Path, content: str) -> None:
+    """Atomically create a file without replacing a concurrent destination."""
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            newline="\n",
+            dir=destination.parent,
+            prefix=f".{destination.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary_file:
+            temporary_file.write(content)
+            temporary_path = Path(temporary_file.name)
+        os.link(temporary_path, destination)
+    except FileExistsError as error:
+        raise PostAuthoringError(f"{destination}: destination already exists") from error
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+def create_post(title: str, published_at_value: str, posts_path: Path = DEFAULT_POSTS_PATH) -> Path:
+    """Validate and create a new public Markdown post."""
+    title = title.strip()
+    if not title:
+        raise PostAuthoringError("title must not be empty")
+
+    slug = slugify(title)
+    if not slug:
+        raise PostAuthoringError("title must contain letters or numbers that can form a URL-safe slug")
+
+    published_at = parse_los_angeles_datetime(published_at_value, "published_at", "post authoring")
+    destination = posts_path / f"{published_at:%Y-%m-%d}--{slug}.md"
+    if destination.exists():
+        raise PostAuthoringError(f"{destination}: destination already exists")
+
+    posts = load_posts(posts_path)
+    url = post_url(published_at, slug)
+    if any(post.get_absolute_url() == url for post in posts):
+        raise PostAuthoringError(f"duplicate public URL '{url}'")
+    if any(post.slug == slug for post in posts):
+        raise PostAuthoringError(f"duplicate post slug '{slug}'")
+
+    write_new_file(destination, post_content(title, slug, published_at.isoformat()))
+    return destination
+
+
+@click.command()
+@click.option("--title", required=True, help="Published post title.")
+@click.option(
+    "--published-at",
+    required=True,
+    help="Los Angeles publication time as ISO 8601 with its correct UTC offset.",
+)
+@click.option(
+    "--posts-path",
+    type=click.Path(path_type=Path, exists=True, file_okay=False),
+    default=DEFAULT_POSTS_PATH,
+    show_default=True,
+    help="Directory containing public Markdown posts.",
+)
+def cli(title: str, published_at: str, posts_path: Path) -> None:
+    """Create a new public post with raw-HTML body scaffolding."""
+    try:
+        destination = create_post(title, published_at, posts_path)
+    except (ContentError, PostAuthoringError) as error:
+        raise click.ClickException(str(error)) from error
+
+    click.echo(f"Created {destination}")
+    click.echo("Next: replace the raw-HTML placeholder, run make check, then make serve or make bake to preview.")
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/test_new_post.py
+++ b/tests/test_new_post.py
@@ -1,0 +1,141 @@
+"""Tests for the safe public-post authoring command."""
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from django.core.management import call_command
+from django.test import override_settings
+
+from coltrane import bakery_views, feeds, sitemaps
+from coltrane.content_loaders import load_posts
+from scripts import new_post
+
+
+def run_new_post(posts_path: Path, title: str = "A new post", published_at: str = "2026-08-24T09:00:00-07:00"):
+    return CliRunner().invoke(
+        new_post.cli,
+        [
+            "--title",
+            title,
+            "--published-at",
+            published_at,
+            "--posts-path",
+            str(posts_path),
+        ],
+    )
+
+
+def test_new_post_creates_loader_compatible_raw_html_file(tmp_path):
+    posts_path = tmp_path / "posts"
+    posts_path.mkdir()
+
+    result = run_new_post(posts_path, title="Café: New post!")
+
+    destination = posts_path / "2026-08-24--cafe-new-post.md"
+    assert result.exit_code == 0, result.output
+    assert f"Created {destination}" in result.output
+    assert "make check" in result.output
+    assert destination.read_text(encoding="utf-8") == (
+        "---\n"
+        "title: 'Café: New post!'\n"
+        "slug: cafe-new-post\n"
+        "published_at: '2026-08-24T09:00:00-07:00'\n"
+        "---\n"
+        "<!-- Replace this placeholder with the published post body in raw HTML. -->\n"
+        "<p>Write your post body as raw HTML.</p>\n"
+    )
+    post = load_posts(posts_path)[0]
+    assert post.get_absolute_url() == "/posts/2026/08/24/cafe-new-post/"
+
+
+@pytest.mark.parametrize(
+    ("title", "published_at", "message"),
+    [
+        ("", "2026-08-24T09:00:00-07:00", "title must not be empty"),
+        ("!!!", "2026-08-24T09:00:00-07:00", "URL-safe slug"),
+        ("Example", "2026-02-30T09:00:00-08:00", "ISO 8601 datetime"),
+        ("Example", "2026-08-24T09:00:00", "timezone offset"),
+        ("Example", "2026-08-24T09:00:00+00:00", "America/Los_Angeles"),
+    ],
+)
+def test_new_post_rejects_invalid_input_without_writing(tmp_path, title, published_at, message):
+    posts_path = tmp_path / "posts"
+    posts_path.mkdir()
+
+    result = run_new_post(posts_path, title, published_at)
+
+    assert result.exit_code == 1
+    assert message in result.output
+    assert list(posts_path.iterdir()) == []
+
+
+def test_new_post_rejects_duplicate_slug_without_writing(tmp_path):
+    posts_path = tmp_path / "posts"
+    posts_path.mkdir()
+    (posts_path / "2025-01-01--shared-title.md").write_text(
+        "---\ntitle: Shared title\nslug: shared-title\npublished_at: '2025-01-01T09:00:00-08:00'\n---\n<p>Old</p>\n",
+        encoding="utf-8",
+    )
+
+    result = run_new_post(posts_path, "Shared title", "2026-08-24T09:00:00-07:00")
+
+    assert result.exit_code == 1
+    assert "duplicate post slug 'shared-title'" in result.output
+    assert [path.name for path in posts_path.iterdir()] == ["2025-01-01--shared-title.md"]
+
+
+def test_new_post_rejects_duplicate_public_url_without_writing(tmp_path):
+    posts_path = tmp_path / "posts"
+    posts_path.mkdir()
+    (posts_path / "existing.md").write_text(
+        "---\ntitle: Shared title\nslug: shared-title\npublished_at: '2026-08-24T09:00:00-07:00'\n---\n<p>Old</p>\n",
+        encoding="utf-8",
+    )
+
+    result = run_new_post(posts_path, "Shared title", "2026-08-24T09:00:00-07:00")
+
+    assert result.exit_code == 1
+    assert "duplicate public URL '/posts/2026/08/24/shared-title/'" in result.output
+    assert [path.name for path in posts_path.iterdir()] == ["existing.md"]
+
+
+def test_new_post_refuses_existing_destination_without_writing(tmp_path):
+    posts_path = tmp_path / "posts"
+    posts_path.mkdir()
+    destination = posts_path / "2026-08-24--example.md"
+    destination.write_text("keep this file unchanged", encoding="utf-8")
+
+    result = run_new_post(posts_path, "Example", "2026-08-24T09:00:00-07:00")
+
+    assert result.exit_code == 1
+    assert "destination already exists" in result.output
+    assert destination.read_text(encoding="utf-8") == "keep this file unchanged"
+
+
+def test_write_new_file_refuses_a_destination_created_during_write(tmp_path):
+    destination = tmp_path / "post.md"
+    destination.write_text("keep this file unchanged", encoding="utf-8")
+
+    with pytest.raises(new_post.PostAuthoringError, match="destination already exists"):
+        new_post.write_new_file(destination, "new content")
+
+    assert destination.read_text(encoding="utf-8") == "keep this file unchanged"
+    assert list(tmp_path.iterdir()) == [destination]
+
+
+def test_new_post_builds_at_its_public_url(tmp_path, monkeypatch):
+    posts_path = tmp_path / "posts"
+    posts_path.mkdir()
+    result = run_new_post(posts_path)
+    assert result.exit_code == 0, result.output
+    post = load_posts(posts_path)[0]
+
+    monkeypatch.setattr(bakery_views, "load_posts", lambda: [post])
+    monkeypatch.setattr(feeds, "load_posts", lambda: [post])
+    monkeypatch.setattr(sitemaps, "load_posts", lambda: [post])
+    build_dir = tmp_path / "dist"
+    with override_settings(BUILD_DIR=str(build_dir)):
+        call_command("build")
+
+    assert (build_dir / "posts/2026/08/24/a-new-post/index.html").is_file()

--- a/tests/test_new_post.py
+++ b/tests/test_new_post.py
@@ -1,5 +1,9 @@
 """Tests for the safe public-post authoring command."""
 
+import multiprocessing
+import time
+from multiprocessing.queues import Queue
+from multiprocessing.synchronize import Event
 from pathlib import Path
 
 import pytest
@@ -8,8 +12,24 @@ from django.core.management import call_command
 from django.test import override_settings
 
 from coltrane import bakery_views, feeds, sitemaps
-from coltrane.content_loaders import load_posts
+from coltrane.content_loaders import ContentError, load_posts
 from scripts import new_post
+
+
+def create_post_in_process(
+    start_event: Event,
+    results: Queue,
+    posts_path: str,
+    published_at: str,
+) -> None:
+    """Create a same-title post after both subprocesses are ready."""
+    start_event.wait()
+    try:
+        path = new_post.create_post("Shared title", published_at, Path(posts_path))
+    except (new_post.PostAuthoringError, ContentError) as error:
+        results.put(("error", str(error)))
+    else:
+        results.put(("created", str(path)))
 
 
 def run_new_post(posts_path: Path, title: str = "A new post", published_at: str = "2026-08-24T09:00:00-07:00"):
@@ -47,6 +67,20 @@ def test_new_post_creates_loader_compatible_raw_html_file(tmp_path):
     )
     post = load_posts(posts_path)[0]
     assert post.get_absolute_url() == "/posts/2026/08/24/cafe-new-post/"
+
+
+def test_new_post_prompt_preserves_shell_sensitive_title(tmp_path):
+    posts_path = tmp_path / "posts"
+    posts_path.mkdir()
+
+    result = CliRunner().invoke(
+        new_post.cli,
+        ["--posts-path", str(posts_path)],
+        input="Costs $5 & tax\n2026-08-24T09:00:00-07:00\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "title: Costs $5 & tax" in (posts_path / "2026-08-24--costs-5-tax.md").read_text(encoding="utf-8")
 
 
 @pytest.mark.parametrize(
@@ -122,6 +156,40 @@ def test_write_new_file_refuses_a_destination_created_during_write(tmp_path):
 
     assert destination.read_text(encoding="utf-8") == "keep this file unchanged"
     assert list(tmp_path.iterdir()) == [destination]
+
+
+def test_new_post_locks_duplicate_slug_validation_through_creation(tmp_path, monkeypatch):
+    posts_path = tmp_path / "posts"
+    posts_path.mkdir()
+    original_load_posts = new_post.load_posts
+
+    def delayed_load_posts(path):
+        posts = original_load_posts(path)
+        time.sleep(0.2)
+        return posts
+
+    monkeypatch.setattr(new_post, "load_posts", delayed_load_posts)
+    context = multiprocessing.get_context("fork")
+    start_event = context.Event()
+    results = context.Queue()
+    processes = [
+        context.Process(
+            target=create_post_in_process,
+            args=(start_event, results, str(posts_path), published_at),
+        )
+        for published_at in ("2026-08-24T09:00:00-07:00", "2026-08-25T09:00:00-07:00")
+    ]
+    for process in processes:
+        process.start()
+    start_event.set()
+    for process in processes:
+        process.join(timeout=5)
+
+    assert all(process.exitcode == 0 for process in processes)
+    outcomes = sorted(results.get(timeout=1) for _ in processes)
+    assert outcomes[0][0] == "created"
+    assert outcomes[1] == ("error", "duplicate post slug 'shared-title'")
+    assert len(load_posts(posts_path)) == 1
 
 
 def test_new_post_builds_at_its_public_url(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add a guarded command and Make target for creating file-backed blog posts
- validate Los Angeles publication times, slugs, destinations, and public URL conflicts before writing
- document the create, edit, validate, preview, build, and pull-request workflow

Closes #407