### PR TITLE
Fix preservation checks with local env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ preservation-review:
 	@set -e; \
 	inventory="$$(mktemp)"; \
 	trap 'rm -f "$$inventory"' EXIT; \
-	"$$(command -v uv)" run python -m scripts.preservation_inventory --json-output "$$inventory" --max-gaps 0; \
+	env -u MEDIA_ARCHIVE_PATH UV_NO_ENV_FILE=1 "$$(command -v uv)" run python -m scripts.preservation_inventory --json-output "$$inventory" --max-gaps 0; \
 	"$$(command -v uv)" run python -m scripts.preservation_review --inventory "$$inventory"
 
 media-archive-inventory:

--- a/tests/test_media_archive_cli.py
+++ b/tests/test_media_archive_cli.py
@@ -88,6 +88,7 @@ def test_backup_requires_archive_root(tmp_path):
     result = runner.invoke(
         cli_module.cli,
         ["backup", "--talks-path", str(talks_path), "--posts-path", str(posts_path)],
+        env={"MEDIA_ARCHIVE_PATH": ""},
     )
 
     assert result.exit_code == 1
@@ -460,7 +461,7 @@ def test_verify_reports_mismatched_checksum(tmp_path):
 
 def test_verify_requires_archive_root():
     runner = CliRunner()
-    result = runner.invoke(cli_module.cli, ["verify"])
+    result = runner.invoke(cli_module.cli, ["verify"], env={"MEDIA_ARCHIVE_PATH": ""})
     assert result.exit_code == 1
     assert "An archive root is required" in result.output
 

--- a/tests/test_preservation_inventory.py
+++ b/tests/test_preservation_inventory.py
@@ -70,7 +70,7 @@ def report_args(tmp_path: Path, *extra_args: str) -> list[str]:
 
 def test_report_marks_media_untracked_without_archive_root(tmp_path):
     runner = CliRunner()
-    result = runner.invoke(cli, report_args(tmp_path))
+    result = runner.invoke(cli, report_args(tmp_path), env={"MEDIA_ARCHIVE_PATH": ""})
 
     assert result.exit_code == 0, result.output
     assert "Preservation inventory: 2 source URL(s), 2 current, 2 gap(s)." in result.output


### PR DESCRIPTION
## Summary

- keep the CI-safe preservation review independent of a developer's local media archive
- prevent archive paths from a symlinked `.env` from changing baseline results
- isolate tests that require a missing archive root from developer environment variables

## Validation

- `make check`