### PR TITLE
Add local dotenv workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,28 @@
+# Local settings are optional. Uncomment and fill only the values you need.
+# .env is ignored by Git. System environment values take precedence.
+
+# Django
+# SECRET_KEY=""
+# DEBUG=""
+# ALLOWED_HOSTS=""
+# STATIC_MANIFEST=""
+# SOURCE_VERSION=""
+
+# Internet Archive Save Page Now
+# SAVEPAGENOW_ACCESS_KEY=""
+# SAVEPAGENOW_SECRET_KEY=""
+
+# Local media archive
+# MEDIA_ARCHIVE_PATH=""
+# SSL_CERT_FILE=""
+
+# Private Cloudflare R2 media replica
+# R2_ACCOUNT_ID=""
+# R2_ACCESS_KEY_ID=""
+# R2_SECRET_ACCESS_KEY=""
+# MEDIA_ARCHIVE_R2_BUCKET=""
+# R2_ENDPOINT_URL=""
+
+# Cloudflare Wrangler
+# CLOUDFLARE_API_TOKEN=""
+# CLOUDFLARE_ACCOUNT_ID=""

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,17 @@
 # palewi.re Makefile
 
-export UV_NO_ENV_FILE = 1
+LOCAL_ENV_FILE := $(CURDIR)/.env
+
+# CI and explicit environment files take precedence over the local template.
+ifeq ($(filter 1 true,$(UV_NO_ENV_FILE)),)
+ifeq ($(UV_ENV_FILE),)
+ifneq ($(wildcard $(LOCAL_ENV_FILE)),)
+export UV_ENV_FILE := $(LOCAL_ENV_FILE)
+else
+export UV_NO_ENV_FILE := 1
+endif
+endif
+endif
 
 HOMEBREW_BIN := $(shell for path in /opt/homebrew/bin /usr/local/bin; do test -x "$$path/brew" && { printf '%s' "$$path"; break; }; done)
 WRANGLER_VERSION := 4.125.0
@@ -16,10 +27,23 @@ LEGACY_WORKER_SAME_ZONE_CANARY_ROUTE := palewi.re/legacy-redirects-canary*
 STATIC_WORKER_DIR := workers/static-site
 STATIC_WORKER_PREVIEW_NAME := palewire-static-site-preview
 
-.PHONY: help bootstrap ci-bootstrap check-tools check-wrangler cloudflare-check install hooks bake check-built-site serve new-post a11y check test lint typecheck django-check fmt archive-clips check-clip-archives preservation-inventory preservation-review media-archive-inventory media-archive-backup media-archive-verify media-archive-r2-sync media-archive-r2-verify media-archive-r2-recover static-worker-test static-worker-validate static-worker-preview-deploy static-worker-deploy static-worker-verify worker-test worker-validate worker-canary-deploy worker-verify-canary worker-delete-canary worker-same-zone-canary-deploy worker-attach-same-zone-canary worker-route-plan worker-attach-routes worker-verify-production worker-detach-routes worker-delete legacy-worker-test legacy-worker-validate legacy-worker-canary-deploy legacy-worker-delete legacy-worker-same-zone-canary-deploy legacy-worker-attach-same-zone-canary legacy-worker-verify-same-zone-canary legacy-worker-delete-same-zone-canary legacy-worker-route-plan legacy-worker-attach-routes legacy-worker-verify-production legacy-worker-detach-routes legacy-worker-delete
+.PHONY: help bootstrap ci-bootstrap check-tools check-wrangler cloudflare-check install hooks dotenv bake check-built-site serve new-post a11y check test lint typecheck django-check fmt archive-clips check-clip-archives preservation-inventory preservation-review media-archive-inventory media-archive-backup media-archive-verify media-archive-r2-sync media-archive-r2-verify media-archive-r2-recover static-worker-test static-worker-validate static-worker-preview-deploy static-worker-deploy static-worker-verify worker-test worker-validate worker-canary-deploy worker-verify-canary worker-delete-canary worker-same-zone-canary-deploy worker-attach-same-zone-canary worker-route-plan worker-attach-routes worker-verify-production worker-detach-routes worker-delete legacy-worker-test legacy-worker-validate legacy-worker-canary-deploy legacy-worker-delete legacy-worker-same-zone-canary-deploy legacy-worker-attach-same-zone-canary legacy-worker-verify-same-zone-canary legacy-worker-delete-same-zone-canary legacy-worker-route-plan legacy-worker-attach-routes legacy-worker-verify-production legacy-worker-detach-routes legacy-worker-delete
 
 
 .PHONY: preservation-inventory report-built-site-quality
+
+# Use uv's parser instead of sourcing a dotenv file in the shell.
+define run-with-dotenv
+if test -n "$${UV_ENV_FILE:-}" && test "$${UV_NO_ENV_FILE:-}" != "1" && test "$${UV_NO_ENV_FILE:-}" != "true"; then \
+	"$$(command -v uv)" run --env-file "$$UV_ENV_FILE" -- $(1); \
+else \
+	$(1); \
+fi
+endef
+
+define run-wrangler
+$(call run-with-dotenv,npm exec -- wrangler $(1))
+endef
 
 
 
@@ -27,6 +51,7 @@ help:
 	@echo "Available targets:"
 	@echo "  bootstrap  Check developer tools, then prepare dependencies and hooks"
 	@echo "  ci-bootstrap  Prepare dependencies for CI"
+	@echo "  dotenv  Create .env from .env.example without overwriting it"
 	@echo "  check-tools  Confirm uv, Node.js, npm, and Wrangler are available"
 	@echo "  check-wrangler  Confirm Wrangler is available"
 	@echo "  cloudflare-check  Show the authenticated Cloudflare account"
@@ -101,11 +126,17 @@ check-wrangler:
 	test "$$version" = "$(WRANGLER_VERSION)" || { echo "Wrangler $(WRANGLER_VERSION) is required. Found $${version:-an unrecognized version}. Install it with: npm install --global wrangler@$(WRANGLER_VERSION)" >&2; exit 1; }
 
 cloudflare-check: check-wrangler
-	@"$$(command -v wrangler)" whoami --json || { echo "Cloudflare authentication failed. Run 'wrangler login' locally or set CLOUDFLARE_API_TOKEN." >&2; exit 1; }
+	@$(call run-with-dotenv,"$$(command -v wrangler)" whoami --json) || { echo "Cloudflare authentication failed. Run 'wrangler login' locally or set CLOUDFLARE_API_TOKEN." >&2; exit 1; }
 
-bootstrap: check-tools install hooks
+bootstrap: check-tools dotenv install hooks
 
 ci-bootstrap: install
+
+dotenv:
+	@if test ! -e "$(LOCAL_ENV_FILE)" && test ! -L "$(LOCAL_ENV_FILE)"; then \
+		cp .env.example "$(LOCAL_ENV_FILE)"; \
+		echo "Created .env from .env.example. Add only the values you need."; \
+	fi
 
 bake:
 	@"$$(command -v uv)" run python manage.py build
@@ -202,12 +233,12 @@ static-worker-validate: bake
 static-worker-preview-deploy: bake
 	@test "$$CONFIRM_STATIC_WORKER_PREVIEW_DEPLOY" = "1" || { echo "Set CONFIRM_STATIC_WORKER_PREVIEW_DEPLOY=1 after make static-worker-validate passes." >&2; exit 1; }
 	npm --prefix "$(STATIC_WORKER_DIR)" ci --ignore-scripts --no-audit --no-fund
-	cd "$(STATIC_WORKER_DIR)" && npm exec -- wrangler deploy --env preview --strict --name "$(STATIC_WORKER_PREVIEW_NAME)"
+	cd "$(STATIC_WORKER_DIR)" && $(call run-wrangler,deploy --env preview --strict --name "$(STATIC_WORKER_PREVIEW_NAME)")
 
 static-worker-deploy: bake
 	@test "$$CONFIRM_STATIC_WORKER_DEPLOY" = "1" || { echo "Set CONFIRM_STATIC_WORKER_DEPLOY=1 after preview verification passes." >&2; exit 1; }
 	npm --prefix "$(STATIC_WORKER_DIR)" ci --ignore-scripts --no-audit --no-fund
-	cd "$(STATIC_WORKER_DIR)" && npm exec -- wrangler deploy --env="" --strict
+	cd "$(STATIC_WORKER_DIR)" && $(call run-wrangler,deploy --env="" --strict)
 
 static-worker-verify:
 	@BASE_URL="$${BASE_URL:?Set BASE_URL to the static site URL.}" scripts/verify-static-site.sh
@@ -223,7 +254,7 @@ worker-validate:
 worker-canary-deploy:
 	@test "$$CONFIRM_WORKER_CANARY_DEPLOY" = "1" || { echo "Set CONFIRM_WORKER_CANARY_DEPLOY=1 after running make worker-validate." >&2; exit 1; }
 	npm --prefix "$(WORKER_DIR)" ci --ignore-scripts --no-audit --no-fund
-	cd "$(WORKER_DIR)" && npm exec -- wrangler deploy --env startup-canary --strict --name "$(WORKER_CANARY_NAME)"
+	cd "$(WORKER_DIR)" && $(call run-wrangler,deploy --env startup-canary --strict --name "$(WORKER_CANARY_NAME)")
 
 worker-verify-canary:
 	@BASE_URL="$${BASE_URL:?Set BASE_URL to the workers.dev or preview URL printed by worker-canary-deploy.}" scripts/verify-worker-endpoints.sh
@@ -231,17 +262,17 @@ worker-verify-canary:
 worker-delete-canary:
 	@test "$$CONFIRM_WORKER_DELETE_CANARY" = "1" || { echo "Set CONFIRM_WORKER_DELETE_CANARY=1 to delete the route-free canary Worker." >&2; exit 1; }
 	npm --prefix "$(WORKER_DIR)" ci --ignore-scripts --no-audit --no-fund
-	cd "$(WORKER_DIR)" && npm exec -- wrangler delete "$(WORKER_CANARY_NAME)" --force
+	cd "$(WORKER_DIR)" && $(call run-wrangler,delete "$(WORKER_CANARY_NAME)" --force)
 
 worker-same-zone-canary-deploy:
 	@test "$$CONFIRM_WORKER_SAME_ZONE_CANARY_DEPLOY" = "1" || { echo "Set CONFIRM_WORKER_SAME_ZONE_CANARY_DEPLOY=1 after make worker-validate passes." >&2; exit 1; }
 	npm --prefix "$(WORKER_DIR)" ci --ignore-scripts --no-audit --no-fund
-	cd "$(WORKER_DIR)" && npm exec -- wrangler deploy --env same-zone-canary --strict
+	cd "$(WORKER_DIR)" && $(call run-wrangler,deploy --env same-zone-canary --strict)
 
 worker-attach-same-zone-canary:
 	@test "$$CONFIRM_WORKER_ATTACH_SAME_ZONE_CANARY" = "1" || { echo "Set CONFIRM_WORKER_ATTACH_SAME_ZONE_CANARY=1 after the route-free same-zone canary deploy passes." >&2; exit 1; }
 	npm --prefix "$(WORKER_DIR)" ci --ignore-scripts --no-audit --no-fund
-	cd "$(WORKER_DIR)" && npm exec -- wrangler deploy --env same-zone-canary --strict --route "$(WORKER_SAME_ZONE_CANARY_ROUTE)"
+	cd "$(WORKER_DIR)" && $(call run-wrangler,deploy --env same-zone-canary --strict --route "$(WORKER_SAME_ZONE_CANARY_ROUTE)")
 
 worker-verify-same-zone-canary:
 	@BASE_URL="$${BASE_URL:-https://palewi.re}" scripts/verify-worker-same-zone-canary.sh
@@ -249,7 +280,7 @@ worker-verify-same-zone-canary:
 worker-delete-same-zone-canary:
 	@test "$$CONFIRM_WORKER_DELETE_SAME_ZONE_CANARY" = "1" || { echo "Set CONFIRM_WORKER_DELETE_SAME_ZONE_CANARY=1 to delete the same-zone canary and detach its route." >&2; exit 1; }
 	npm --prefix "$(WORKER_DIR)" ci --ignore-scripts --no-audit --no-fund
-	cd "$(WORKER_DIR)" && npm exec -- wrangler delete --env same-zone-canary --force
+	cd "$(WORKER_DIR)" && $(call run-wrangler,delete --env same-zone-canary --force)
 
 worker-route-plan:
 	@printf '%s\n' "$(WORKER_ROUTES)"
@@ -257,7 +288,7 @@ worker-route-plan:
 worker-attach-routes:
 	@test "$$CONFIRM_WORKER_ATTACH_ROUTES" = "1" || { echo "Set CONFIRM_WORKER_ATTACH_ROUTES=1 only after same-zone canary verification and cleanup pass." >&2; exit 1; }
 	npm --prefix "$(WORKER_DIR)" ci --ignore-scripts --no-audit --no-fund
-	cd "$(WORKER_DIR)" && npm exec -- wrangler deploy --env="" --strict $(WORKER_ROUTES)
+	cd "$(WORKER_DIR)" && $(call run-wrangler,deploy --env="" --strict $(WORKER_ROUTES))
 
 worker-verify-production:
 	@scripts/verify-worker-endpoints.sh
@@ -265,12 +296,12 @@ worker-verify-production:
 worker-detach-routes:
 	@test "$$CONFIRM_WORKER_DETACH_ROUTES" = "1" || { echo "Set CONFIRM_WORKER_DETACH_ROUTES=1 to delete the Worker and detach its routes." >&2; exit 1; }
 	npm --prefix "$(WORKER_DIR)" ci --ignore-scripts --no-audit --no-fund
-	cd "$(WORKER_DIR)" && npm exec -- wrangler delete --env="" --force
+	cd "$(WORKER_DIR)" && $(call run-wrangler,delete --env="" --force)
 
 worker-delete:
 	@test "$$CONFIRM_WORKER_DELETE" = "1" || { echo "Set CONFIRM_WORKER_DELETE=1 to delete the Worker and any attached routes." >&2; exit 1; }
 	npm --prefix "$(WORKER_DIR)" ci --ignore-scripts --no-audit --no-fund
-	cd "$(WORKER_DIR)" && npm exec -- wrangler delete --env="" --force
+	cd "$(WORKER_DIR)" && $(call run-wrangler,delete --env="" --force)
 
 legacy-worker-test:
 	npm --prefix "$(LEGACY_WORKER_DIR)" ci --ignore-scripts --no-audit --no-fund
@@ -283,22 +314,22 @@ legacy-worker-validate:
 legacy-worker-canary-deploy:
 	@test "$$CONFIRM_LEGACY_WORKER_CANARY_DEPLOY" = "1" || { echo "Set CONFIRM_LEGACY_WORKER_CANARY_DEPLOY=1 after make legacy-worker-validate." >&2; exit 1; }
 	npm --prefix "$(LEGACY_WORKER_DIR)" ci --ignore-scripts --no-audit --no-fund
-	cd "$(LEGACY_WORKER_DIR)" && npm exec -- wrangler deploy --env startup-canary --strict --name "$(LEGACY_WORKER_CANARY_NAME)"
+	cd "$(LEGACY_WORKER_DIR)" && $(call run-wrangler,deploy --env startup-canary --strict --name "$(LEGACY_WORKER_CANARY_NAME)")
 
 legacy-worker-delete-canary:
 	@test "$$CONFIRM_LEGACY_WORKER_DELETE_CANARY" = "1" || { echo "Set CONFIRM_LEGACY_WORKER_DELETE_CANARY=1 to delete the route-free canary Worker." >&2; exit 1; }
 	npm --prefix "$(LEGACY_WORKER_DIR)" ci --ignore-scripts --no-audit --no-fund
-	cd "$(LEGACY_WORKER_DIR)" && npm exec -- wrangler delete "$(LEGACY_WORKER_CANARY_NAME)" --force
+	cd "$(LEGACY_WORKER_DIR)" && $(call run-wrangler,delete "$(LEGACY_WORKER_CANARY_NAME)" --force)
 
 legacy-worker-same-zone-canary-deploy:
 	@test "$$CONFIRM_LEGACY_WORKER_SAME_ZONE_CANARY_DEPLOY" = "1" || { echo "Set CONFIRM_LEGACY_WORKER_SAME_ZONE_CANARY_DEPLOY=1 after make legacy-worker-validate passes." >&2; exit 1; }
 	npm --prefix "$(LEGACY_WORKER_DIR)" ci --ignore-scripts --no-audit --no-fund
-	cd "$(LEGACY_WORKER_DIR)" && npm exec -- wrangler deploy --env same-zone-canary --strict
+	cd "$(LEGACY_WORKER_DIR)" && $(call run-wrangler,deploy --env same-zone-canary --strict)
 
 legacy-worker-attach-same-zone-canary:
 	@test "$$CONFIRM_LEGACY_WORKER_ATTACH_SAME_ZONE_CANARY" = "1" || { echo "Set CONFIRM_LEGACY_WORKER_ATTACH_SAME_ZONE_CANARY=1 after the route-free same-zone canary deploy passes." >&2; exit 1; }
 	npm --prefix "$(LEGACY_WORKER_DIR)" ci --ignore-scripts --no-audit --no-fund
-	cd "$(LEGACY_WORKER_DIR)" && npm exec -- wrangler deploy --env same-zone-canary --strict --route "$(LEGACY_WORKER_SAME_ZONE_CANARY_ROUTE)"
+	cd "$(LEGACY_WORKER_DIR)" && $(call run-wrangler,deploy --env same-zone-canary --strict --route "$(LEGACY_WORKER_SAME_ZONE_CANARY_ROUTE)")
 
 legacy-worker-verify-same-zone-canary:
 	@BASE_URL="$${BASE_URL:-https://palewi.re}" scripts/verify-legacy-redirect-canary.sh
@@ -306,7 +337,7 @@ legacy-worker-verify-same-zone-canary:
 legacy-worker-delete-same-zone-canary:
 	@test "$$CONFIRM_LEGACY_WORKER_DELETE_SAME_ZONE_CANARY" = "1" || { echo "Set CONFIRM_LEGACY_WORKER_DELETE_SAME_ZONE_CANARY=1 to delete the same-zone canary and detach its route." >&2; exit 1; }
 	npm --prefix "$(LEGACY_WORKER_DIR)" ci --ignore-scripts --no-audit --no-fund
-	cd "$(LEGACY_WORKER_DIR)" && npm exec -- wrangler delete --env same-zone-canary --force
+	cd "$(LEGACY_WORKER_DIR)" && $(call run-wrangler,delete --env same-zone-canary --force)
 
 legacy-worker-route-plan:
 	@uv run python -c 'from project.redirect_manifest import RULES, cloudflare_route_plan; print(" ".join(f"--route {route}" for route in cloudflare_route_plan(RULES)))'
@@ -314,7 +345,7 @@ legacy-worker-route-plan:
 legacy-worker-attach-routes:
 	@test "$$CONFIRM_LEGACY_WORKER_ATTACH_ROUTES" = "1" || { echo "Set CONFIRM_LEGACY_WORKER_ATTACH_ROUTES=1 only after same-zone canary verification and cleanup pass." >&2; exit 1; }
 	npm --prefix "$(LEGACY_WORKER_DIR)" ci --ignore-scripts --no-audit --no-fund
-	@routes="$$(uv run python -c 'from project.redirect_manifest import RULES, cloudflare_route_plan; print(" ".join(f"--route {route}" for route in cloudflare_route_plan(RULES)))')"; cd "$(LEGACY_WORKER_DIR)" && npm exec -- wrangler deploy --env="" --strict $$routes
+	@routes="$$(uv run python -c 'from project.redirect_manifest import RULES, cloudflare_route_plan; print(" ".join(f"--route {route}" for route in cloudflare_route_plan(RULES)))')"; cd "$(LEGACY_WORKER_DIR)" && $(call run-wrangler,deploy --env="" --strict $$routes)
 
 legacy-worker-verify-production:
 	@scripts/verify-legacy-redirects.sh
@@ -322,9 +353,9 @@ legacy-worker-verify-production:
 legacy-worker-detach-routes:
 	@test "$$CONFIRM_LEGACY_WORKER_DETACH_ROUTES" = "1" || { echo "Set CONFIRM_LEGACY_WORKER_DETACH_ROUTES=1 to delete the Worker and detach its routes." >&2; exit 1; }
 	npm --prefix "$(LEGACY_WORKER_DIR)" ci --ignore-scripts --no-audit --no-fund
-	cd "$(LEGACY_WORKER_DIR)" && npm exec -- wrangler delete --env="" --force
+	cd "$(LEGACY_WORKER_DIR)" && $(call run-wrangler,delete --env="" --force)
 
 legacy-worker-delete:
 	@test "$$CONFIRM_LEGACY_WORKER_DELETE" = "1" || { echo "Set CONFIRM_LEGACY_WORKER_DELETE=1 to delete the Worker and any attached routes." >&2; exit 1; }
 	npm --prefix "$(LEGACY_WORKER_DIR)" ci --ignore-scripts --no-audit --no-fund
-	cd "$(LEGACY_WORKER_DIR)" && npm exec -- wrangler delete --env="" --force
+	cd "$(LEGACY_WORKER_DIR)" && $(call run-wrangler,delete --env="" --force)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ make serve
 `make bootstrap` checks these commands before it installs anything. For its
 commands, it also adds common user installation paths including
 `$HOME/.local/bin`, npm's user directory, Volta, asdf, fnm, and a detected
-Homebrew bin directory. It does not install or authenticate any command.
+Homebrew bin directory. It does not install or authenticate any command. When
+`.env` is missing, it creates an ignored copy from `.env.example`. Uncomment
+and fill only the settings you need. Existing `.env` files, including worktree
+symlinks, are never changed.
 
 ### CSS design tokens
 
@@ -49,20 +52,30 @@ npm install --global wrangler@4.125.0
 Open the URL printed by the server. Linked Git worktrees automatically use
 available local ports, so multiple agents can run the site at the same time.
 
-## Environment variables
+## Local environment
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `SECRET_KEY` | No | Django secret key for local development and checks |
-| `DEBUG` | No | Set `false` to disable debug output |
-| `SAVEPAGENOW_ACCESS_KEY` | No | Internet Archive access key used by `make archive-clips` |
-| `SAVEPAGENOW_SECRET_KEY` | No | Internet Archive secret key used by `make archive-clips` |
-| `MEDIA_ARCHIVE_PATH` | No | Directory outside the repo where `make media-archive-backup`/`verify` store media and the manifest |
-| `SSL_CERT_FILE` | No | Readable PEM CA bundle used by the media archive's verified yt-dlp connections |
-| `R2_ACCOUNT_ID` | No | Cloudflare account ID used only by the manual private R2 media replica |
-| `R2_ACCESS_KEY_ID` | No | Bucket-scoped R2 S3 access key, supplied outside Git |
-| `R2_SECRET_ACCESS_KEY` | No | Bucket-scoped R2 S3 secret, supplied outside Git |
-| `MEDIA_ARCHIVE_R2_BUCKET` | No | Private R2 bucket name; defaults to `palewire-media-archive` |
+`.env.example` lists the optional local settings. `make` passes its ignored
+root `.env` to `uv` commands when it exists. Values already set in your shell
+take precedence. CI sets `UV_NO_ENV_FILE=1`, so it never loads local settings.
+
+| Variable | Description |
+|----------|-------------|
+| `SECRET_KEY` | Django secret key for local development and checks |
+| `DEBUG` | Set `false` to disable debug output |
+| `ALLOWED_HOSTS` | Comma-separated hosts accepted by Django |
+| `STATIC_MANIFEST` | Set `true` to build Django's hashed static manifest |
+| `SOURCE_VERSION` | Commit identifier displayed in the site metadata |
+| `SAVEPAGENOW_ACCESS_KEY` | Internet Archive access key used by `make archive-clips` |
+| `SAVEPAGENOW_SECRET_KEY` | Internet Archive secret key used by `make archive-clips` |
+| `MEDIA_ARCHIVE_PATH` | Directory outside the repo where media and its manifest are stored |
+| `SSL_CERT_FILE` | Readable PEM CA bundle for verified media archive downloads |
+| `R2_ACCOUNT_ID` | Cloudflare account ID used by the manual private R2 media replica |
+| `R2_ACCESS_KEY_ID` | Bucket-scoped R2 S3 access key |
+| `R2_SECRET_ACCESS_KEY` | Bucket-scoped R2 S3 secret |
+| `MEDIA_ARCHIVE_R2_BUCKET` | Private R2 bucket name; defaults to `palewire-media-archive` |
+| `R2_ENDPOINT_URL` | Optional R2 endpoint for jurisdiction-specific storage |
+| `CLOUDFLARE_API_TOKEN` | Wrangler API token for non-interactive local Cloudflare commands |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account ID for explicitly authorized Worker deployments |
 
 ## Quality gate
 
@@ -272,8 +285,9 @@ make cloudflare-check
 ```
 
 For local use, authenticate interactively with `wrangler login`, then run the
-check. In non-interactive environments, set `CLOUDFLARE_API_TOKEN` in the
-environment instead. Do not commit tokens or add them to `.env` files.
+check. In non-interactive local use, set `CLOUDFLARE_API_TOKEN` in the ignored
+`.env` file or your shell. Do not commit tokens. Cloud-agent and CI tokens
+belong in their configured secrets, not a checked-out `.env`.
 
 For a Copilot cloud-agent session, create a **user API token** with only
 **User > User Details > Read** and **User > Memberships > Read**, then save it


### PR DESCRIPTION
## Summary
- add a safe commented `.env.example` for local Django, archive, R2, and Cloudflare settings
- create `.env` from the template during bootstrap only when it is missing
- load local dotenv values through uv and safely pass them to Wrangler commands without sourcing the file

## Validation
- dotenv loading, shell precedence, CI isolation, and nested Worker command checks
- `make lint`
- `make typecheck`
- `make django-check`
- `make test` (338 passed, 2 skipped)
- `make bake`

Full `make check` is blocked only by the existing unrelated `on-assignment` preservation gap for `https://www.youtube.com/watch?v=me0DlYHkJKE&t=28s`; no content or baseline changes were made.