### PR TITLE
Replicate preserved media to private R2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ LEGACY_WORKER_SAME_ZONE_CANARY_ROUTE := palewi.re/legacy-redirects-canary*
 STATIC_WORKER_DIR := workers/static-site
 STATIC_WORKER_PREVIEW_NAME := palewire-static-site-preview
 
-.PHONY: help bootstrap ci-bootstrap check-tools check-wrangler cloudflare-check install hooks css css-dev bake serve new-post a11y check test lint typecheck django-check fmt archive-clips check-clip-archives media-archive-inventory media-archive-backup media-archive-verify static-worker-test static-worker-validate static-worker-preview-deploy static-worker-deploy static-worker-verify worker-test worker-validate worker-canary-deploy worker-verify-canary worker-delete-canary worker-same-zone-canary-deploy worker-attach-same-zone-canary worker-verify-same-zone-canary worker-delete-same-zone-canary worker-route-plan worker-attach-routes worker-verify-production worker-detach-routes worker-delete legacy-worker-test legacy-worker-validate legacy-worker-canary-deploy legacy-worker-delete-canary legacy-worker-same-zone-canary-deploy legacy-worker-attach-same-zone-canary legacy-worker-verify-same-zone-canary legacy-worker-delete-same-zone-canary legacy-worker-route-plan legacy-worker-attach-routes legacy-worker-verify-production legacy-worker-detach-routes legacy-worker-delete
+.PHONY: help bootstrap ci-bootstrap check-tools check-wrangler cloudflare-check install hooks css css-dev bake serve new-post a11y check test lint typecheck django-check fmt archive-clips check-clip-archives media-archive-inventory media-archive-backup media-archive-verify media-archive-r2-sync media-archive-r2-verify media-archive-r2-recover static-worker-test static-worker-validate static-worker-preview-deploy static-worker-deploy static-worker-verify worker-test worker-validate worker-canary-deploy worker-verify-canary worker-delete-canary worker-same-zone-canary-deploy worker-attach-same-zone-canary worker-route-plan worker-attach-routes worker-verify-production worker-detach-routes worker-delete legacy-worker-test legacy-worker-validate legacy-worker-canary-deploy legacy-worker-delete-canary legacy-worker-same-zone-canary-deploy legacy-worker-attach-same-zone-canary legacy-worker-verify-same-zone-canary legacy-worker-delete-same-zone-canary legacy-worker-route-plan legacy-worker-attach-routes legacy-worker-verify-production legacy-worker-detach-routes legacy-worker-delete
 
 help:
 	@echo "Available targets:"
@@ -43,6 +43,9 @@ help:
 	@echo "  media-archive-inventory  List discovered talk/post media without downloading anything"
 	@echo "  media-archive-backup  Back up pending media to ARCHIVE_ROOT (or MEDIA_ARCHIVE_PATH)"
 	@echo "  media-archive-verify  Recompute checksums of already-archived media, offline"
+	@echo "  media-archive-r2-sync  Replicate an external archive to private R2"
+	@echo "  media-archive-r2-verify  Compare local archive checksums to private R2"
+	@echo "  media-archive-r2-recover  Restore one selected media file from private R2"
 	@echo "  static-worker-test  Run the static site Worker tests"
 	@echo "  static-worker-validate  Validate the static site Worker without deploying"
 	@echo "  static-worker-preview-deploy  Deploy a route-free static-site preview after confirmation"
@@ -156,6 +159,20 @@ media-archive-backup:
 media-archive-verify:
 	@test -n "$$ARCHIVE_ROOT$$MEDIA_ARCHIVE_PATH" || { echo "Set ARCHIVE_ROOT=/path/outside/repo (or export MEDIA_ARCHIVE_PATH) to a directory outside this repository." >&2; exit 1; }
 	@"$$(command -v uv)" run python -m scripts.media_archive verify $(if $(ARCHIVE_ROOT),--archive-root "$(ARCHIVE_ROOT)",)
+
+media-archive-r2-sync:
+	@test -n "$$ARCHIVE_ROOT$$MEDIA_ARCHIVE_PATH" || { echo "Set ARCHIVE_ROOT=/path/outside/repo (or export MEDIA_ARCHIVE_PATH) to a directory outside this repository." >&2; exit 1; }
+	@"$$(command -v uv)" run python -m scripts.media_archive r2-sync $(if $(ARCHIVE_ROOT),--archive-root "$(ARCHIVE_ROOT)",)
+
+media-archive-r2-verify:
+	@test -n "$$ARCHIVE_ROOT$$MEDIA_ARCHIVE_PATH" || { echo "Set ARCHIVE_ROOT=/path/outside/repo (or export MEDIA_ARCHIVE_PATH) to a directory outside this repository." >&2; exit 1; }
+	@"$$(command -v uv)" run python -m scripts.media_archive r2-verify $(if $(ARCHIVE_ROOT),--archive-root "$(ARCHIVE_ROOT)",)
+
+media-archive-r2-recover:
+	@test -n "$$ARCHIVE_ROOT$$MEDIA_ARCHIVE_PATH" || { echo "Set ARCHIVE_ROOT=/path/outside/repo (or export MEDIA_ARCHIVE_PATH) to a directory outside this repository." >&2; exit 1; }
+	@test -n "$$OUTPUT_FILENAME" || { echo "Set OUTPUT_FILENAME to the relative media filename from manifest.json." >&2; exit 1; }
+	@test -n "$$DESTINATION" || { echo "Set DESTINATION to an external file path for the recovered media." >&2; exit 1; }
+	@"$$(command -v uv)" run python -m scripts.media_archive r2-recover $(if $(ARCHIVE_ROOT),--archive-root "$(ARCHIVE_ROOT)",) --output-filename "$$OUTPUT_FILENAME" --destination "$$DESTINATION"
 
 static-worker-test:
 	npm --prefix "$(STATIC_WORKER_DIR)" ci --ignore-scripts --no-audit --no-fund

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ available local ports, so multiple agents can run the site at the same time.
 | `SAVEPAGENOW_ACCESS_KEY` | No | Internet Archive access key used by `make archive-clips` |
 | `SAVEPAGENOW_SECRET_KEY` | No | Internet Archive secret key used by `make archive-clips` |
 | `MEDIA_ARCHIVE_PATH` | No | Directory outside the repo where `make media-archive-backup`/`verify` store media and the manifest |
+| `R2_ACCOUNT_ID` | No | Cloudflare account ID used only by the manual private R2 media replica |
+| `R2_ACCESS_KEY_ID` | No | Bucket-scoped R2 S3 access key, supplied outside Git |
+| `R2_SECRET_ACCESS_KEY` | No | Bucket-scoped R2 S3 secret, supplied outside Git |
+| `MEDIA_ARCHIVE_R2_BUCKET` | No | Private R2 bucket name; defaults to `palewire-media-archive` |
 
 ## Quality gate
 
@@ -126,6 +130,14 @@ idempotent and resumable, and a JSON manifest inside the archive root tracks
 every source URL, checksum, size, and any failure so nothing is silently
 dropped. `ffmpeg` is only needed for sources that require it (YouTube, Vimeo)
 and is never installed automatically by `make bootstrap`.
+
+### Private R2 replica
+
+The local archive remains the source of truth. A private R2 bucket is a manual,
+offsite replica only: it has no public domain, Worker binding, CORS policy, or
+scheduled sync. See [the R2 archive runbook](docs/media-archive-r2.md) for
+bucket-scoped credentials, sync, remote verification, selected-file recovery,
+and cost-aware maintenance.
 
 ## Blog post authoring
 

--- a/docs/media-archive-r2.md
+++ b/docs/media-archive-r2.md
@@ -11,8 +11,8 @@ Use the Cloudflare dashboard: **R2 Object Storage** > **Manage** > **API
 Tokens**. Create an R2 S3-compatible API token with **Object Read and Write**,
 scoped only to `palewire-media-archive`. Store its Access Key ID and Secret
 Access Key in a shell environment or private configuration outside Git. In a
-Bash or Zsh session, enter the values interactively so they are never saved in
-shell history:
+Bash session, enter the values interactively so they are never saved in shell
+history:
 
 ```sh
 read -r -p "R2 account ID: " R2_ACCOUNT_ID

--- a/docs/media-archive-r2.md
+++ b/docs/media-archive-r2.md
@@ -1,0 +1,89 @@
+# Private R2 media archive replica
+
+`palewire-media-archive` is a private, Standard-class R2 bucket for an
+offsite copy of the existing external media archive. It is not a public media
+host, a Worker binding, or a replacement for the local archive. Keep the
+media, `manifest.json`, and extractor sidecars outside this repository.
+
+## Credentials
+
+Use the Cloudflare dashboard: **R2 Object Storage** > **Manage** > **API
+Tokens**. Create an R2 S3-compatible API token with **Object Read and Write**,
+scoped only to `palewire-media-archive`. Store its Access Key ID and Secret
+Access Key in a shell environment or private configuration outside Git:
+
+```sh
+export R2_ACCOUNT_ID="your-cloudflare-account-id"
+export R2_ACCESS_KEY_ID="your-r2-access-key-id"
+export R2_SECRET_ACCESS_KEY="your-r2-secret-access-key"
+```
+
+Never add these values to Git, `.env`, shell history, or command arguments.
+The CLI uses `https://<R2_ACCOUNT_ID>.r2.cloudflarestorage.com` and region
+`auto`. Set `R2_ENDPOINT_URL` only when a jurisdiction-specific endpoint is
+needed.
+
+## Sync and verify
+
+First run the existing offline check. It protects the local source before any
+transfer:
+
+```sh
+ARCHIVE_ROOT=/absolute/path/outside/the/repo make media-archive-verify
+ARCHIVE_ROOT=/absolute/path/outside/the/repo make media-archive-r2-sync
+ARCHIVE_ROOT=/absolute/path/outside/the/repo make media-archive-r2-verify
+```
+
+The sync uploads each successful media file, its yt-dlp `.info.json` sidecar
+when present, `manifest.json`, and a generated `checksums.sha256` listing.
+Each R2 object receives its SHA-256 in private object metadata. A later sync
+uses the object size and that metadata to skip byte-identical files, so an
+interrupted pass resumes safely without re-uploading verified objects.
+
+Remote verification uses `HeadObject` requests only. It reports every missing
+or mismatched object but does not retrieve media, which avoids unnecessary
+retrieval and transfer. Run it after each sync and periodically thereafter.
+
+## Recovery
+
+To restore one media file recorded in the local manifest, use its
+`output_filename` and an external destination:
+
+```sh
+ARCHIVE_ROOT=/absolute/path/outside/the/repo \
+OUTPUT_FILENAME=direct/example.mp4 \
+DESTINATION=/absolute/path/outside/the/repo/recovered/example.mp4 \
+make media-archive-r2-recover
+```
+
+The command refuses repository destinations, will not replace an existing
+file without an explicit CLI `--force`, and hashes the downloaded file before
+keeping it. A checksum failure leaves no partial restored file.
+
+## Cost-aware operation
+
+Sync only after a successful local backup or checksum check. The normal
+remote verification is metadata-only; avoid bulk downloads and full remote
+rehashes. R2 Standard storage has no minimum duration, while Infrequent
+Access has a 30-day minimum and retrieval fees, so Standard remains the
+default for this preservation copy until actual access patterns justify a
+change. Review current pricing before changing storage class or running large
+replication batches.
+
+## Deferred bucket lock
+
+Do not enable a bucket lock until the first real replica and recovery drill
+are complete. The proposed policy is one R2 bucket-lock rule with no prefix,
+named `media-archive-retain-30d`, using the `Age` condition with
+`maxAgeSeconds: 2592000` (30 days). It applies to the entire bucket, including
+existing and future media, manifests, metadata, and checksum files, preventing
+deletion and overwriting during the retention window.
+
+Cloudflare allows bucket-lock rules to be removed, but a bucket cannot be
+emptied while any rule exists. Do not enable this policy until a maintainer
+explicitly approves the 30-day window after the pilot and recovery drill. The
+current pinned Wrangler command that would apply it is:
+
+```sh
+wrangler r2 bucket lock add palewire-media-archive media-archive-retain-30d "" --retention-days 30
+```

--- a/docs/media-archive-r2.md
+++ b/docs/media-archive-r2.md
@@ -10,12 +10,15 @@ media, `manifest.json`, and extractor sidecars outside this repository.
 Use the Cloudflare dashboard: **R2 Object Storage** > **Manage** > **API
 Tokens**. Create an R2 S3-compatible API token with **Object Read and Write**,
 scoped only to `palewire-media-archive`. Store its Access Key ID and Secret
-Access Key in a shell environment or private configuration outside Git:
+Access Key in a shell environment or private configuration outside Git. In a
+Bash or Zsh session, enter the values interactively so they are never saved in
+shell history:
 
 ```sh
-export R2_ACCOUNT_ID="your-cloudflare-account-id"
-export R2_ACCESS_KEY_ID="your-r2-access-key-id"
-export R2_SECRET_ACCESS_KEY="your-r2-secret-access-key"
+read -r -p "R2 account ID: " R2_ACCOUNT_ID
+read -r -s -p "R2 access key ID: " R2_ACCESS_KEY_ID; printf "\n"
+read -r -s -p "R2 secret access key: " R2_SECRET_ACCESS_KEY; printf "\n"
+export R2_ACCOUNT_ID R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY
 ```
 
 Never add these values to Git, `.env`, shell history, or command arguments.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dev = [
     "savepagenow>=1.3.1",
     "ty>=0.0.10",
     "yt-dlp>=2026.8.19",
+    "boto3>=1.40",
 ]
 
 [tool.uv]

--- a/scripts/media_archive/cli.py
+++ b/scripts/media_archive/cli.py
@@ -5,6 +5,9 @@ Commands:
 * ``inventory`` - discover candidates without downloading anything (dry run).
 * ``backup`` - download pending/failed candidates into ``--archive-root``.
 * ``verify`` - recompute checksums of already-downloaded files, offline.
+* ``r2-sync`` - replicate verified local media to a private R2 bucket.
+* ``r2-verify`` - compare local archive checksums against private R2 metadata.
+* ``r2-recover`` - restore one selected media file from private R2.
 """
 
 from __future__ import annotations
@@ -18,6 +21,7 @@ import click
 
 from coltrane.content_loaders import ContentError, load_posts, load_talks
 from scripts.media_archive import manifest as manifest_mod
+from scripts.media_archive import r2
 from scripts.media_archive.discovery import MediaCandidate, discover_candidates
 from scripts.media_archive.downloader import DownloadError, download_candidate, ffmpeg_available
 
@@ -76,6 +80,17 @@ def _archive_root_option() -> Any:
         default=None,
         help="Directory outside the repository where media and the manifest are stored. "
         "Can also be set with the MEDIA_ARCHIVE_PATH environment variable.",
+    )
+
+
+def _r2_bucket_option() -> Any:
+    return click.option(
+        "--bucket",
+        type=str,
+        default=r2.DEFAULT_BUCKET,
+        show_default=True,
+        envvar="MEDIA_ARCHIVE_R2_BUCKET",
+        help="Private R2 bucket containing this archive replica.",
     )
 
 
@@ -268,6 +283,75 @@ def verify(archive_root: Path | None) -> None:
     click.echo(f"\nVerified {verified} file(s); {missing} missing; {mismatched} mismatched.")
     if missing or mismatched:
         raise click.ClickException(f"{missing + mismatched} file(s) failed verification.")
+
+
+@cli.command("r2-sync")
+@_archive_root_option()
+@_r2_bucket_option()
+def r2_sync(archive_root: Path | None, bucket: str) -> None:
+    """Replicate verified media, manifests, checksums, and extractor metadata to private R2."""
+    resolved_root = _resolve_archive_root(archive_root)
+    try:
+        result = r2.sync_archive(r2.create_client_from_environment(), resolved_root, bucket)
+    except r2.R2ReplicaError as error:
+        raise click.ClickException(str(error)) from error
+    click.echo(f"R2 sync complete: {result.uploaded} uploaded; {result.skipped} already verified.")
+
+
+@cli.command("r2-verify")
+@_archive_root_option()
+@_r2_bucket_option()
+def r2_verify(archive_root: Path | None, bucket: str) -> None:
+    """Verify that private R2 has every local object with its expected checksum metadata."""
+    resolved_root = _resolve_archive_root(archive_root)
+    try:
+        result = r2.verify_remote_archive(r2.create_client_from_environment(), resolved_root, bucket)
+    except r2.R2ReplicaError as error:
+        raise click.ClickException(str(error)) from error
+    click.echo(f"R2 verified {result.verified} object(s); {result.missing} missing; {result.mismatched} mismatched.")
+    if result.missing or result.mismatched:
+        raise click.ClickException(f"{result.missing + result.mismatched} R2 object(s) failed verification.")
+
+
+@cli.command("r2-recover")
+@_archive_root_option()
+@_r2_bucket_option()
+@click.option(
+    "--output-filename",
+    required=True,
+    help="Relative media filename recorded in the local archive manifest.",
+)
+@click.option(
+    "--destination",
+    type=click.Path(path_type=Path, dir_okay=False),
+    required=True,
+    help="External path where the recovered media file will be written.",
+)
+@click.option("--force/--no-force", default=False, help="Replace an existing destination file.")
+def r2_recover(
+    archive_root: Path | None,
+    bucket: str,
+    output_filename: str,
+    destination: Path,
+    force: bool,
+) -> None:
+    """Restore one media file from private R2 and validate its manifest checksum."""
+    resolved_root = _resolve_archive_root(archive_root)
+    resolved_destination = destination.expanduser().resolve()
+    if resolved_destination == REPO_ROOT or REPO_ROOT in resolved_destination.parents:
+        raise click.ClickException(f"Refusing to write recovered media under the repository at {REPO_ROOT}.")
+    try:
+        r2.recover_media(
+            r2.create_client_from_environment(),
+            resolved_root,
+            bucket,
+            output_filename,
+            resolved_destination,
+            force=force,
+        )
+    except r2.R2ReplicaError as error:
+        raise click.ClickException(str(error)) from error
+    click.echo(f"Recovered and verified {output_filename} to {resolved_destination}")
 
 
 if __name__ == "__main__":

--- a/scripts/media_archive/r2.py
+++ b/scripts/media_archive/r2.py
@@ -1,0 +1,264 @@
+"""Private, resumable R2 replication for an external media archive."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path
+from typing import Any, Protocol
+
+from botocore.exceptions import ClientError
+
+from scripts.media_archive.manifest import (
+    MANIFEST_FILENAME,
+    STATUS_SUCCESS,
+    Manifest,
+    ManifestEntry,
+    load_manifest,
+    sha256_file,
+)
+
+CHECKSUMS_FILENAME = "checksums.sha256"
+DEFAULT_BUCKET = "palewire-media-archive"
+_SHA256_METADATA_KEY = "sha256"
+
+
+class R2ReplicaError(RuntimeError):
+    """Raised when an archive cannot be safely replicated or recovered."""
+
+
+class SupportsR2(Protocol):
+    """The small S3 client surface used by the local replication commands."""
+
+    def head_object(self, *, Bucket: str, Key: str) -> dict[str, Any]: ...
+
+    def upload_file(self, Filename: str, Bucket: str, Key: str, ExtraArgs: dict[str, Any]) -> None: ...
+
+    def put_object(
+        self,
+        *,
+        Bucket: str,
+        Key: str,
+        Body: bytes,
+        ContentType: str,
+        Metadata: dict[str, str],
+    ) -> dict[str, Any]: ...
+
+    def download_file(self, Bucket: str, Key: str, Filename: str) -> None: ...
+
+
+@dataclass(frozen=True)
+class ArchiveObject:
+    """A local archive object and the checksum expected at its private R2 key."""
+
+    key: str
+    size_bytes: int
+    sha256: str
+    path: Path | None = None
+    body: bytes | None = None
+
+    @property
+    def content_type(self) -> str:
+        if self.key.endswith(".json"):
+            return "application/json"
+        if self.key.endswith(".sha256"):
+            return "text/plain; charset=utf-8"
+        return "application/octet-stream"
+
+
+@dataclass(frozen=True)
+class ReplicationResult:
+    """Counts from one complete sync or remote verification pass."""
+
+    uploaded: int = 0
+    skipped: int = 0
+    verified: int = 0
+    missing: int = 0
+    mismatched: int = 0
+
+
+def create_client_from_environment(environ: Mapping[str, str] | None = None) -> SupportsR2:
+    """Create an R2 S3 client using only explicitly named environment variables."""
+    values = os.environ if environ is None else environ
+    required = ("R2_ACCOUNT_ID", "R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY")
+    missing = [name for name in required if not values.get(name)]
+    if missing:
+        names = ", ".join(missing)
+        raise R2ReplicaError(
+            f"Missing {names}. Create bucket-scoped R2 S3 credentials and set them in your shell or private config."
+        )
+
+    import boto3
+
+    account_id = values["R2_ACCOUNT_ID"]
+    endpoint_url = values.get("R2_ENDPOINT_URL") or f"https://{account_id}.r2.cloudflarestorage.com"
+    return boto3.client(
+        "s3",
+        aws_access_key_id=values["R2_ACCESS_KEY_ID"],
+        aws_secret_access_key=values["R2_SECRET_ACCESS_KEY"],
+        endpoint_url=endpoint_url,
+        region_name="auto",
+    )
+
+
+def _relative_path(value: str) -> Path:
+    path = Path(value)
+    if path.is_absolute() or ".." in path.parts:
+        raise R2ReplicaError(f"Archive path must be relative and stay inside the archive root: {value}")
+    return path
+
+
+def _local_object(archive_root: Path, relative_path: Path) -> ArchiveObject:
+    path = (archive_root / relative_path).resolve()
+    if archive_root not in path.parents or not path.is_file():
+        raise R2ReplicaError(f"Missing archived file: {relative_path.as_posix()}")
+    return ArchiveObject(
+        key=relative_path.as_posix(),
+        size_bytes=path.stat().st_size,
+        sha256=sha256_file(path),
+        path=path,
+    )
+
+
+def _entry_paths(entry: ManifestEntry) -> list[Path]:
+    paths: list[Path] = []
+    if entry.output_filename:
+        paths.append(_relative_path(entry.output_filename))
+    if entry.info_json_path:
+        paths.append(_relative_path(entry.info_json_path))
+    return paths
+
+
+def collect_archive_objects(archive_root: Path) -> tuple[Manifest, list[ArchiveObject]]:
+    """Return media, metadata, manifest, and a derived checksum listing for upload."""
+    manifest_file = archive_root / MANIFEST_FILENAME
+    if not manifest_file.is_file():
+        raise R2ReplicaError(f"Missing archive manifest: {manifest_file}")
+
+    manifest = load_manifest(archive_root)
+    objects_by_key: dict[str, ArchiveObject] = {}
+    for entry in manifest.entries.values():
+        if entry.status == STATUS_SUCCESS:
+            if not entry.output_filename:
+                continue
+            media = _local_object(archive_root, _relative_path(entry.output_filename))
+            if media.size_bytes != entry.size_bytes or media.sha256 != entry.sha256:
+                raise R2ReplicaError(
+                    f"Local media does not match its manifest checksum: {media.key}. Run media-archive-verify first."
+                )
+            objects_by_key[media.key] = media
+            for relative_path in _entry_paths(entry)[1:]:
+                metadata = _local_object(archive_root, relative_path)
+                objects_by_key[metadata.key] = metadata
+
+    manifest_object = _local_object(archive_root, Path(MANIFEST_FILENAME))
+    objects_by_key[manifest_object.key] = manifest_object
+    objects = [objects_by_key[key] for key in sorted(objects_by_key)]
+    checksum_body = "".join(f"{item.sha256}  {item.key}\n" for item in objects).encode()
+    objects.append(
+        ArchiveObject(
+            key=CHECKSUMS_FILENAME,
+            size_bytes=len(checksum_body),
+            sha256=sha256(checksum_body).hexdigest(),
+            body=checksum_body,
+        )
+    )
+    return manifest, objects
+
+
+def _head_object(client: SupportsR2, bucket: str, key: str) -> dict[str, Any] | None:
+    try:
+        return client.head_object(Bucket=bucket, Key=key)
+    except ClientError as error:
+        code = str(error.response.get("Error", {}).get("Code", ""))
+        if code in {"404", "NoSuchKey", "NotFound"}:
+            return None
+        raise
+
+
+def _matches_remote(remote: dict[str, Any] | None, item: ArchiveObject) -> bool:
+    if remote is None or remote.get("ContentLength") != item.size_bytes:
+        return False
+    metadata = remote.get("Metadata", {})
+    return isinstance(metadata, dict) and metadata.get(_SHA256_METADATA_KEY) == item.sha256
+
+
+def _upload_object(client: SupportsR2, bucket: str, item: ArchiveObject) -> None:
+    extra_args = {
+        "ContentType": item.content_type,
+        "Metadata": {_SHA256_METADATA_KEY: item.sha256},
+    }
+    if item.path is not None:
+        client.upload_file(str(item.path), bucket, item.key, ExtraArgs=extra_args)
+        return
+    assert item.body is not None
+    client.put_object(Bucket=bucket, Key=item.key, Body=item.body, **extra_args)
+
+
+def sync_archive(client: SupportsR2, archive_root: Path, bucket: str) -> ReplicationResult:
+    """Upload only objects that R2 cannot prove are byte-identical."""
+    _, objects = collect_archive_objects(archive_root)
+    uploaded = 0
+    skipped = 0
+    for item in objects:
+        if _matches_remote(_head_object(client, bucket, item.key), item):
+            skipped += 1
+            continue
+        _upload_object(client, bucket, item)
+        uploaded += 1
+    return ReplicationResult(uploaded=uploaded, skipped=skipped)
+
+
+def verify_remote_archive(client: SupportsR2, archive_root: Path, bucket: str) -> ReplicationResult:
+    """Compare local archive checksums and sizes to R2 object metadata without downloads."""
+    _, objects = collect_archive_objects(archive_root)
+    verified = 0
+    missing = 0
+    mismatched = 0
+    for item in objects:
+        remote = _head_object(client, bucket, item.key)
+        if remote is None:
+            missing += 1
+        elif _matches_remote(remote, item):
+            verified += 1
+        else:
+            mismatched += 1
+    return ReplicationResult(verified=verified, missing=missing, mismatched=mismatched)
+
+
+def recover_media(
+    client: SupportsR2,
+    archive_root: Path,
+    bucket: str,
+    output_filename: str,
+    destination: Path,
+    *,
+    force: bool = False,
+) -> None:
+    """Restore one selected successful media file and validate it before keeping it."""
+    requested_path = _relative_path(output_filename)
+    manifest = load_manifest(archive_root)
+    entry = next(
+        (
+            candidate
+            for candidate in manifest.entries.values()
+            if candidate.status == STATUS_SUCCESS and candidate.output_filename == requested_path.as_posix()
+        ),
+        None,
+    )
+    if entry is None or not entry.sha256 or entry.size_bytes is None:
+        raise R2ReplicaError(f"No successful manifest entry found for {requested_path.as_posix()}")
+    if destination.exists() and not force:
+        raise R2ReplicaError(f"Destination already exists: {destination}. Pass --force to replace it.")
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = destination.with_name(f"{destination.name}.download")
+    if temporary_path.exists():
+        temporary_path.unlink()
+    client.download_file(bucket, requested_path.as_posix(), str(temporary_path))
+    if temporary_path.stat().st_size != entry.size_bytes or sha256_file(temporary_path) != entry.sha256:
+        temporary_path.unlink(missing_ok=True)
+        raise R2ReplicaError(f"Recovered file failed checksum verification: {requested_path.as_posix()}")
+    temporary_path.replace(destination)

--- a/scripts/media_archive/r2.py
+++ b/scripts/media_archive/r2.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from typing import Any, Protocol
 
 from botocore.exceptions import ClientError
@@ -254,11 +255,20 @@ def recover_media(
         raise R2ReplicaError(f"Destination already exists: {destination}. Pass --force to replace it.")
 
     destination.parent.mkdir(parents=True, exist_ok=True)
-    temporary_path = destination.with_name(f"{destination.name}.download")
-    if temporary_path.exists():
-        temporary_path.unlink()
-    client.download_file(bucket, requested_path.as_posix(), str(temporary_path))
-    if temporary_path.stat().st_size != entry.size_bytes or sha256_file(temporary_path) != entry.sha256:
-        temporary_path.unlink(missing_ok=True)
-        raise R2ReplicaError(f"Recovered file failed checksum verification: {requested_path.as_posix()}")
-    temporary_path.replace(destination)
+    with NamedTemporaryFile(
+        dir=destination.parent,
+        prefix=f".{destination.name}.",
+        suffix=".download",
+        delete=False,
+    ) as temporary_file:
+        temporary_path = Path(temporary_file.name)
+    recovered = False
+    try:
+        client.download_file(bucket, requested_path.as_posix(), str(temporary_path))
+        if temporary_path.stat().st_size != entry.size_bytes or sha256_file(temporary_path) != entry.sha256:
+            raise R2ReplicaError(f"Recovered file failed checksum verification: {requested_path.as_posix()}")
+        temporary_path.replace(destination)
+        recovered = True
+    finally:
+        if not recovered:
+            temporary_path.unlink(missing_ok=True)

--- a/tests/test_media_archive_r2.py
+++ b/tests/test_media_archive_r2.py
@@ -141,10 +141,14 @@ def test_recover_media_restores_and_verifies_selected_file(tmp_path):
     r2.sync_archive(client, archive_root, "bucket")
     media_path.unlink()
     destination = tmp_path / "restored" / "clip.bin"
+    unrelated_download = destination.with_name(f"{destination.name}.download")
+    destination.parent.mkdir()
+    unrelated_download.write_bytes(b"unrelated temporary data")
 
     r2.recover_media(client, archive_root, "bucket", entry.output_filename or "", destination)
 
     assert destination.read_bytes() == b"preserved media"
+    assert unrelated_download.read_bytes() == b"unrelated temporary data"
 
 
 def test_recover_media_rejects_existing_destination_and_bad_checksum(tmp_path):
@@ -162,7 +166,7 @@ def test_recover_media_rejects_existing_destination_and_bad_checksum(tmp_path):
     with pytest.raises(r2.R2ReplicaError, match="failed checksum"):
         r2.recover_media(client, archive_root, "bucket", entry.output_filename or "", destination, force=True)
     assert destination.read_bytes() == b"keep this"
-    assert not (tmp_path / "restored.bin.download").exists()
+    assert not list(tmp_path.glob(".restored.bin.*.download"))
 
 
 def test_collect_archive_objects_rejects_missing_or_unsafe_media_paths(tmp_path):

--- a/tests/test_media_archive_r2.py
+++ b/tests/test_media_archive_r2.py
@@ -1,0 +1,205 @@
+"""Tests for private R2 media archive replication without live cloud access."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, TypedDict
+
+import pytest
+from botocore.exceptions import ClientError
+
+from scripts.media_archive import manifest as manifest_mod
+from scripts.media_archive import r2
+
+
+class StoredObject(TypedDict):
+    """One object retained by the fake S3 client."""
+
+    body: bytes
+    metadata: dict[str, str]
+
+
+class FakeR2:
+    """Small in-memory S3 client that records exactly what replica code sends."""
+
+    def __init__(self) -> None:
+        self.objects: dict[str, StoredObject] = {}
+
+    def head_object(self, *, Bucket: str, Key: str):
+        if Key not in self.objects:
+            raise ClientError({"Error": {"Code": "404"}}, "HeadObject")
+        stored = self.objects[Key]
+        return {
+            "ContentLength": len(stored["body"]),
+            "Metadata": stored["metadata"],
+        }
+
+    def upload_file(self, Filename: str, Bucket: str, Key: str, ExtraArgs: dict[str, Any]) -> None:
+        metadata = ExtraArgs["Metadata"]
+        assert isinstance(metadata, dict)
+        assert all(isinstance(key, str) and isinstance(value, str) for key, value in metadata.items())
+        self.objects[Key] = {
+            "body": Path(Filename).read_bytes(),
+            "metadata": ExtraArgs["Metadata"],
+        }
+
+    def put_object(
+        self,
+        *,
+        Bucket: str,
+        Key: str,
+        Body: bytes,
+        ContentType: str,
+        Metadata: dict[str, str],
+    ) -> dict[str, object]:
+        self.objects[Key] = {
+            "body": Body,
+            "metadata": Metadata,
+        }
+        return {}
+
+    def download_file(self, Bucket: str, Key: str, Filename: str) -> None:
+        if Key not in self.objects:
+            raise ClientError({"Error": {"Code": "404"}}, "GetObject")
+        Path(Filename).write_bytes(self.objects[Key]["body"])
+
+
+def make_archive(archive_root: Path) -> tuple[Path, manifest_mod.ManifestEntry]:
+    media_path = archive_root / "direct" / "clip.bin"
+    metadata_path = archive_root / "direct" / "clip.info.json"
+    media_path.parent.mkdir(parents=True)
+    media_path.write_bytes(b"preserved media")
+    metadata_path.write_text('{"extractor": "Fake"}\n', encoding="utf-8")
+    entry = manifest_mod.ManifestEntry(
+        source_url="https://example.com/clip.mp4",
+        kind="direct",
+        occurrences=[],
+        status=manifest_mod.STATUS_SUCCESS,
+        output_filename="direct/clip.bin",
+        size_bytes=media_path.stat().st_size,
+        sha256=manifest_mod.sha256_file(media_path),
+        info_json_path="direct/clip.info.json",
+    )
+    manifest_mod.write_manifest(archive_root, manifest_mod.Manifest(entries={entry.source_url: entry}))
+    return media_path, entry
+
+
+def test_collect_archive_objects_includes_media_metadata_manifest_and_checksums(tmp_path):
+    archive_root = tmp_path / "archive"
+    make_archive(archive_root)
+
+    _, objects = r2.collect_archive_objects(archive_root)
+
+    assert [item.key for item in objects] == [
+        "direct/clip.bin",
+        "direct/clip.info.json",
+        "manifest.json",
+        "checksums.sha256",
+    ]
+    checksums = objects[-1]
+    assert checksums.body is not None
+    assert b"direct/clip.bin" in checksums.body
+    assert b"manifest.json" in checksums.body
+
+
+def test_sync_is_idempotent_and_uses_checksum_metadata(tmp_path):
+    archive_root = tmp_path / "archive"
+    make_archive(archive_root)
+    client = FakeR2()
+
+    first = r2.sync_archive(client, archive_root, "bucket")
+    second = r2.sync_archive(client, archive_root, "bucket")
+
+    assert first.uploaded == 4
+    assert first.skipped == 0
+    assert second.uploaded == 0
+    assert second.skipped == 4
+    assert client.objects["direct/clip.bin"]["metadata"] == {
+        "sha256": manifest_mod.sha256_file(archive_root / "direct" / "clip.bin")
+    }
+
+
+def test_verify_remote_reports_missing_and_mismatched_objects(tmp_path):
+    archive_root = tmp_path / "archive"
+    make_archive(archive_root)
+    client = FakeR2()
+    r2.sync_archive(client, archive_root, "bucket")
+    del client.objects["manifest.json"]
+    client.objects["direct/clip.bin"]["metadata"] = {"sha256": "incorrect"}
+
+    result = r2.verify_remote_archive(client, archive_root, "bucket")
+
+    assert result.verified == 2
+    assert result.missing == 1
+    assert result.mismatched == 1
+
+
+def test_recover_media_restores_and_verifies_selected_file(tmp_path):
+    archive_root = tmp_path / "archive"
+    media_path, entry = make_archive(archive_root)
+    client = FakeR2()
+    r2.sync_archive(client, archive_root, "bucket")
+    media_path.unlink()
+    destination = tmp_path / "restored" / "clip.bin"
+
+    r2.recover_media(client, archive_root, "bucket", entry.output_filename or "", destination)
+
+    assert destination.read_bytes() == b"preserved media"
+
+
+def test_recover_media_rejects_existing_destination_and_bad_checksum(tmp_path):
+    archive_root = tmp_path / "archive"
+    _, entry = make_archive(archive_root)
+    client = FakeR2()
+    r2.sync_archive(client, archive_root, "bucket")
+    destination = tmp_path / "restored.bin"
+    destination.write_bytes(b"keep this")
+
+    with pytest.raises(r2.R2ReplicaError, match="Destination already exists"):
+        r2.recover_media(client, archive_root, "bucket", entry.output_filename or "", destination)
+
+    client.objects["direct/clip.bin"]["body"] = b"corrupt"
+    with pytest.raises(r2.R2ReplicaError, match="failed checksum"):
+        r2.recover_media(client, archive_root, "bucket", entry.output_filename or "", destination, force=True)
+    assert destination.read_bytes() == b"keep this"
+    assert not (tmp_path / "restored.bin.download").exists()
+
+
+def test_collect_archive_objects_rejects_missing_or_unsafe_media_paths(tmp_path):
+    archive_root = tmp_path / "archive"
+    manifest_mod.write_manifest(
+        archive_root,
+        manifest_mod.Manifest(
+            entries={
+                "https://example.com/clip.mp4": manifest_mod.ManifestEntry(
+                    source_url="https://example.com/clip.mp4",
+                    kind="direct",
+                    occurrences=[],
+                    status=manifest_mod.STATUS_SUCCESS,
+                    output_filename="../not-allowed.bin",
+                )
+            }
+        ),
+    )
+
+    with pytest.raises(r2.R2ReplicaError, match="must be relative"):
+        r2.collect_archive_objects(archive_root)
+
+
+def test_collect_archive_objects_requires_manifest(tmp_path):
+    with pytest.raises(r2.R2ReplicaError, match="Missing archive manifest"):
+        r2.collect_archive_objects(tmp_path / "archive")
+
+
+def test_collect_archive_objects_requires_media_to_match_its_manifest(tmp_path):
+    archive_root = tmp_path / "archive"
+    media_path, _ = make_archive(archive_root)
+    media_path.write_bytes(b"changed after backup")
+
+    with pytest.raises(r2.R2ReplicaError, match="does not match its manifest checksum"):
+        r2.collect_archive_objects(archive_root)
+
+
+def test_create_client_requires_explicit_r2_environment_variables():
+    with pytest.raises(r2.R2ReplicaError, match="R2_ACCOUNT_ID"):
+        r2.create_client_from_environment({})

--- a/uv.lock
+++ b/uv.lock
@@ -456,6 +456,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "boto3" },
     { name = "click" },
     { name = "coverage" },
     { name = "pre-commit" },
@@ -481,6 +482,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "boto3", specifier = ">=1.40" },
     { name = "click", specifier = ">=8.1" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.8" },
     { name = "pre-commit", specifier = ">=4.2" },


### PR DESCRIPTION
## Summary
- add a manual, private R2 sync, metadata verification, and selected-file recovery workflow
- retain the local archive as the source of truth and document bucket-scoped S3 credentials and cost-aware operation
- provision `palewire-media-archive` and validate a small Wrangler pilot, then remove its named objects

## Validation
- `make check`
- private Wrangler pilot upload, download, checksum comparison, and targeted cleanup

Closes #414