### PR TITLE
Add unified preservation inventory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ STATIC_WORKER_PREVIEW_NAME := palewire-static-site-preview
 
 .PHONY: help bootstrap ci-bootstrap check-tools check-wrangler cloudflare-check install hooks css css-dev bake serve new-post a11y check test lint typecheck django-check fmt archive-clips check-clip-archives media-archive-inventory media-archive-backup media-archive-verify media-archive-r2-sync media-archive-r2-verify media-archive-r2-recover static-worker-test static-worker-validate static-worker-preview-deploy static-worker-deploy static-worker-verify worker-test worker-validate worker-canary-deploy worker-verify-canary worker-delete-canary worker-same-zone-canary-deploy worker-attach-same-zone-canary worker-route-plan worker-attach-routes worker-verify-production worker-detach-routes worker-delete legacy-worker-test legacy-worker-validate legacy-worker-canary-deploy legacy-worker-delete-canary legacy-worker-same-zone-canary-deploy legacy-worker-attach-same-zone-canary legacy-worker-verify-same-zone-canary legacy-worker-delete-same-zone-canary legacy-worker-route-plan legacy-worker-attach-routes legacy-worker-verify-production legacy-worker-detach-routes legacy-worker-delete
 
+
+.PHONY: preservation-inventory
+
 help:
 	@echo "Available targets:"
 	@echo "  bootstrap  Check developer tools, then prepare dependencies and hooks"
@@ -40,6 +43,7 @@ help:
 	@echo "  fmt        Auto-format with Ruff"
 	@echo "  archive-clips  Archive clip URLs missing Wayback metadata"
 	@echo "  check-clip-archives  Confirm every clip has Wayback metadata"
+	@echo "  preservation-inventory  Report page and media preservation state without network access"
 	@echo "  media-archive-inventory  List discovered talk/post media without downloading anything"
 	@echo "  media-archive-backup  Back up pending media to ARCHIVE_ROOT (or MEDIA_ARCHIVE_PATH)"
 	@echo "  media-archive-verify  Recompute checksums of already-archived media, offline"
@@ -148,6 +152,9 @@ archive-clips:
 
 check-clip-archives:
 	@"$$(command -v uv)" run python -m scripts.archive_clips check
+
+preservation-inventory:
+	@"$$(command -v uv)" run python -m scripts.preservation_inventory $(if $(ARCHIVE_ROOT),--archive-root "$(ARCHIVE_ROOT)",)
 
 media-archive-inventory:
 	@"$$(command -v uv)" run python -m scripts.media_archive inventory

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ STATIC_WORKER_PREVIEW_NAME := palewire-static-site-preview
 
 .PHONY: preservation-inventory
 
+
+
 help:
 	@echo "Available targets:"
 	@echo "  bootstrap  Check developer tools, then prepare dependencies and hooks"

--- a/README.md
+++ b/README.md
@@ -118,6 +118,30 @@ The first command reuses an existing snapshot or creates one with the
 It writes progress after every clip and supports resumable batches with
 `uv run python -m scripts.archive_clips archive --limit 10`.
 
+## Preservation inventory and policy
+
+Use the combined, network-free report to review the public Wayback snapshots
+and optional external media archive together:
+
+```bash
+# Without an archive root, media is clearly reported as untracked.
+make preservation-inventory
+
+# Join current sources with an external manifest.
+ARCHIVE_ROOT=/absolute/path/outside/the/repo make preservation-inventory
+
+# Save stable JSON for another local tool.
+uv run python -m scripts.preservation_inventory \
+  --archive-root /absolute/path/outside/the/repo \
+  --json-output /tmp/preservation-inventory.json
+```
+
+The JSON has one sorted record per source URL, its content locations,
+applicable methods, statuses, metadata, and action-specific gaps. It is
+intended for local review and future maintenance tooling, not deployment or
+CI. See [the preservation policy](docs/preservation.md) for status meanings,
+safe maintenance, and recovery limits.
+
 ## Media archive (audio/video backup)
 
 `scripts/media_archive/` finds every playable audio/video source referenced

--- a/README.md
+++ b/README.md
@@ -206,6 +206,14 @@ field to this repository.
    `<pre lang="...">` code blocks. The command's placeholder is deliberately
    raw HTML. `repr_image` and `wordpress_id` are optional legacy fields.
 
+   Creating a post does not create external media or require preservation
+   maintenance. If the post adds a playable audio or video URL, review
+   `make preservation-inventory`, then follow the local backup and checksum
+   steps in [the preservation policy](docs/preservation.md). If a change adds
+   or updates a clip URL, run `make archive-clips` and
+   `make check-clip-archives`. These are manual maintenance steps; `make check`
+   does not fail on existing historical preservation gaps.
+
 3. Validate and preview the post locally.
 
    ```bash

--- a/docs/preservation.md
+++ b/docs/preservation.md
@@ -1,0 +1,113 @@
+# Preservation policy and runbook
+
+## Purpose and boundaries
+
+The preservation inventory is a local, network-free view of two separate
+systems:
+
+| Material | Source of truth | Preservation method | Storage boundary |
+| --- | --- | --- | --- |
+| Public clip pages | `coltrane/content/clips.yaml` | Wayback snapshot or recorded exemption | Public Internet Archive URL |
+| Playable audio and video | External `manifest.json` | Local downloaded file with SHA-256 checksum | A user-chosen directory outside this repository |
+| Future replica | Future R2 process | Private copy of verified local media | Not implemented by this policy |
+
+The report does not fetch pages, download media, recompute checksums, upload
+files, or write a database. It never copies media or its manifest into Git.
+It joins records only when their source URLs match. A source URL can have both
+the `webpage` and `media:*` classifications; in that case, it needs both
+applicable methods.
+
+## Running the report
+
+```bash
+# Shows all current media as untracked because no external manifest is joined.
+make preservation-inventory
+
+# Joins the selected external manifest. The root must be outside this repo.
+ARCHIVE_ROOT=/absolute/path/outside/the/repo make preservation-inventory
+
+# Write stable JSON for another local maintenance tool.
+uv run python -m scripts.preservation_inventory \
+  --archive-root /absolute/path/outside/the/repo \
+  --json-output /tmp/preservation-inventory.json
+```
+
+The JSON format is versioned (`version: 1`) and deterministic: sources,
+origins, classifications, status summaries, and gap records are sorted. It
+contains no run timestamp or machine-specific archive path. Consumers should
+use the explicit `status`, `verification_status`, and `gaps` fields instead
+of parsing terminal output. The terminal shows the first 20 gap details by
+default; use `--max-gaps 0` for a summary-only run.
+
+## Status vocabulary
+
+Wayback status applies only to a clip URL:
+
+| Status | Meaning |
+| --- | --- |
+| `snapshot` | `archive_url` points to a Wayback snapshot. |
+| `exempt` | `archive_exemption` documents why Wayback cannot preserve the page. |
+| `missing` | No snapshot or exemption is recorded. |
+| `not-applicable` | The source is not a clip page. |
+
+Local-media status applies only to playable media:
+
+| Status | Meaning |
+| --- | --- |
+| `untracked` | The current source has no entry in the joined manifest, or no root was supplied. |
+| `pending` | The manifest has not recorded a completed backup. |
+| `success` | A download completed and the manifest records its checksum and size. |
+| `failed` | The last permitted download attempt failed; inspect `error`. |
+| `skipped` | The manifest records that the source was intentionally skipped. Resolve it explicitly. |
+| `invalid` | The manifest has an unsupported status value. |
+| `not-applicable` | The source is not playable media. |
+
+`verification_status` is `verified` only after the offline checksum command
+has recorded a successful verification. A `success` item without that record
+is `not-verified` and is listed as a gap.
+
+## Exemptions and gaps
+
+Use a Wayback exemption only when the page cannot be captured, such as a
+publisher robots policy. Keep the explanation brief and specific. An
+exemption is not a substitute for a missing snapshot, and it does not apply
+to a playable media source.
+
+The report names gaps with stable codes. `wayback-missing` needs a snapshot or
+a specific exemption. `local-media-untracked`, `local-media-pending`,
+`local-media-failed`, and `local-media-skipped` need a local maintenance
+decision. `local-media-not-verified` needs the checksum command. An archived
+media source that is no longer referenced remains in the manifest and is
+reported as historical; do not delete it solely because it no longer appears
+on the site.
+
+## Safe maintenance cadence
+
+1. After changing a clip URL, run `make archive-clips`, then
+   `make check-clip-archives`.
+2. Before a media backup session, review `make media-archive-inventory` and
+   the combined report.
+3. Back up only permitted public sources to a chosen external root with
+   `ARCHIVE_ROOT=/path/outside/repo make media-archive-backup`.
+4. After each backup session, and at least quarterly for long-lived storage,
+   run `uv run python -m scripts.media_archive verify --archive-root /path/outside/repo`.
+5. Re-run the combined report and keep its JSON with local maintenance
+   records if another system needs it.
+
+The future R2 replica may copy only a verified local-media record and its
+checksum metadata. It is intentionally outside this workflow: this project
+does not configure R2 credentials, uploads, replication schedules, or public
+media serving.
+
+## Recovery boundaries
+
+Wayback snapshots are external public references. If a snapshot disappears,
+rerun the clip archive workflow or record a specific, truthful exemption; a
+local media file is not a replacement for a page snapshot.
+
+The external media manifest and files are the recovery source for local
+media. Restore a missing or checksum-mismatched file from a separate durable
+copy, then run the offline verification command. Do not recreate a manifest
+entry by guessing its checksum or download around access controls. Sources
+that require DRM, login, paywalls, or other access controls remain failed or
+skipped with their recorded reason.

--- a/scripts/media_archive/cli.py
+++ b/scripts/media_archive/cli.py
@@ -264,6 +264,7 @@ def verify(archive_root: Path | None) -> None:
     missing = 0
     mismatched = 0
     verified = 0
+    manifest_changed = False
     for entry in successful_entries:
         if not entry.output_filename:
             continue
@@ -279,8 +280,12 @@ def verify(archive_root: Path | None) -> None:
             mismatched += 1
             continue
         verified += 1
+        entry.last_verified_at = manifest_mod.current_timestamp()
+        manifest_changed = True
 
     click.echo(f"\nVerified {verified} file(s); {missing} missing; {mismatched} mismatched.")
+    if manifest_changed:
+        manifest_mod.write_manifest(resolved_root, manifest)
     if missing or mismatched:
         raise click.ClickException(f"{missing + mismatched} file(s) failed verification.")
 

--- a/scripts/media_archive/manifest.py
+++ b/scripts/media_archive/manifest.py
@@ -200,7 +200,7 @@ def load_manifest(archive_root: Path) -> Manifest:
         return Manifest()
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as error:
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
         raise ManifestError(f"{path}: manifest is not valid JSON") from error
     if not isinstance(raw, dict):
         raise ManifestError(f"{path}: manifest must be a JSON object")

--- a/scripts/media_archive/manifest.py
+++ b/scripts/media_archive/manifest.py
@@ -55,6 +55,7 @@ class ManifestEntry:
     info_json_path: str | None = None
     attempts: int = 0
     error: str | None = None
+    last_verified_at: str | None = None
     created_at: str = field(default_factory=current_timestamp)
     updated_at: str = field(default_factory=current_timestamp)
 

--- a/scripts/media_archive/manifest.py
+++ b/scripts/media_archive/manifest.py
@@ -39,6 +39,10 @@ def current_timestamp() -> str:
     return datetime.now(UTC).isoformat()
 
 
+class ManifestError(RuntimeError):
+    """Raised when a manifest file on disk is invalid."""
+
+
 @dataclass
 class ManifestEntry:
     """One tracked media source and the outcome of the last attempt to back it up."""
@@ -89,16 +93,22 @@ class Manifest:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Manifest:
         """Rebuild a manifest from its JSON-serializable representation."""
-        entries = {url: ManifestEntry.from_dict(entry) for url, entry in data.get("entries", {}).items()}
+        raw_entries = data.get("entries", {})
+        if not isinstance(raw_entries, dict):
+            raise ManifestError("manifest 'entries' must be a JSON object")
+        entries: dict[str, ManifestEntry] = {}
+        for url, raw_entry in raw_entries.items():
+            if not isinstance(raw_entry, dict):
+                raise ManifestError(f"manifest entry for {url!r} must be a JSON object")
+            try:
+                entries[url] = ManifestEntry.from_dict(raw_entry)
+            except TypeError as error:
+                raise ManifestError(f"manifest entry for {url!r} has invalid fields") from error
         return cls(
             entries=entries,
             version=data.get("version", MANIFEST_VERSION),
             updated_at=data.get("updated_at", current_timestamp()),
         )
-
-
-class ManifestError(RuntimeError):
-    """Raised when a manifest file on disk is invalid."""
 
 
 def manifest_path(archive_root: Path) -> Path:

--- a/scripts/media_archive/manifest.py
+++ b/scripts/media_archive/manifest.py
@@ -43,6 +43,18 @@ class ManifestError(RuntimeError):
     """Raised when a manifest file on disk is invalid."""
 
 
+_OPTIONAL_STRING_FIELDS = (
+    "extractor",
+    "media_id",
+    "output_filename",
+    "sha256",
+    "info_json_path",
+    "error",
+    "last_verified_at",
+)
+_OCCURRENCE_FIELDS = ("origin_type", "origin_id", "location", "raw_url")
+
+
 @dataclass
 class ManifestEntry:
     """One tracked media source and the outcome of the last attempt to back it up."""
@@ -70,8 +82,41 @@ class ManifestEntry:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ManifestEntry:
         """Rebuild an entry from its JSON-serializable representation."""
-        known_fields = {f for f in cls.__dataclass_fields__}
-        return cls(**{key: value for key, value in data.items() if key in known_fields})
+        if not isinstance(data, dict):
+            raise ManifestError("manifest entry must be a JSON object")
+
+        source_url = _required_string(data, "source_url", "manifest entry")
+        kind = _required_string(data, "kind", "manifest entry")
+        occurrences = _occurrences_from_dict(data)
+        values: dict[str, Any] = {
+            "source_url": source_url,
+            "kind": kind,
+            "occurrences": occurrences,
+        }
+
+        for field_name in ("status", "created_at", "updated_at"):
+            if field_name in data:
+                values[field_name] = _required_string(data, field_name, "manifest entry")
+        for field_name in _OPTIONAL_STRING_FIELDS:
+            if field_name in data:
+                value = data[field_name]
+                if value is not None and not isinstance(value, str):
+                    raise ManifestError(f"manifest entry field {field_name!r} must be a string or null")
+                values[field_name] = value
+        if "size_bytes" in data:
+            size_bytes = data["size_bytes"]
+            if size_bytes is not None and (
+                isinstance(size_bytes, bool) or not isinstance(size_bytes, int) or size_bytes < 0
+            ):
+                raise ManifestError("manifest entry field 'size_bytes' must be a non-negative integer or null")
+            values["size_bytes"] = size_bytes
+        if "attempts" in data:
+            attempts = data["attempts"]
+            if isinstance(attempts, bool) or not isinstance(attempts, int) or attempts < 0:
+                raise ManifestError("manifest entry field 'attempts' must be a non-negative integer")
+            values["attempts"] = attempts
+
+        return cls(**values)
 
 
 @dataclass
@@ -93,6 +138,8 @@ class Manifest:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Manifest:
         """Rebuild a manifest from its JSON-serializable representation."""
+        if not isinstance(data, dict):
+            raise ManifestError("manifest must be a JSON object")
         raw_entries = data.get("entries", {})
         if not isinstance(raw_entries, dict):
             raise ManifestError("manifest 'entries' must be a JSON object")
@@ -100,20 +147,50 @@ class Manifest:
         for url, raw_entry in raw_entries.items():
             if not isinstance(raw_entry, dict):
                 raise ManifestError(f"manifest entry for {url!r} must be a JSON object")
-            try:
-                entries[url] = ManifestEntry.from_dict(raw_entry)
-            except TypeError as error:
-                raise ManifestError(f"manifest entry for {url!r} has invalid fields") from error
+            entries[url] = ManifestEntry.from_dict(raw_entry)
+        version = data.get("version", MANIFEST_VERSION)
+        if isinstance(version, bool) or not isinstance(version, int):
+            raise ManifestError("manifest 'version' must be an integer")
+        updated_at = data.get("updated_at", current_timestamp())
+        if not isinstance(updated_at, str):
+            raise ManifestError("manifest 'updated_at' must be a string")
         return cls(
             entries=entries,
-            version=data.get("version", MANIFEST_VERSION),
-            updated_at=data.get("updated_at", current_timestamp()),
+            version=version,
+            updated_at=updated_at,
         )
 
 
 def manifest_path(archive_root: Path) -> Path:
     """Return the manifest path inside an archive root."""
     return archive_root / MANIFEST_FILENAME
+
+
+def _required_string(data: dict[str, Any], field_name: str, label: str) -> str:
+    """Return a required, non-empty string from a manifest object."""
+    value = data.get(field_name)
+    if not isinstance(value, str) or not value:
+        raise ManifestError(f"{label} field {field_name!r} must be a non-empty string")
+    return value
+
+
+def _occurrences_from_dict(data: dict[str, Any]) -> list[dict[str, str]]:
+    """Validate and return the occurrence records used by the inventory."""
+    raw_occurrences = data.get("occurrences")
+    if not isinstance(raw_occurrences, list):
+        raise ManifestError("manifest entry field 'occurrences' must be a JSON array")
+
+    occurrences: list[dict[str, str]] = []
+    for index, raw_occurrence in enumerate(raw_occurrences):
+        if not isinstance(raw_occurrence, dict):
+            raise ManifestError(f"manifest occurrence {index} must be a JSON object")
+        occurrences.append(
+            {
+                field_name: _required_string(raw_occurrence, field_name, f"manifest occurrence {index}")
+                for field_name in _OCCURRENCE_FIELDS
+            }
+        )
+    return occurrences
 
 
 def load_manifest(archive_root: Path) -> Manifest:

--- a/scripts/preservation_inventory.py
+++ b/scripts/preservation_inventory.py
@@ -1,0 +1,426 @@
+"""Build a network-free report of the site's preservation coverage."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import click
+
+from coltrane.content_loaders import Clip, ContentError, load_clips, load_posts, load_talks
+from scripts.media_archive import manifest as manifest_mod
+from scripts.media_archive.cli import REPO_ROOT, _resolve_archive_root
+from scripts.media_archive.discovery import MediaCandidate, discover_candidates
+
+INVENTORY_VERSION = 1
+CLIPS_PATH = REPO_ROOT / "coltrane" / "content" / "clips.yaml"
+TALKS_PATH = REPO_ROOT / "coltrane" / "content" / "talks.yaml"
+POSTS_PATH = REPO_ROOT / "coltrane" / "content" / "posts"
+
+WAYBACK_SNAPSHOT = "snapshot"
+WAYBACK_EXEMPT = "exempt"
+WAYBACK_MISSING = "missing"
+WAYBACK_NOT_APPLICABLE = "not-applicable"
+
+LOCAL_UNTRACKED = "untracked"
+LOCAL_NOT_APPLICABLE = "not-applicable"
+LOCAL_INVALID = "invalid"
+VERIFICATION_VERIFIED = "verified"
+VERIFICATION_NOT_VERIFIED = "not-verified"
+VERIFICATION_NOT_APPLICABLE = "not-applicable"
+
+MANIFEST_STATUSES = frozenset(
+    {
+        manifest_mod.STATUS_PENDING,
+        manifest_mod.STATUS_SUCCESS,
+        manifest_mod.STATUS_FAILED,
+        manifest_mod.STATUS_SKIPPED,
+    }
+)
+
+
+@dataclass
+class InventorySource:
+    """One URL and all preservation records that apply to it."""
+
+    source_url: str
+    classifications: set[str] = field(default_factory=set)
+    origins: list[dict[str, str]] = field(default_factory=list)
+    has_current_reference: bool = False
+    wayback: dict[str, str | None] = field(
+        default_factory=lambda: {
+            "status": WAYBACK_NOT_APPLICABLE,
+            "archive_url": None,
+            "archive_exemption": None,
+        }
+    )
+    local_media: dict[str, str | int | None] = field(
+        default_factory=lambda: {
+            "status": LOCAL_NOT_APPLICABLE,
+            "manifest_status": None,
+            "kind": None,
+            "verification_status": VERIFICATION_NOT_APPLICABLE,
+            "attempts": None,
+            "last_attempt_at": None,
+            "last_verified_at": None,
+            "output_filename": None,
+            "size_bytes": None,
+            "sha256": None,
+            "error": None,
+        }
+    )
+
+    def add_origins(self, origins: list[dict[str, str]]) -> None:
+        """Add unique origins while preserving a deterministic output order."""
+        self.origins.extend(origin for origin in origins if origin not in self.origins)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the stable JSON representation for this source."""
+        methods: list[str] = []
+        if self.wayback["status"] != WAYBACK_NOT_APPLICABLE:
+            methods.append("wayback")
+        if self.local_media["status"] != LOCAL_NOT_APPLICABLE:
+            methods.append("local-media")
+
+        result = {
+            "source_url": self.source_url,
+            "classifications": sorted(self.classifications),
+            "current_reference": self.has_current_reference,
+            "origins": sorted(
+                self.origins,
+                key=lambda origin: (
+                    origin.get("origin_type", ""),
+                    origin.get("origin_id", ""),
+                    origin.get("location", ""),
+                    origin.get("raw_url", ""),
+                ),
+            ),
+            "preservation_methods": methods,
+            "wayback": self.wayback,
+            "local_media": self.local_media,
+        }
+        result["gaps"] = source_gaps(result)
+        return result
+
+
+def clip_origin(clip: Clip) -> dict[str, str]:
+    """Return a location record for a clip source URL."""
+    return {
+        "origin_type": "clip",
+        "origin_id": clip.title,
+        "location": "clips.yaml:url",
+        "raw_url": clip.url,
+    }
+
+
+def candidate_origins(candidate: MediaCandidate) -> list[dict[str, str]]:
+    """Return content locations for a discovered media candidate."""
+    return [
+        {
+            "origin_type": occurrence.origin_type,
+            "origin_id": occurrence.origin_id,
+            "location": occurrence.location,
+            "raw_url": occurrence.raw_url,
+        }
+        for occurrence in candidate.occurrences
+    ]
+
+
+def manifest_origins(entry: manifest_mod.ManifestEntry) -> list[dict[str, str]]:
+    """Return the durable occurrence history stored by the media manifest."""
+    return [
+        {
+            "origin_type": origin.get("origin_type", "unknown"),
+            "origin_id": origin.get("origin_id", "unknown"),
+            "location": origin.get("location", "unknown"),
+            "raw_url": origin.get("raw_url", entry.source_url),
+        }
+        for origin in entry.occurrences
+    ]
+
+
+def local_media_record(entry: manifest_mod.ManifestEntry | None) -> dict[str, str | int | None]:
+    """Return media state without reading media files or contacting any service."""
+    if entry is None:
+        return {
+            "status": LOCAL_UNTRACKED,
+            "manifest_status": None,
+            "kind": None,
+            "verification_status": VERIFICATION_NOT_APPLICABLE,
+            "attempts": None,
+            "last_attempt_at": None,
+            "last_verified_at": None,
+            "output_filename": None,
+            "size_bytes": None,
+            "sha256": None,
+            "error": None,
+        }
+
+    status = entry.status if entry.status in MANIFEST_STATUSES else LOCAL_INVALID
+    last_verified_at = entry.last_verified_at
+    verification_status = VERIFICATION_NOT_APPLICABLE
+    if status == manifest_mod.STATUS_SUCCESS:
+        verification_status = VERIFICATION_VERIFIED if last_verified_at else VERIFICATION_NOT_VERIFIED
+    return {
+        "status": status,
+        "manifest_status": entry.status,
+        "kind": entry.kind,
+        "verification_status": verification_status,
+        "attempts": entry.attempts,
+        "last_attempt_at": entry.updated_at if entry.attempts else None,
+        "last_verified_at": last_verified_at,
+        "output_filename": entry.output_filename,
+        "size_bytes": entry.size_bytes,
+        "sha256": entry.sha256,
+        "error": entry.error,
+    }
+
+
+def source_gaps(source: dict[str, Any]) -> list[dict[str, str]]:
+    """List action-specific preservation gaps without turning status into policy."""
+    gaps: list[dict[str, str]] = []
+    wayback_status = source["wayback"]["status"]
+    if wayback_status == WAYBACK_MISSING:
+        gaps.append(
+            {
+                "code": "wayback-missing",
+                "message": "A clip source needs a Wayback snapshot or a specific exemption.",
+            }
+        )
+
+    media = source["local_media"]
+    media_status = media["status"]
+    if media_status == LOCAL_UNTRACKED:
+        gaps.append(
+            {
+                "code": "local-media-untracked",
+                "message": "No entry for this current media source was found in the external manifest.",
+            }
+        )
+    elif media_status == manifest_mod.STATUS_PENDING:
+        gaps.append(
+            {
+                "code": "local-media-pending",
+                "message": "The external manifest has not recorded a completed local-media backup.",
+            }
+        )
+    elif media_status == manifest_mod.STATUS_FAILED:
+        detail = f" Last error: {media['error']}" if media["error"] else ""
+        gaps.append(
+            {
+                "code": "local-media-failed",
+                "message": f"The last local-media backup attempt failed.{detail}",
+            }
+        )
+    elif media_status == manifest_mod.STATUS_SKIPPED:
+        gaps.append(
+            {
+                "code": "local-media-skipped",
+                "message": "The external manifest marks this local-media source as skipped.",
+            }
+        )
+    elif media_status == LOCAL_INVALID:
+        gaps.append(
+            {
+                "code": "local-media-invalid-status",
+                "message": f"The external manifest has an unsupported status: {media['manifest_status']}.",
+            }
+        )
+    elif media_status == manifest_mod.STATUS_SUCCESS and media["verification_status"] == VERIFICATION_NOT_VERIFIED:
+        gaps.append(
+            {
+                "code": "local-media-not-verified",
+                "message": "A downloaded file has not yet passed a recorded offline checksum verification.",
+            }
+        )
+    return gaps
+
+
+def build_inventory(
+    clips: list[Clip],
+    candidates: list[MediaCandidate],
+    manifest: manifest_mod.Manifest | None,
+    *,
+    archive_root_provided: bool,
+    manifest_found: bool,
+) -> dict[str, Any]:
+    """Join current site sources with an optional external media manifest."""
+    sources: dict[str, InventorySource] = {}
+
+    def get_source(url: str) -> InventorySource:
+        if url not in sources:
+            sources[url] = InventorySource(source_url=url)
+        return sources[url]
+
+    for clip in clips:
+        source = get_source(clip.url)
+        source.has_current_reference = True
+        source.classifications.add("webpage")
+        source.add_origins([clip_origin(clip)])
+        source.wayback = {
+            "status": WAYBACK_SNAPSHOT
+            if clip.archive_url
+            else WAYBACK_EXEMPT
+            if clip.archive_exemption
+            else WAYBACK_MISSING,
+            "archive_url": clip.archive_url or None,
+            "archive_exemption": clip.archive_exemption or None,
+        }
+
+    for candidate in candidates:
+        source = get_source(candidate.url)
+        source.has_current_reference = True
+        source.classifications.add(f"media:{candidate.kind}")
+        source.add_origins(candidate_origins(candidate))
+        entry = manifest.entries.get(candidate.url) if manifest is not None else None
+        source.local_media = local_media_record(entry)
+        if entry is not None:
+            source.add_origins(manifest_origins(entry))
+
+    if manifest is not None:
+        for url, entry in manifest.entries.items():
+            source = get_source(url)
+            source.classifications.add(f"media:{entry.kind}")
+            source.add_origins(manifest_origins(entry))
+            if source.local_media["status"] == LOCAL_NOT_APPLICABLE:
+                source.local_media = local_media_record(entry)
+
+    serialized_sources = [sources[url].to_dict() for url in sorted(sources)]
+    wayback_statuses = Counter(
+        source["wayback"]["status"]
+        for source in serialized_sources
+        if source["wayback"]["status"] != WAYBACK_NOT_APPLICABLE
+    )
+    media_statuses = Counter(
+        source["local_media"]["status"]
+        for source in serialized_sources
+        if source["local_media"]["status"] != LOCAL_NOT_APPLICABLE
+    )
+    gap_count = sum(len(source["gaps"]) for source in serialized_sources)
+    return {
+        "version": INVENTORY_VERSION,
+        "media_manifest": {
+            "archive_root_provided": archive_root_provided,
+            "manifest_found": manifest_found,
+        },
+        "sources": serialized_sources,
+        "summary": {
+            "source_count": len(serialized_sources),
+            "current_source_count": sum(source["current_reference"] for source in serialized_sources),
+            "historical_media_source_count": sum(not source["current_reference"] for source in serialized_sources),
+            "wayback_statuses": dict(sorted(wayback_statuses.items())),
+            "local_media_statuses": dict(sorted(media_statuses.items())),
+            "gap_count": gap_count,
+        },
+    }
+
+
+def load_inventory(
+    clips_path: Path,
+    talks_path: Path,
+    posts_path: Path,
+    archive_root: Path | None,
+) -> dict[str, Any]:
+    """Load content and optional manifest without performing network or file checks."""
+    try:
+        clips = load_clips(clips_path)
+        candidates = discover_candidates(load_talks(talks_path), load_posts(posts_path))
+    except ContentError as error:
+        raise click.ClickException(str(error)) from error
+
+    if archive_root is None:
+        return build_inventory(clips, candidates, None, archive_root_provided=False, manifest_found=False)
+
+    resolved_root = _resolve_archive_root(archive_root)
+    manifest_file = manifest_mod.manifest_path(resolved_root)
+    try:
+        manifest = manifest_mod.load_manifest(resolved_root)
+    except manifest_mod.ManifestError as error:
+        raise click.ClickException(str(error)) from error
+    return build_inventory(
+        clips,
+        candidates,
+        manifest,
+        archive_root_provided=True,
+        manifest_found=manifest_file.exists(),
+    )
+
+
+def print_inventory(inventory: dict[str, Any], max_gaps: int) -> None:
+    """Render a concise human-readable report from the stable JSON data."""
+    summary = inventory["summary"]
+    click.echo(
+        f"Preservation inventory: {summary['source_count']} source URL(s), "
+        f"{summary['current_source_count']} current, {summary['gap_count']} gap(s)."
+    )
+    click.echo(f"  Wayback: {format_status_counts(summary['wayback_statuses'])}")
+    click.echo(f"  Local media: {format_status_counts(summary['local_media_statuses'])}")
+    displayed_gaps = 0
+    for source in inventory["sources"]:
+        for gap in source["gaps"]:
+            if max_gaps and displayed_gaps == max_gaps:
+                remaining = summary["gap_count"] - displayed_gaps
+                click.echo(f"... {remaining} additional gap(s) are available in the JSON report.")
+                return
+            if max_gaps == 0:
+                continue
+            click.echo(f"{gap['code'].upper()}  {source['source_url']}  {gap['message']}")
+            displayed_gaps += 1
+
+
+def format_status_counts(counts: dict[str, int]) -> str:
+    """Format sorted status counts for terminal output."""
+    return ", ".join(f"{status}={count}" for status, count in sorted(counts.items())) or "none"
+
+
+@click.command()
+@click.option(
+    "--clips-path", type=click.Path(path_type=Path, exists=True, dir_okay=False), default=CLIPS_PATH, show_default=True
+)
+@click.option(
+    "--talks-path", type=click.Path(path_type=Path, exists=True, dir_okay=False), default=TALKS_PATH, show_default=True
+)
+@click.option(
+    "--posts-path", type=click.Path(path_type=Path, exists=True, file_okay=False), default=POSTS_PATH, show_default=True
+)
+@click.option(
+    "--archive-root",
+    type=click.Path(path_type=Path, file_okay=False),
+    envvar="MEDIA_ARCHIVE_PATH",
+    default=None,
+    help="External media archive root to join through its manifest.json file.",
+)
+@click.option(
+    "--json-output",
+    type=click.Path(path_type=Path, dir_okay=False),
+    default=None,
+    help="Write the stable JSON report to this path.",
+)
+@click.option(
+    "--max-gaps",
+    type=click.IntRange(min=0),
+    default=20,
+    show_default=True,
+    help="Maximum number of gap details to show in the terminal.",
+)
+def cli(
+    clips_path: Path,
+    talks_path: Path,
+    posts_path: Path,
+    archive_root: Path | None,
+    json_output: Path | None,
+    max_gaps: int,
+) -> None:
+    """Report page and media preservation state without network access."""
+    inventory = load_inventory(clips_path, talks_path, posts_path, archive_root)
+    print_inventory(inventory, max_gaps)
+    if json_output is not None:
+        json_output.write_text(json.dumps(inventory, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        click.echo(f"Wrote JSON inventory to {json_output}")
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/test_media_archive_cli.py
+++ b/tests/test_media_archive_cli.py
@@ -402,6 +402,7 @@ def test_verify_passes_for_intact_file(tmp_path):
 
     assert result.exit_code == 0
     assert "Verified 1 file(s); 0 missing; 0 mismatched." in result.output
+    assert manifest_mod.load_manifest(archive_root).entries[entry.source_url].last_verified_at is not None
 
 
 def test_verify_reports_missing_file(tmp_path):

--- a/tests/test_media_archive_manifest.py
+++ b/tests/test_media_archive_manifest.py
@@ -103,6 +103,48 @@ def test_load_manifest_invalid_entry_shapes_raise_manifest_error(tmp_path, conte
         load_manifest(tmp_path)
 
 
+@pytest.mark.parametrize(
+    ("entry", "message"),
+    [
+        ({"kind": "direct", "occurrences": []}, "source_url"),
+        ({"source_url": "https://example.com/a.mp4", "kind": "direct", "occurrences": None}, "occurrences"),
+        (
+            {
+                "source_url": "https://example.com/a.mp4",
+                "kind": "direct",
+                "occurrences": [{"origin_type": "post", "origin_id": "example", "location": "video", "raw_url": None}],
+            },
+            "raw_url",
+        ),
+        (
+            {
+                "source_url": "https://example.com/a.mp4",
+                "kind": "direct",
+                "occurrences": [],
+                "attempts": "one",
+            },
+            "attempts",
+        ),
+        (
+            {
+                "source_url": "https://example.com/a.mp4",
+                "kind": "direct",
+                "occurrences": [],
+                "error": [],
+            },
+            "error",
+        ),
+    ],
+)
+def test_load_manifest_invalid_entry_fields_raise_manifest_error(tmp_path, entry, message):
+    manifest_path(tmp_path).write_text(
+        json.dumps({"entries": {entry.get("source_url", "missing"): entry}}), encoding="utf-8"
+    )
+
+    with pytest.raises(ManifestError, match=message):
+        load_manifest(tmp_path)
+
+
 def test_write_manifest_is_atomic_and_readable(tmp_path):
     manifest = Manifest()
     manifest.entries["https://example.com/a.mp4"] = ManifestEntry(

--- a/tests/test_media_archive_manifest.py
+++ b/tests/test_media_archive_manifest.py
@@ -3,6 +3,8 @@
 import hashlib
 import json
 
+import pytest
+
 from scripts.media_archive.discovery import MediaCandidate, MediaOccurrence
 from scripts.media_archive.manifest import (
     STATUS_PENDING,
@@ -85,6 +87,20 @@ def test_load_manifest_non_object_raises(tmp_path):
         raise AssertionError("expected ManifestError")
     except ManifestError as error:
         assert "must be a JSON object" in str(error)
+
+
+@pytest.mark.parametrize(
+    ("contents", "message"),
+    [
+        ('{"entries": null}', "manifest 'entries' must be a JSON object"),
+        ('{"entries": {"https://example.com/a.mp4": []}}', "manifest entry for 'https://example.com/a.mp4'"),
+    ],
+)
+def test_load_manifest_invalid_entry_shapes_raise_manifest_error(tmp_path, contents, message):
+    manifest_path(tmp_path).write_text(contents, encoding="utf-8")
+
+    with pytest.raises(ManifestError, match=message):
+        load_manifest(tmp_path)
 
 
 def test_write_manifest_is_atomic_and_readable(tmp_path):

--- a/tests/test_media_archive_manifest.py
+++ b/tests/test_media_archive_manifest.py
@@ -80,6 +80,13 @@ def test_load_manifest_invalid_json_raises(tmp_path):
         assert "not valid JSON" in str(error)
 
 
+def test_load_manifest_non_utf8_bytes_raise_manifest_error(tmp_path):
+    manifest_path(tmp_path).write_bytes(b"\xff")
+
+    with pytest.raises(ManifestError, match="not valid JSON"):
+        load_manifest(tmp_path)
+
+
 def test_load_manifest_non_object_raises(tmp_path):
     manifest_path(tmp_path).write_text("[1, 2, 3]", encoding="utf-8")
     try:

--- a/tests/test_preservation_inventory.py
+++ b/tests/test_preservation_inventory.py
@@ -173,3 +173,27 @@ def test_report_keeps_unknown_manifest_status_visible_as_a_gap(tmp_path):
 
     assert result.exit_code == 0, result.output
     assert "LOCAL-MEDIA-INVALID-STATUS" in result.output
+
+
+def test_report_surfaces_invalid_manifest_as_a_click_error(tmp_path):
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir()
+    manifest_mod.manifest_path(archive_root).write_text(
+        json.dumps(
+            {
+                "entries": {
+                    "https://vimeo.com/123456": {
+                        "source_url": "https://vimeo.com/123456",
+                        "kind": "vimeo",
+                        "occurrences": None,
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(cli, report_args(tmp_path, "--archive-root", str(archive_root)))
+
+    assert result.exit_code == 1
+    assert "occurrences" in result.output

--- a/tests/test_preservation_inventory.py
+++ b/tests/test_preservation_inventory.py
@@ -1,0 +1,175 @@
+"""Tests for the combined, read-only preservation report."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from scripts.media_archive import manifest as manifest_mod
+from scripts.preservation_inventory import cli
+
+
+def write_clips(path: Path) -> None:
+    path.write_text(
+        "clips:\n"
+        "- title: Saved media page\n"
+        "  type: story\n"
+        "  date: '2024-01-01'\n"
+        "  url: https://example.com/clip.mp4\n"
+        "  archive_url: https://web.archive.org/web/20240101000000/https://example.com/clip.mp4\n",
+        encoding="utf-8",
+    )
+
+
+def write_talks(path: Path) -> None:
+    path.write_text(
+        "talks:\n"
+        "- title: Untracked talk\n"
+        "  venue: Venue\n"
+        "  location: City\n"
+        "  date: '2024-01-02'\n"
+        "  video_url: https://vimeo.com/123456\n",
+        encoding="utf-8",
+    )
+
+
+def write_posts(path: Path) -> None:
+    path.mkdir()
+    (path / "2024-01-01--example.md").write_text(
+        "---\n"
+        "title: Example\n"
+        "slug: example\n"
+        'published_at: "2024-01-01T09:00:00-08:00"\n'
+        "---\n"
+        '<video src="https://example.com/clip.mp4"></video>\n',
+        encoding="utf-8",
+    )
+
+
+def report_args(tmp_path: Path, *extra_args: str) -> list[str]:
+    clips_path = tmp_path / "clips.yaml"
+    talks_path = tmp_path / "talks.yaml"
+    posts_path = tmp_path / "posts"
+    write_clips(clips_path)
+    write_talks(talks_path)
+    write_posts(posts_path)
+    return [
+        "--clips-path",
+        str(clips_path),
+        "--talks-path",
+        str(talks_path),
+        "--posts-path",
+        str(posts_path),
+        *extra_args,
+    ]
+
+
+def test_report_marks_media_untracked_without_archive_root(tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(cli, report_args(tmp_path))
+
+    assert result.exit_code == 0, result.output
+    assert "Preservation inventory: 2 source URL(s), 2 current, 2 gap(s)." in result.output
+    assert "LOCAL-MEDIA-UNTRACKED" in result.output
+
+
+def test_report_joins_clip_and_media_records_and_writes_stable_json(tmp_path):
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir()
+    current_entry = manifest_mod.ManifestEntry(
+        source_url="https://example.com/clip.mp4",
+        kind="direct",
+        occurrences=[
+            {
+                "origin_type": "post",
+                "origin_id": "old-example",
+                "location": "video",
+                "raw_url": "https://example.com/clip.mp4",
+            }
+        ],
+        status=manifest_mod.STATUS_SUCCESS,
+        attempts=2,
+        output_filename="direct/clip.mp4",
+        size_bytes=12,
+        sha256="abc123",
+        last_verified_at="2026-08-25T00:00:00+00:00",
+        updated_at="2026-08-24T00:00:00+00:00",
+    )
+    historical_entry = manifest_mod.ManifestEntry(
+        source_url="https://example.com/removed.mp3",
+        kind="direct",
+        occurrences=[],
+        status=manifest_mod.STATUS_SUCCESS,
+        last_verified_at="2026-08-25T00:00:00+00:00",
+    )
+    manifest_mod.write_manifest(
+        archive_root,
+        manifest_mod.Manifest(
+            entries={
+                current_entry.source_url: current_entry,
+                historical_entry.source_url: historical_entry,
+            }
+        ),
+    )
+    output_path = tmp_path / "inventory.json"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        report_args(
+            tmp_path,
+            "--archive-root",
+            str(archive_root),
+            "--json-output",
+            str(output_path),
+        ),
+    )
+
+    assert result.exit_code == 0, result.output
+    report = json.loads(output_path.read_text(encoding="utf-8"))
+    assert report["version"] == 1
+    assert report["media_manifest"] == {"archive_root_provided": True, "manifest_found": True}
+    assert [source["source_url"] for source in report["sources"]] == [
+        "https://example.com/clip.mp4",
+        "https://example.com/removed.mp3",
+        "https://vimeo.com/123456",
+    ]
+
+    current = report["sources"][0]
+    assert current["classifications"] == ["media:direct", "webpage"]
+    assert current["preservation_methods"] == ["wayback", "local-media"]
+    assert current["wayback"]["status"] == "snapshot"
+    assert current["local_media"]["status"] == "success"
+    assert current["local_media"]["last_attempt_at"] == "2026-08-24T00:00:00+00:00"
+    assert current["local_media"]["verification_status"] == "verified"
+    assert current["gaps"] == []
+    assert {origin["origin_id"] for origin in current["origins"]} == {"Saved media page", "example", "old-example"}
+
+    historical = report["sources"][1]
+    assert historical["current_reference"] is False
+    assert historical["classifications"] == ["media:direct"]
+    assert historical["local_media"]["status"] == "success"
+
+    untracked = report["sources"][2]
+    assert untracked["local_media"]["status"] == "untracked"
+    assert untracked["gaps"][0]["code"] == "local-media-untracked"
+
+
+def test_report_keeps_unknown_manifest_status_visible_as_a_gap(tmp_path):
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir()
+    entry = manifest_mod.ManifestEntry(
+        source_url="https://vimeo.com/123456",
+        kind="vimeo",
+        occurrences=[],
+        status="unexpected",
+    )
+    manifest_mod.write_manifest(archive_root, manifest_mod.Manifest(entries={entry.source_url: entry}))
+
+    runner = CliRunner()
+    result = runner.invoke(cli, report_args(tmp_path, "--archive-root", str(archive_root)))
+
+    assert result.exit_code == 0, result.output
+    assert "LOCAL-MEDIA-INVALID-STATUS" in result.output


### PR DESCRIPTION
## Summary
- add a network-free combined page and media preservation report with stable JSON
- track recorded offline checksum verification times in the external media manifest
- document preservation policy, maintenance steps, and recovery boundaries

Closes #412