### PR TITLE
Add security contact file

### DIFF
--- a/coltrane/bakery_views.py
+++ b/coltrane/bakery_views.py
@@ -128,6 +128,12 @@ class RobotsBuildView(CanonicalBuildMixin, BuildableTemplateView):
     template_name = "robots.txt"
 
 
+class SecurityTxtBuildView(CanonicalBuildMixin, BuildableTemplateView):
+    build_path = ".well-known/security.txt"
+    content_type = "text/plain; charset=utf-8"
+    template_name = "security.txt"
+
+
 class Static404BuildView(CanonicalBuildMixin, Buildable404View):
     pass
 

--- a/coltrane/templates/security.txt
+++ b/coltrane/templates/security.txt
@@ -1,0 +1,4 @@
+Contact: mailto:b@palewi.re
+Expires: 2027-08-01T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://palewi.re/.well-known/security.txt

--- a/project/settings.py
+++ b/project/settings.py
@@ -79,6 +79,7 @@ BAKERY_VIEWS = [
     "coltrane.bakery_views.PostDetailBuildView",
     "coltrane.bakery_views.LatestPostsBuildFeed",
     "coltrane.bakery_views.RobotsBuildView",
+    "coltrane.bakery_views.SecurityTxtBuildView",
     "coltrane.bakery_views.Static404BuildView",
     "coltrane.bakery_views.Static500BuildView",
     "coltrane.bakery_views.SitemapIndexBuildView",

--- a/project/urls.py
+++ b/project/urls.py
@@ -36,12 +36,17 @@ urlpatterns = [
         {"sitemaps": sitemaps},
         name="django.contrib.sitemaps.views.sitemap",
     ),
-    # Robots and favicon
+    # Plain-text site metadata
     path("feeds/posts/", LatestPostsFeed()),
     path(
         "robots.txt",
         TemplateView.as_view(template_name="robots.txt", content_type="text/plain"),
         name="robots",
+    ),
+    path(
+        ".well-known/security.txt",
+        TemplateView.as_view(template_name="security.txt", content_type="text/plain; charset=utf-8"),
+        name="security_txt",
     ),
     path("favicon.ico", RedirectView.as_view(url=f"{settings.STATIC_URL}favicon.ico"), name="favicon"),
     path("@palewire", views.username_redirect),

--- a/tests/test_static_build.py
+++ b/tests/test_static_build.py
@@ -7,6 +7,13 @@ from django.test import Client, override_settings
 
 from coltrane.content_loaders import load_posts
 
+SECURITY_TXT_CONTENT = (
+    "Contact: mailto:b@palewi.re\n"
+    "Expires: 2027-08-01T00:00:00.000Z\n"
+    "Preferred-Languages: en\n"
+    "Canonical: https://palewi.re/.well-known/security.txt\n"
+)
+
 
 def test_static_build_matches_public_django_pages(tmp_path: Path) -> None:
     """The baked files must retain the public content served by Django."""
@@ -47,3 +54,18 @@ def test_static_build_matches_public_django_pages(tmp_path: Path) -> None:
     assert (build_dir / "favicon.ico").is_file()
     assert (build_dir / "static/styles.css").is_file()
     assert len(list(build_dir.glob("posts/*/*/*/*/index.html"))) == len(load_posts())
+
+
+def test_security_txt_is_baked_as_canonical_plain_text(tmp_path: Path) -> None:
+    """The security contact document remains a direct plain-text static asset."""
+    build_dir = tmp_path / "dist"
+    with override_settings(BUILD_DIR=str(build_dir)):
+        call_command("build")
+
+    response = Client(HTTP_HOST="palewi.re").get("/.well-known/security.txt", secure=True)
+
+    assert response.status_code == 200
+    assert response["Content-Type"] == "text/plain; charset=utf-8"
+    assert not response.has_header("Location")
+    assert response.content.decode() == SECURITY_TXT_CONTENT
+    assert build_dir.joinpath(".well-known/security.txt").read_text(encoding="utf-8") == SECURITY_TXT_CONTENT

--- a/workers/static-site/README.md
+++ b/workers/static-site/README.md
@@ -16,5 +16,6 @@ autoplay or fullscreen capabilities used by existing embeds.
 
 Cross-origin isolation headers are intentionally deferred: COEP and related
 headers would require every existing third-party embed and asset to opt in.
-`/.well-known/security.txt` is also deferred until the site has a maintained,
-public security contact and policy URL.
+
+`/.well-known/security.txt` is a baked plain-text asset. Renew its `Expires`
+date in `coltrane/templates/security.txt` before 2027-08-01.

--- a/workers/static-site/src/index.ts
+++ b/workers/static-site/src/index.ts
@@ -9,6 +9,7 @@ export interface WorkerEnvironment {
 const CANONICAL_HOST = "palewi.re";
 const SIBLING_HOSTS = new Set(["www.palewi.re", "palewire.com", "www.palewire.com"]);
 const USERNAME_DESTINATION = "https://mastodon.palewi.re/@palewire";
+const SECURITY_TXT_PATH = "/.well-known/security.txt";
 const CONTENT_SECURITY_POLICY = [
   "base-uri 'self'",
   "default-src 'self'",
@@ -80,6 +81,17 @@ async function serveFeed(request: Request, assets: StaticAssets): Promise<Respon
   });
 }
 
+async function serveSecurityTxt(request: Request, assets: StaticAssets): Promise<Response> {
+  const response = await assets.fetch(request);
+  const headers = new Headers(response.headers);
+  headers.set("content-type", "text/plain; charset=utf-8");
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
 export async function handleRequest(request: Request, environment: WorkerEnvironment): Promise<Response> {
   const url = new URL(request.url);
   if (SIBLING_HOSTS.has(url.hostname)) {
@@ -101,6 +113,9 @@ export async function handleRequest(request: Request, environment: WorkerEnviron
   }
   if (url.pathname === "/feeds/posts/") {
     return withSecurityHeaders(await serveFeed(request, environment.ASSETS), request);
+  }
+  if (url.pathname === SECURITY_TXT_PATH) {
+    return withSecurityHeaders(await serveSecurityTxt(request, environment.ASSETS), request);
   }
   return withSecurityHeaders(await environment.ASSETS.fetch(request), request);
 }

--- a/workers/static-site/tests/index.test.ts
+++ b/workers/static-site/tests/index.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, it } from "vitest";
 
 import { handleRequest, type StaticAssets } from "../src/index";
 
+const SECURITY_TXT_CONTENT = [
+  "Contact: mailto:b@palewi.re",
+  "Expires: 2027-08-01T00:00:00.000Z",
+  "Preferred-Languages: en",
+  "Canonical: https://palewi.re/.well-known/security.txt",
+  "",
+].join("\n");
+
 const assets: StaticAssets = {
   async fetch(request) {
     return new Response(request.url, {
@@ -52,6 +60,24 @@ describe("static site Worker", () => {
 
     expect(response.headers.get("content-type")).toBe("application/rss+xml; charset=utf-8");
     await expect(response.text()).resolves.toContain("/feeds/posts/index.xml");
+  });
+
+  it("serves security.txt directly as plain text", async () => {
+    const response = await handleRequest(request("/.well-known/security.txt"), {
+      ASSETS: {
+        async fetch(assetRequest) {
+          expect(new URL(assetRequest.url).pathname).toBe("/.well-known/security.txt");
+          return new Response(SECURITY_TXT_CONTENT, {
+            headers: { "content-type": "text/html; charset=utf-8" },
+          });
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(response.headers.get("location")).toBeNull();
+    await expect(response.text()).resolves.toBe(SECURITY_TXT_CONTENT);
   });
 
   it("passes static assets through with security headers", async () => {


### PR DESCRIPTION
## Summary
- publish the standard security contact document at `/.well-known/security.txt`
- bake the plain-text asset and preserve its exact MIME type through the static Worker
- cover the direct response, build output, and Worker response with tests

## Validation
- `make check`
- `make static-worker-test`
- `make static-worker-validate`
- `make worker-test`
- `make worker-validate`
- `make legacy-worker-test`
- `make legacy-worker-validate`