### PR TITLE
Honor configured media CA bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ available local ports, so multiple agents can run the site at the same time.
 | `SAVEPAGENOW_ACCESS_KEY` | No | Internet Archive access key used by `make archive-clips` |
 | `SAVEPAGENOW_SECRET_KEY` | No | Internet Archive secret key used by `make archive-clips` |
 | `MEDIA_ARCHIVE_PATH` | No | Directory outside the repo where `make media-archive-backup`/`verify` store media and the manifest |
+| `SSL_CERT_FILE` | No | Readable PEM CA bundle used by the media archive's verified yt-dlp connections |
 | `R2_ACCOUNT_ID` | No | Cloudflare account ID used only by the manual private R2 media replica |
 | `R2_ACCESS_KEY_ID` | No | Bucket-scoped R2 S3 access key, supplied outside Git |
 | `R2_SECRET_ACCESS_KEY` | No | Bucket-scoped R2 S3 secret, supplied outside Git |
@@ -184,6 +185,21 @@ idempotent and resumable, and a JSON manifest inside the archive root tracks
 every source URL, checksum, size, and any failure so nothing is silently
 dropped. `ffmpeg` is only needed for sources that require it (YouTube, Vimeo)
 and is never installed automatically by `make bootstrap`.
+
+### TLS trust bundles
+
+When a network requires an enterprise root certificate, create a readable PEM
+bundle that includes both the public roots and that enterprise root, then set
+it before running the archive command:
+
+```bash
+export SSL_CERT_FILE=/path/to/combined-ca-bundle.pem
+ARCHIVE_ROOT=/absolute/path/outside/the/repo make media-archive-backup
+```
+
+The archive tool honors a valid `SSL_CERT_FILE` while keeping TLS certificate
+validation enabled. Never use a yt-dlp or other option that disables
+certificate validation.
 
 ### Private R2 replica
 

--- a/scripts/media_archive/downloader.py
+++ b/scripts/media_archive/downloader.py
@@ -9,6 +9,7 @@ path regardless of host.
 
 from __future__ import annotations
 
+import os
 import re
 import shutil
 from dataclasses import dataclass
@@ -52,6 +53,18 @@ def require_ffmpeg(kind: str) -> None:
             "ffmpeg is required to merge the separate audio and video streams "
             f"yt-dlp downloads for '{kind}' sources. Install ffmpeg and retry."
         )
+
+
+def _configured_ssl_cert_file() -> Path | None:
+    """Return an explicitly configured, readable CA bundle, if one is available."""
+    value = os.environ.get("SSL_CERT_FILE")
+    if not value:
+        return None
+
+    path = Path(value)
+    if path.is_file() and os.access(path, os.R_OK):
+        return path
+    return None
 
 
 def _safe_dirname(kind: str) -> str:
@@ -130,6 +143,9 @@ def download_candidate(
         # Never let the generic extractor treat a direct file link as a
         # webpage to crawl for other links.
         options["force_generic_extractor"] = True
+    if _configured_ssl_cert_file() is not None:
+        # yt-dlp otherwise prefers certifi over the caller's configured bundle.
+        options["compat_opts"] = ["no-certifi"]
 
     try:
         with ydl_factory(options) as ydl:

--- a/tests/test_media_archive_downloader.py
+++ b/tests/test_media_archive_downloader.py
@@ -89,6 +89,53 @@ def test_download_candidate_success_direct(tmp_path, monkeypatch):
     assert (tmp_path / "direct" / "abc123.mp4").exists()
 
 
+def test_download_candidate_uses_default_tls_configuration_without_ssl_cert_file(tmp_path, monkeypatch):
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    captured_options = {}
+
+    def factory(options):
+        captured_options.update(options)
+        return FakeYoutubeDL(options, info={"id": "abc123", "ext": "mp4"})
+
+    downloader.download_candidate("https://example.com/clip.mp4", "direct", tmp_path, ydl_factory=factory)
+
+    assert "compat_opts" not in captured_options
+    assert "nocheckcertificate" not in captured_options
+
+
+def test_download_candidate_honors_readable_ssl_cert_file(tmp_path, monkeypatch):
+    certificate_bundle = tmp_path / "combined-ca.pem"
+    certificate_bundle.write_text("public and enterprise roots", encoding="utf-8")
+    monkeypatch.setenv("SSL_CERT_FILE", str(certificate_bundle))
+    captured_options = {}
+
+    def factory(options):
+        captured_options.update(options)
+        return FakeYoutubeDL(options, info={"id": "abc123", "ext": "mp4"})
+
+    downloader.download_candidate("https://example.com/clip.mp4", "direct", tmp_path, ydl_factory=factory)
+
+    assert captured_options["compat_opts"] == ["no-certifi"]
+    assert "nocheckcertificate" not in captured_options
+
+
+def test_download_candidate_ignores_unreadable_ssl_cert_file(tmp_path, monkeypatch):
+    certificate_bundle = tmp_path / "unreadable-ca.pem"
+    certificate_bundle.write_text("public and enterprise roots", encoding="utf-8")
+    monkeypatch.setenv("SSL_CERT_FILE", str(certificate_bundle))
+    monkeypatch.setattr(downloader.os, "access", lambda path, mode: False)
+    captured_options = {}
+
+    def factory(options):
+        captured_options.update(options)
+        return FakeYoutubeDL(options, info={"id": "abc123", "ext": "mp4"})
+
+    downloader.download_candidate("https://example.com/clip.mp4", "direct", tmp_path, ydl_factory=factory)
+
+    assert "compat_opts" not in captured_options
+    assert "nocheckcertificate" not in captured_options
+
+
 def test_download_candidate_success_youtube_requires_ffmpeg(tmp_path, monkeypatch):
     monkeypatch.setattr(downloader, "ffmpeg_available", lambda: False)
     factory = make_factory(info={"id": "abc123", "ext": "mp4"})


### PR DESCRIPTION
## Summary
- honor a readable `SSL_CERT_FILE` in media archive yt-dlp requests with yt-dlp's `no-certifi` compatibility option
- keep the default certificate behavior for missing or unreadable paths and never disable validation
- document safe combined public and enterprise CA bundles

## Validation
- `uv run pytest --no-cov tests/test_media_archive_downloader.py`
- `make check`