### PR TITLE
Standardize post lead image spacing

### DIFF
--- a/coltrane/static/_posts.scss
+++ b/coltrane/static/_posts.scss
@@ -5,6 +5,12 @@
     margin-bottom: var(--space-body-copy);
     font-weight: var(--font-weight-light);
   }
+  .twelvecol > img:first-child,
+  .twelvecol > picture:first-child,
+  .twelvecol > figure:first-child {
+    display: block;
+    margin-bottom: var(--space-body-copy) !important;
+  }
   strong, b {
     font-weight: var(--font-weight-bold);
   }


### PR DESCRIPTION
## Summary
- apply the shared body-copy gap below every post lead image, picture, or figure
- override legacy inline lead-image margins without changing immutable historical post files

## Validation
- make check