### PR TITLE
Add browser-framed lead art screenshot skill

### DIFF
--- a/.github/skills/lead-art-screenshot/SKILL.md
+++ b/.github/skills/lead-art-screenshot/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: lead-art-screenshot
+description: Create consistent browser-framed lead art from a public URL for the top of a palewi.re blog post. Use whenever the user asks to screenshot a webpage for post artwork, make lead art from a URL, or refresh an existing browser-framed post image.
+---
+
+# Create browser-framed lead art
+
+Turn a public webpage into a consistent 2000x1250 PNG for a blog post. The
+finished image fills the site's 755-pixel desktop post width while remaining
+sharp on high-density screens.
+
+## Inputs
+
+The user must provide a public HTTP or HTTPS URL. An output name is optional.
+
+- If the user supplies a filename or post slug, use it.
+- Otherwise, derive a short kebab-case filename from the page title.
+- Save the finished PNG to `coltrane/static/img/<name>.png`.
+- Keep raw captures in the gitignored `.lead-art/` directory; never commit
+  them.
+
+Do not capture authenticated, private, personalized, or access-controlled
+pages. Do not expose browser profiles, cookies, account names, extensions, or
+other real browser chrome in the image.
+
+## Fixed design
+
+Use these values for every capture:
+
+| Item | Value |
+|---|---:|
+| Finished image | 2000x1250 pixels |
+| Page viewport | 1860x1022 pixels |
+| Browser frame | 1860x1110 pixels |
+| Outer margin | 70 pixels |
+| Device scale | 1 |
+| Format | PNG |
+
+The browser frame is deliberately synthetic. It provides a stable neutral
+frame without leaking details from the user's real browser.
+
+## Capture workflow
+
+1. Run the bundled command from the repository root:
+
+   ```bash
+   uv run python .github/skills/lead-art-screenshot/capture.py "https://example.com/"
+   ```
+
+   To choose the image name:
+
+   ```bash
+   uv run python .github/skills/lead-art-screenshot/capture.py \
+     "https://example.com/" \
+     --output post-slug
+   ```
+
+   The helper uses the pinned Chrome DevTools CLI through `npx`. It keeps a
+   reusable headless Chrome instance across commands and does not open a visible
+   browser window. On first use, `npx` may download the pinned package.
+
+2. Inspect the finished image. Repeat the capture if the page is obscured by an
+   error, loading state, consent panel, modal, or broken asset. Do not produce
+   misleading or incomplete artwork.
+3. Report the final path and include this ready-to-paste post markup:
+
+    ```html
+    <img src="/static/img/<name>.png" alt="<plain description of the visible page>">
+    ```
+
+The helper navigates only to the supplied URL and the bundled local frame. It
+freezes animation, returns to the top of the page, verifies the final dimensions,
+removes the raw capture, and closes its temporary tab.
+
+If the page cannot be captured cleanly, delete the finished image and explain
+what blocked it.

--- a/.github/skills/lead-art-screenshot/capture.py
+++ b/.github/skills/lead-art-screenshot/capture.py
@@ -200,11 +200,11 @@ def main(url: str, output: str | None) -> None:
         browser.prepare_source(page_id)
 
         name = output_name(output, browser.page_title(page_id), source_url)
-        raw_path = WORK_DIR / f"{name}-raw.png"
+        raw_path = WORK_DIR / "source.png"
         final_path = IMAGE_DIR / f"{name}.png"
         browser.screenshot(page_id, raw_path)
 
-        frame_url = f"{FRAME_PATH.as_uri()}?{urlencode({'image': raw_path.as_uri(), 'url': source_url})}"
+        frame_url = f"{FRAME_PATH.as_uri()}?{urlencode({'url': source_url})}"
         browser.navigate(page_id, frame_url)
         browser.emulate(page_id, OUTPUT_VIEWPORT)
         browser.wait_for_frame(page_id)

--- a/.github/skills/lead-art-screenshot/capture.py
+++ b/.github/skills/lead-art-screenshot/capture.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import ipaddress
+import json
+import re
+import shutil
+import struct
+import subprocess
+import unicodedata
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode, urlparse
+
+import click
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FRAME_PATH = Path(__file__).with_name("frame.html")
+WORK_DIR = REPO_ROOT / ".lead-art"
+IMAGE_DIR = REPO_ROOT / "coltrane" / "static" / "img"
+CHROME_DEVTOOLS_VERSION = "1.8.0"
+SOURCE_VIEWPORT = "1860x1022x1"
+OUTPUT_VIEWPORT = "2000x1250x1"
+OUTPUT_SIZE = (2000, 1250)
+
+
+class ChromeDevTools:
+    def __init__(self) -> None:
+        self.command = [
+            "npx",
+            "--yes",
+            "--package",
+            f"chrome-devtools-mcp@{CHROME_DEVTOOLS_VERSION}",
+            "chrome-devtools",
+        ]
+
+    def _run(self, *args: str) -> dict[str, Any]:
+        try:
+            result = subprocess.run(
+                [*self.command, *args, "--output-format=json"],
+                cwd=REPO_ROOT,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            details = exc.stderr.strip() or exc.stdout.strip() or "No details returned."
+            raise click.ClickException(f"Chrome command failed: {details}") from exc
+        try:
+            data: object = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise click.ClickException(f"Chrome returned an invalid response: {result.stdout.strip()}") from exc
+        if not isinstance(data, dict):
+            raise click.ClickException(f"Chrome returned an unexpected response: {data!r}")
+        return data
+
+    def open_page(self) -> int:
+        data = self._run("new_page", "about:blank", "--background", "--timeout", "30000")
+        selected_pages = [page for page in data.get("pages", []) if page.get("selected")]
+        if not selected_pages:
+            raise click.ClickException("Chrome did not report the new page.")
+        return int(selected_pages[-1]["id"])
+
+    def emulate(self, page_id: int, viewport: str) -> None:
+        self._run("emulate", str(page_id), "--viewport", viewport, "--colorScheme", "light")
+
+    def navigate(self, page_id: int, url: str) -> None:
+        self._run(
+            "navigate_page",
+            str(page_id),
+            "--type",
+            "url",
+            "--url",
+            url,
+            "--timeout",
+            "30000",
+        )
+
+    def prepare_source(self, page_id: int) -> None:
+        script = """
+        async () => {
+          await new Promise((resolve) => setTimeout(resolve, 2000));
+          window.scrollTo(0, 0);
+          const style = document.createElement("style");
+          style.textContent = `
+            html { scrollbar-width: none !important; }
+            html::-webkit-scrollbar { display: none !important; }
+            *, *::before, *::after {
+              animation-duration: 0s !important;
+              animation-delay: 0s !important;
+              transition-duration: 0s !important;
+            }
+          `;
+          document.head.appendChild(style);
+          return document.title;
+        }
+        """
+        self._run("evaluate_script", script, "--pageId", str(page_id), "--waitForStableDom", "false")
+
+    def page_title(self, page_id: int) -> str:
+        data = self._run("list_pages")
+        for page in data.get("pages", []):
+            if int(page["id"]) == page_id:
+                return str(page.get("title", "")).strip()
+        raise click.ClickException("Chrome lost track of the source page.")
+
+    def wait_for_frame(self, page_id: int) -> None:
+        script = """
+        async () => {
+          for (let attempt = 0; attempt < 50; attempt += 1) {
+            if (document.title === "Ready") return true;
+            if (document.title === "Image failed to load") {
+              throw new Error("The raw screenshot failed to load.");
+            }
+            await new Promise((resolve) => setTimeout(resolve, 100));
+          }
+          throw new Error("The browser frame did not finish loading.");
+        }
+        """
+        self._run("evaluate_script", script, "--pageId", str(page_id), "--waitForStableDom", "false")
+
+    def screenshot(self, page_id: int, destination: Path) -> None:
+        data = self._run("take_screenshot", str(page_id), "--format", "png")
+        images = data.get("images", [])
+        if not images:
+            raise click.ClickException("Chrome did not return a screenshot.")
+        source = Path(str(images[0]["filePath"]))
+        if not source.is_file():
+            raise click.ClickException(f"Chrome screenshot is missing: {source}")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, destination)
+
+    def close_page(self, page_id: int) -> None:
+        self._run("close_page", str(page_id))
+
+
+def validate_url(value: str) -> str:
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise click.BadParameter("Use a complete public HTTP or HTTPS URL.", param_hint="URL")
+    if parsed.username or parsed.password:
+        raise click.BadParameter("The URL must not contain credentials.", param_hint="URL")
+
+    hostname = parsed.hostname.lower()
+    if hostname == "localhost" or hostname.endswith(".local"):
+        raise click.BadParameter("The URL must be public.", param_hint="URL")
+
+    try:
+        address = ipaddress.ip_address(hostname)
+    except ValueError:
+        pass
+    else:
+        if not address.is_global:
+            raise click.BadParameter("The URL must use a public IP address.", param_hint="URL")
+
+    return value
+
+
+def slugify(value: str) -> str:
+    ascii_value = unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode()
+    return re.sub(r"[^a-z0-9]+", "-", ascii_value.lower()).strip("-")[:80]
+
+
+def output_name(value: str | None, title: str, source_url: str) -> str:
+    if value:
+        candidate = Path(value)
+        if candidate.parent != Path(".") or candidate.suffix not in {"", ".png"}:
+            raise click.BadParameter("Use a filename or slug, not a path.", param_hint="--output")
+        name = slugify(candidate.stem)
+    else:
+        parsed = urlparse(source_url)
+        fallback = f"{parsed.hostname or ''}-{parsed.path.strip('/').replace('/', '-')}"
+        name = slugify(title) or slugify(fallback)
+
+    if not name:
+        raise click.ClickException("Could not derive an output filename. Pass --output.")
+    return name
+
+
+def png_size(path: Path) -> tuple[int, int]:
+    with path.open("rb") as image:
+        header = image.read(24)
+    if len(header) != 24 or header[:8] != b"\x89PNG\r\n\x1a\n" or header[12:16] != b"IHDR":
+        raise click.ClickException(f"Chrome did not create a valid PNG: {path}")
+    return struct.unpack(">II", header[16:24])
+
+
+@click.command()
+@click.argument("url")
+@click.option("--output", help="Output filename or post slug. Defaults to the page title.")
+def main(url: str, output: str | None) -> None:
+    """Create browser-framed lead art from URL."""
+    source_url = validate_url(url)
+    browser = ChromeDevTools()
+    page_id = browser.open_page()
+    raw_path: Path | None = None
+
+    try:
+        browser.emulate(page_id, SOURCE_VIEWPORT)
+        browser.navigate(page_id, source_url)
+        browser.prepare_source(page_id)
+
+        name = output_name(output, browser.page_title(page_id), source_url)
+        raw_path = WORK_DIR / f"{name}-raw.png"
+        final_path = IMAGE_DIR / f"{name}.png"
+        browser.screenshot(page_id, raw_path)
+
+        frame_url = f"{FRAME_PATH.as_uri()}?{urlencode({'image': raw_path.as_uri(), 'url': source_url})}"
+        browser.navigate(page_id, frame_url)
+        browser.emulate(page_id, OUTPUT_VIEWPORT)
+        browser.wait_for_frame(page_id)
+        browser.screenshot(page_id, final_path)
+
+        actual_size = png_size(final_path)
+        if actual_size != OUTPUT_SIZE:
+            final_path.unlink(missing_ok=True)
+            raise click.ClickException(
+                f"Expected a 2000x1250 PNG, but Chrome created {actual_size[0]}x{actual_size[1]}."
+            )
+
+        click.echo(final_path.relative_to(REPO_ROOT))
+    finally:
+        if raw_path is not None:
+            raw_path.unlink(missing_ok=True)
+        browser.close_page(page_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/lead-art-screenshot/frame.html
+++ b/.github/skills/lead-art-screenshot/frame.html
@@ -134,7 +134,6 @@
     <p class="status" id="status" role="status">Loading</p>
     <script>
       const params = new URLSearchParams(window.location.search);
-      const image = params.get("image");
       const sourceUrl = params.get("url");
       const address = document.querySelector("#address");
       const viewport = document.querySelector("#viewport");
@@ -147,23 +146,18 @@
         address.textContent = sourceUrl || "";
       }
 
-      if (image) {
-        const capture = document.createElement("img");
-        capture.alt = "";
-        capture.addEventListener("load", () => {
-          status.textContent = "Ready";
-          document.title = "Ready";
-        });
-        capture.addEventListener("error", () => {
-          status.textContent = "Image failed to load";
-          document.title = "Image failed to load";
-        });
-        capture.src = image;
-        viewport.appendChild(capture);
-      } else {
-        status.textContent = "Missing image";
-        document.title = "Missing image";
-      }
+      const capture = document.createElement("img");
+      capture.alt = "";
+      capture.addEventListener("load", () => {
+        status.textContent = "Ready";
+        document.title = "Ready";
+      });
+      capture.addEventListener("error", () => {
+        status.textContent = "Image failed to load";
+        document.title = "Image failed to load";
+      });
+      capture.src = "../../../.lead-art/source.png";
+      viewport.appendChild(capture);
     </script>
   </body>
 </html>

--- a/.github/skills/lead-art-screenshot/frame.html
+++ b/.github/skills/lead-art-screenshot/frame.html
@@ -1,0 +1,169 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Lead art frame</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        width: 2000px;
+        height: 1250px;
+        margin: 0;
+        overflow: hidden;
+      }
+
+      body {
+        display: grid;
+        place-items: center;
+        background: #f1f2f4;
+      }
+
+      .browser {
+        width: 1860px;
+        height: 1110px;
+        overflow: hidden;
+        border: 1px solid #c9cbd0;
+        border-radius: 24px;
+        background: #fff;
+        box-shadow:
+          0 32px 80px rgb(31 35 41 / 18%),
+          0 8px 24px rgb(31 35 41 / 10%);
+      }
+
+      .toolbar {
+        display: grid;
+        grid-template-columns: 132px 1fr 132px;
+        align-items: center;
+        height: 88px;
+        padding: 0 28px;
+        border-bottom: 1px solid #d7d9dd;
+        background: #e9eaed;
+      }
+
+      .controls {
+        display: flex;
+        gap: 16px;
+      }
+
+      .control {
+        width: 20px;
+        height: 20px;
+        border: 1px solid rgb(0 0 0 / 12%);
+        border-radius: 50%;
+      }
+
+      .control.close {
+        background: #ff5f57;
+      }
+
+      .control.minimize {
+        background: #febc2e;
+      }
+
+      .control.maximize {
+        background: #28c840;
+      }
+
+      .address {
+        min-width: 0;
+        height: 52px;
+        padding: 0 24px;
+        overflow: hidden;
+        border: 1px solid #d2d4d8;
+        border-radius: 13px;
+        background: #f8f8f9;
+        color: #50545b;
+        font-size: 22px;
+        line-height: 50px;
+        text-align: center;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .viewport,
+      .viewport img {
+        width: 1860px;
+        height: 1022px;
+      }
+
+      .viewport {
+        object-fit: cover;
+        object-position: top left;
+        background: #fff;
+      }
+
+      .viewport img {
+        display: block;
+        object-fit: cover;
+        object-position: top left;
+      }
+
+      .status {
+        position: fixed;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+        clip-path: inset(50%);
+        white-space: nowrap;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="browser" aria-label="Browser-framed webpage screenshot">
+      <header class="toolbar">
+        <div class="controls" aria-hidden="true">
+          <span class="control close"></span>
+          <span class="control minimize"></span>
+          <span class="control maximize"></span>
+        </div>
+        <div class="address" id="address"></div>
+        <div></div>
+      </header>
+      <div class="viewport" id="viewport"></div>
+    </main>
+    <p class="status" id="status" role="status">Loading</p>
+    <script>
+      const params = new URLSearchParams(window.location.search);
+      const image = params.get("image");
+      const sourceUrl = params.get("url");
+      const address = document.querySelector("#address");
+      const viewport = document.querySelector("#viewport");
+      const status = document.querySelector("#status");
+
+      try {
+        const parsedUrl = new URL(sourceUrl);
+        address.textContent = parsedUrl.hostname + parsedUrl.pathname;
+      } catch {
+        address.textContent = sourceUrl || "";
+      }
+
+      if (image) {
+        const capture = document.createElement("img");
+        capture.alt = "";
+        capture.addEventListener("load", () => {
+          status.textContent = "Ready";
+          document.title = "Ready";
+        });
+        capture.addEventListener("error", () => {
+          status.textContent = "Image failed to load";
+          document.title = "Image failed to load";
+        });
+        capture.src = image;
+        viewport.appendChild(capture);
+      } else {
+        status.textContent = "Missing image";
+        document.title = "Missing image";
+      }
+    </script>
+  </body>
+</html>

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ node_modules/
 
 # Local agent state
 .goals/
+.lead-art/
+.impeccable/
 *.cpuprofile
 
 # Collected static

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,9 @@ When running, auditing, or troubleshooting a local audio/video backup of the
 media referenced by `coltrane/content/talks.yaml` or blog posts, load the
 `archive-media` skill (`.github/skills/archive-media/SKILL.md`) first.
 
+When creating browser-framed lead art for a post from a public URL, load the
+`lead-art-screenshot` skill (`.github/skills/lead-art-screenshot/SKILL.md`).
+
 ## Before finishing
 
 Run `make check`. This is the same set of lint, type, Django, and test checks


### PR DESCRIPTION
## Summary
- add a reusable `lead-art-screenshot` project skill for public URLs
- generate consistent 2000×1250 PNG artwork with a synthetic browser frame
- include a one-command Click helper that uses pinned headless Chrome tooling
- keep temporary capture and agent cache files out of git

## Usage
```bash
uv run python .github/skills/lead-art-screenshot/capture.py "https://example.com/" --output post-slug
```

## Tests
- `UV_NO_ENV_FILE=1 make check`
- end-to-end capture against `https://example.com/`