### PR TITLE
Harden static-site security headers

### DIFF
--- a/scripts/verify-static-site.sh
+++ b/scripts/verify-static-site.sh
@@ -59,6 +59,9 @@ request "/posts/2010/03/10/google-charts-takes-tufte-challenge/" 200
 grep -Fq 'src="http://chart.apis.google.com/' "$body_file"
 request "/posts/2008/07/06/permalinks-low-rent-data-viz-and-other-stupid-caspio-tricks/" 200
 grep -Fq 'src="http://www.palewire.com/' "$body_file"
+request "/posts/2018/04/14/my-times/" 200
+grep -Fq 'src="//palewire.s3.amazonaws.com/latimes-tour/1.jpg"' "$body_file"
+grep -Fq 'src="//palewire.s3.amazonaws.com/latimes-tour/9track.mp4"' "$body_file"
 request "/sitemap.xml" 200
 grep -Fq '<sitemapindex' "$body_file"
 request "/robots.txt" 200

--- a/scripts/verify-static-site.sh
+++ b/scripts/verify-static-site.sh
@@ -31,14 +31,34 @@ request() {
   }
 }
 
+expect_security_headers() {
+  grep -Fiq "content-security-policy: " "$headers_file"
+  grep -Fiq "frame-src 'self' https://docs.google.com https://player.vimeo.com http://s3-us-west-1.amazonaws.com https://w.soundcloud.com" "$headers_file"
+  grep -Fiq "permissions-policy: camera=(), geolocation=(), microphone=(), payment=(), usb=()" "$headers_file"
+}
+
 request "/health/" 200
 grep -Fq '{"status":"ok"}' "$body_file"
+expect_security_headers
 request "/who-is-ben-welsh/" 200
 grep -Fq '<link rel="canonical" href="https://palewi.re/who-is-ben-welsh/"' "$body_file"
+expect_security_headers
 request "/posts/" 200
 request "/work/" 200
 request "/talks/" 200
 request "/docs/" 200
+request "/posts/2012/02/25/nicar-2012-things-i-said/" 200
+grep -Fq 'src="https://docs.google.com/' "$body_file"
+request "/posts/2012/03/26/leaflet-recipe-hover-events-features-and-polygons/" 200
+grep -Fq 'src="http://s3-us-west-1.amazonaws.com/' "$body_file"
+request "/posts/2017/09/09/what-i-learned/" 200
+grep -Fq 'src="https://player.vimeo.com/' "$body_file"
+request "/posts/2025/05/21/ire-podcast-transcript/" 200
+grep -Fq 'src="https://w.soundcloud.com/' "$body_file"
+request "/posts/2010/03/10/google-charts-takes-tufte-challenge/" 200
+grep -Fq 'src="http://chart.apis.google.com/' "$body_file"
+request "/posts/2008/07/06/permalinks-low-rent-data-viz-and-other-stupid-caspio-tricks/" 200
+grep -Fq 'src="http://www.palewire.com/' "$body_file"
 request "/sitemap.xml" 200
 grep -Fq '<sitemapindex' "$body_file"
 request "/robots.txt" 200

--- a/workers/static-site/README.md
+++ b/workers/static-site/README.md
@@ -6,8 +6,8 @@ origins explicit:
 - Google Fonts for styles and fonts.
 - Google Slides, Vimeo, SoundCloud, and the archived S3 Leaflet examples for
   historical iframes.
-- The canonical `palewi.re`, Google Charts, and the legacy `www.palewire.com`
-  hosts for historical images.
+- The canonical `palewi.re`, Google Charts, legacy `www.palewire.com`, and
+  `palewire.s3.amazonaws.com` hosts for historical images and videos.
 
 Inline styles remain enabled because published post HTML uses them. Executable
 scripts are limited to the site itself. The Permissions Policy disables only

--- a/workers/static-site/README.md
+++ b/workers/static-site/README.md
@@ -1,0 +1,20 @@
+# Static-site security headers
+
+The Worker applies a CSP that keeps the published site's required resource
+origins explicit:
+
+- Google Fonts for styles and fonts.
+- Google Slides, Vimeo, SoundCloud, and the archived S3 Leaflet examples for
+  historical iframes.
+- The canonical `palewi.re`, Google Charts, and the legacy `www.palewire.com`
+  hosts for historical images.
+
+Inline styles remain enabled because published post HTML uses them. Executable
+scripts are limited to the site itself. The Permissions Policy disables only
+camera, geolocation, microphone, payment, and USB; it does not restrict the
+autoplay or fullscreen capabilities used by existing embeds.
+
+Cross-origin isolation headers are intentionally deferred: COEP and related
+headers would require every existing third-party embed and asset to opt in.
+`/.well-known/security.txt` is also deferred until the site has a maintained,
+public security contact and policy URL.

--- a/workers/static-site/src/index.ts
+++ b/workers/static-site/src/index.ts
@@ -15,11 +15,11 @@ const CONTENT_SECURITY_POLICY = [
   "form-action 'self'",
   "frame-ancestors 'none'",
   "frame-src 'self' https://docs.google.com https://player.vimeo.com http://s3-us-west-1.amazonaws.com https://w.soundcloud.com",
-  "img-src 'self' https://palewi.re http://chart.apis.google.com http://www.palewire.com",
+  "img-src 'self' https://palewi.re http://chart.apis.google.com http://www.palewire.com https://palewire.s3.amazonaws.com",
   "font-src 'self' https://fonts.gstatic.com",
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
   "script-src 'self'",
-  "media-src 'self'",
+  "media-src 'self' https://palewire.s3.amazonaws.com",
   "object-src 'none'",
 ].join("; ");
 const SECURITY_HEADERS = {

--- a/workers/static-site/src/index.ts
+++ b/workers/static-site/src/index.ts
@@ -9,7 +9,22 @@ export interface WorkerEnvironment {
 const CANONICAL_HOST = "palewi.re";
 const SIBLING_HOSTS = new Set(["www.palewi.re", "palewire.com", "www.palewire.com"]);
 const USERNAME_DESTINATION = "https://mastodon.palewi.re/@palewire";
+const CONTENT_SECURITY_POLICY = [
+  "base-uri 'self'",
+  "default-src 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+  "frame-src 'self' https://docs.google.com https://player.vimeo.com http://s3-us-west-1.amazonaws.com https://w.soundcloud.com",
+  "img-src 'self' https://palewi.re http://chart.apis.google.com http://www.palewire.com",
+  "font-src 'self' https://fonts.gstatic.com",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "script-src 'self'",
+  "media-src 'self'",
+  "object-src 'none'",
+].join("; ");
 const SECURITY_HEADERS = {
+  "content-security-policy": CONTENT_SECURITY_POLICY,
+  "permissions-policy": "camera=(), geolocation=(), microphone=(), payment=(), usb=()",
   "referrer-policy": "strict-origin-when-cross-origin",
   "x-content-type-options": "nosniff",
   "x-frame-options": "DENY",

--- a/workers/static-site/tests/index.test.ts
+++ b/workers/static-site/tests/index.test.ts
@@ -58,7 +58,25 @@ describe("static site Worker", () => {
     const response = await handleRequest(request("/who-is-ben-welsh/"), { ASSETS: assets });
 
     expect(await response.text()).toBe("https://palewi.re/who-is-ben-welsh/");
+    expect(response.headers.get("content-security-policy")).toBe(
+      "base-uri 'self'; default-src 'self'; form-action 'self'; frame-ancestors 'none'; frame-src 'self' https://docs.google.com https://player.vimeo.com http://s3-us-west-1.amazonaws.com https://w.soundcloud.com; img-src 'self' https://palewi.re http://chart.apis.google.com http://www.palewire.com; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self'; media-src 'self'; object-src 'none'",
+    );
+    expect(response.headers.get("permissions-policy")).toBe(
+      "camera=(), geolocation=(), microphone=(), payment=(), usb=()",
+    );
     expect(response.headers.get("referrer-policy")).toBe("strict-origin-when-cross-origin");
     expect(response.headers.get("strict-transport-security")).toContain("max-age=31536000");
+  });
+
+  it("applies the security policy to redirects and health responses", async () => {
+    const redirectResponse = await handleRequest(request("/"), { ASSETS: assets });
+    const healthResponse = await handleRequest(request("/health/"), { ASSETS: assets });
+
+    for (const response of [redirectResponse, healthResponse]) {
+      expect(response.headers.get("content-security-policy")).toContain("frame-ancestors 'none'");
+      expect(response.headers.get("permissions-policy")).toBe(
+        "camera=(), geolocation=(), microphone=(), payment=(), usb=()",
+      );
+    }
   });
 });

--- a/workers/static-site/tests/index.test.ts
+++ b/workers/static-site/tests/index.test.ts
@@ -59,7 +59,7 @@ describe("static site Worker", () => {
 
     expect(await response.text()).toBe("https://palewi.re/who-is-ben-welsh/");
     expect(response.headers.get("content-security-policy")).toBe(
-      "base-uri 'self'; default-src 'self'; form-action 'self'; frame-ancestors 'none'; frame-src 'self' https://docs.google.com https://player.vimeo.com http://s3-us-west-1.amazonaws.com https://w.soundcloud.com; img-src 'self' https://palewi.re http://chart.apis.google.com http://www.palewire.com; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self'; media-src 'self'; object-src 'none'",
+      "base-uri 'self'; default-src 'self'; form-action 'self'; frame-ancestors 'none'; frame-src 'self' https://docs.google.com https://player.vimeo.com http://s3-us-west-1.amazonaws.com https://w.soundcloud.com; img-src 'self' https://palewi.re http://chart.apis.google.com http://www.palewire.com https://palewire.s3.amazonaws.com; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self'; media-src 'self' https://palewire.s3.amazonaws.com; object-src 'none'",
     );
     expect(response.headers.get("permissions-policy")).toBe(
       "camera=(), geolocation=(), microphone=(), payment=(), usb=()",


### PR DESCRIPTION
Closes #417

## Security headers

- Adds an explicit Content Security Policy with `script-src 'self'`, `object-src 'none'`, `base-uri 'self'`, `form-action 'self'`, and `frame-ancestors 'none'` protection.
- Adds a restrictive Permissions Policy for camera, geolocation, microphone, payment, and USB only.
- Preserves the existing referrer, MIME, framing, transport, redirect, health, RSS, asset, and Mastodon behavior.

## Audited compatibility allowlist

The baked static output was inspected before policy enforcement. The CSP allows only the observed resource origins:

- Styles/fonts: `fonts.googleapis.com` and `fonts.gstatic.com`.
- Historical frames: Google Slides, Vimeo, SoundCloud, and archived S3 Leaflet examples.
- Historical images: canonical `palewi.re`, Google Charts, legacy `www.palewire.com`, and `palewire.s3.amazonaws.com`.
- Historical media: `palewire.s3.amazonaws.com` for the protocol-relative MP4 files in the 2018 My Times post.

Inline styles remain allowed because published raw-HTML posts use them. No executable third-party scripts were found; JSON-LD is retained. Autoplay and fullscreen stay available for existing embeds.

## Compatibility coverage

- Expanded static verification covers `/who-is-ben-welsh/`, `/posts/`, `/work/`, `/talks/`, `/docs/`, and historical pages for every iframe provider, both external image providers, and the S3 image/video post.
- Unit tests verify the exact CSP and Permissions Policy on asset, redirect, and health responses.
- HTTPS browser checks loaded 145 `palewire.s3.amazonaws.com` image and video resources from the historical post with zero CSP messages. Browser checks also reached each page and every iframe provider with no CSP errors.
- `make static-worker-test static-worker-validate`, `PORT=8788 make a11y`, and `make check` pass.

## Deferred decisions

COEP and related cross-origin isolation headers remain deferred because existing third-party embeds and historical assets do not opt in. `/.well-known/security.txt` remains deferred until a maintained public security contact and policy URL are available.
