### PR TITLE
Allow Datawrapper chart embeds

### DIFF
--- a/scripts/verify-static-site.sh
+++ b/scripts/verify-static-site.sh
@@ -33,7 +33,7 @@ request() {
 
 expect_security_headers() {
   grep -Fiq "content-security-policy: " "$headers_file"
-  grep -Fiq "frame-src 'self' https://docs.google.com https://player.vimeo.com http://s3-us-west-1.amazonaws.com https://w.soundcloud.com" "$headers_file"
+  grep -Fiq "frame-src 'self' https://datawrapper.dwcdn.net https://docs.google.com https://player.vimeo.com http://s3-us-west-1.amazonaws.com https://w.soundcloud.com" "$headers_file"
   grep -Fiq "permissions-policy: camera=(), geolocation=(), microphone=(), payment=(), usb=()" "$headers_file"
 }
 
@@ -55,6 +55,8 @@ request "/posts/2017/09/09/what-i-learned/" 200
 grep -Fq 'src="https://player.vimeo.com/' "$body_file"
 request "/posts/2025/05/21/ire-podcast-transcript/" 200
 grep -Fq 'src="https://w.soundcloud.com/' "$body_file"
+request "/posts/2026/01/27/how-journalism-lost-its-culture-of-sharing/" 200
+grep -Fq 'src="https://datawrapper.dwcdn.net/6T1Lq/4/"' "$body_file"
 request "/posts/2010/03/10/google-charts-takes-tufte-challenge/" 200
 grep -Fq 'src="http://chart.apis.google.com/' "$body_file"
 request "/posts/2008/07/06/permalinks-low-rent-data-viz-and-other-stupid-caspio-tricks/" 200

--- a/workers/static-site/src/index.ts
+++ b/workers/static-site/src/index.ts
@@ -15,7 +15,7 @@ const CONTENT_SECURITY_POLICY = [
   "default-src 'self'",
   "form-action 'self'",
   "frame-ancestors 'none'",
-  "frame-src 'self' https://docs.google.com https://player.vimeo.com http://s3-us-west-1.amazonaws.com https://w.soundcloud.com",
+  "frame-src 'self' https://datawrapper.dwcdn.net https://docs.google.com https://player.vimeo.com http://s3-us-west-1.amazonaws.com https://w.soundcloud.com",
   "img-src 'self' https://palewi.re http://chart.apis.google.com http://www.palewire.com https://palewire.s3.amazonaws.com",
   "font-src 'self' https://fonts.gstatic.com",
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",

--- a/workers/static-site/tests/index.test.ts
+++ b/workers/static-site/tests/index.test.ts
@@ -85,7 +85,7 @@ describe("static site Worker", () => {
 
     expect(await response.text()).toBe("https://palewi.re/who-is-ben-welsh/");
     expect(response.headers.get("content-security-policy")).toBe(
-      "base-uri 'self'; default-src 'self'; form-action 'self'; frame-ancestors 'none'; frame-src 'self' https://docs.google.com https://player.vimeo.com http://s3-us-west-1.amazonaws.com https://w.soundcloud.com; img-src 'self' https://palewi.re http://chart.apis.google.com http://www.palewire.com https://palewire.s3.amazonaws.com; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self'; media-src 'self' https://palewire.s3.amazonaws.com; object-src 'none'",
+      "base-uri 'self'; default-src 'self'; form-action 'self'; frame-ancestors 'none'; frame-src 'self' https://datawrapper.dwcdn.net https://docs.google.com https://player.vimeo.com http://s3-us-west-1.amazonaws.com https://w.soundcloud.com; img-src 'self' https://palewi.re http://chart.apis.google.com http://www.palewire.com https://palewire.s3.amazonaws.com; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self'; media-src 'self' https://palewire.s3.amazonaws.com; object-src 'none'",
     );
     expect(response.headers.get("permissions-policy")).toBe(
       "camera=(), geolocation=(), microphone=(), payment=(), usb=()",


### PR DESCRIPTION
## Summary
- allow Datawrapper charts from `datawrapper.dwcdn.net`
- cover the policy and deployment probe for the journalism-sharing post

## Validation
- `make static-worker-test static-worker-validate worker-test worker-validate legacy-worker-test legacy-worker-validate`
- `make check` *(blocked by unrelated preservation-review baseline drift)*