### PR TITLE
Fix malformed historic URLs

### DIFF
--- a/coltrane/content/posts-manifest.json
+++ b/coltrane/content/posts-manifest.json
@@ -108,11 +108,11 @@
       "sha256": "1c4df5e52dc1a79a7c19c8dd391cb3bae722e80eaed639e1f8ae331b5ff34458"
     },
     {
-      "body_sha256": "39c69d244e3713cc1db953f2aa24b7c7c209248c555e9f182964eca2f2baa254",
+      "body_sha256": "708f69b1b97d8c36d2eb98fe6adf03deef28512fde0478542f3125a34c8661e6",
       "path": "posts/2008-06-23--tickertube-bens-first-stab-at-amazon-web-services.md",
       "permalink": "/posts/2008/06/23/tickertube-bens-first-stab-at-amazon-web-services/",
       "published_at": "2008-06-23T08:36:39-07:00",
-      "sha256": "1f959d8e2a81a96a1be50dd07c4f40b693da3fc9cd5b34e8e4d6d21fafe5feae"
+      "sha256": "7e1fd470d0f4730ff492cf1ab30e2ec2a4404fe3f7425c78ac9fc68fbc8b9cd3"
     },
     {
       "body_sha256": "ad671cb98afa3ff26ae6e0d9e10af554480ef7de37c788899e99301ad9e9cd08",
@@ -507,7 +507,7 @@
       "sha256": "568ae2a319b6bf239f507326e7dc1a5f5ac5b7725a022abe45264e1e690cd669"
     }
   ],
-  "posts_fingerprint_sha256": "e8a2e756637515e52e55cdd313ca79643c5e2f90eae50e50ef8090ce78ce6082",
+  "posts_fingerprint_sha256": "258f6200ebd3e9dd364f5d78ed40d4cf3ec8ba801e37a0a86cc2c5139b424444",
   "production_inventory": {
     "draft": 94,
     "hidden": 0,

--- a/coltrane/content/posts/2008-06-23--tickertube-bens-first-stab-at-amazon-web-services.md
+++ b/coltrane/content/posts/2008-06-23--tickertube-bens-first-stab-at-amazon-web-services.md
@@ -8,7 +8,7 @@ wordpress_id: 129
 
 
 
-<p>But my objective isn't to build a hit site. I just want to figure out Amazon's toys. What I learned is that while they aren't all that well documented, they can be a lot of fun once you figure out the basics. You'll have to do more hands-on server configuration than you would with <a href="www.feedjack.org/">Google App Engine</a>, but greater control does come with benefits.</p>
+<p>But my objective isn't to build a hit site. I just want to figure out Amazon's toys. What I learned is that while they aren't all that well documented, they can be a lot of fun once you figure out the basics. You'll have to do more hands-on server configuration than you would with <a href="https://www.feedjack.org/">Google App Engine</a>, but greater control does come with benefits.</p>
 
 
 
@@ -16,4 +16,4 @@ wordpress_id: 129
 
 
 
-<p>Thanks to all the great tools that made this project easy. Besides Amazon, much love to <a href="www.djangoproject.com/">Django</a>, <a href="developer.yahoo.com/yui/">YUI</a> and <a href="www.feedjack.org/">Feedjack</a>.</p>
+<p>Thanks to all the great tools that made this project easy. Besides Amazon, much love to <a href="https://www.djangoproject.com/">Django</a>, <a href="https://developer.yahoo.com/yui/">YUI</a> and <a href="https://www.feedjack.org/">Feedjack</a>.</p>

--- a/scripts/built_site_quality_baseline.txt
+++ b/scripts/built_site_quality_baseline.txt
@@ -50,10 +50,6 @@ image-alt	posts/2018/04/14/my-times/index.html	image is missing an alt attribute
 image-alt	posts/2018/04/14/my-times/index.html	image is missing an alt attribute
 image-alt	posts/2018/04/14/my-times/index.html	image is missing an alt attribute
 image-alt	posts/2018/04/14/my-times/index.html	image is missing an alt attribute
-invalid-external-url	posts/2008/06/23/tickertube-bens-first-stab-at-amazon-web-services/index.html	a[href="developer.yahoo.com/yui/"] is missing an HTTP(S) scheme
-invalid-external-url	posts/2008/06/23/tickertube-bens-first-stab-at-amazon-web-services/index.html	a[href="www.djangoproject.com/"] is missing an HTTP(S) scheme
-invalid-external-url	posts/2008/06/23/tickertube-bens-first-stab-at-amazon-web-services/index.html	a[href="www.feedjack.org/"] is missing an HTTP(S) scheme
-invalid-external-url	posts/2008/06/23/tickertube-bens-first-stab-at-amazon-web-services/index.html	a[href="www.feedjack.org/"] is missing an HTTP(S) scheme
 missing-generated-page	404.html	a[href="/"] targets absent generated page /
 missing-generated-page	404.html	link[href="https://palewi.re/"] targets absent generated page /
 missing-generated-page	500.html	a[href="/"] targets absent generated page /


### PR DESCRIPTION
Fixes #424.

Restores HTTPS schemes for the four malformed historical Tickertube links, removes the four matching occurrence-aware built-site-quality baseline entries, and refreshes the affected public-post manifest hashes.

Validation: `make check`