### PR TITLE
Tighten spacing between post list items

### DIFF
--- a/coltrane/content/posts/2022-10-14--studs-terkel-archive-podcast-season-two.md
+++ b/coltrane/content/posts/2022-10-14--studs-terkel-archive-podcast-season-two.md
@@ -1,0 +1,63 @@
+---
+title: The Studs Terkel Archive Podcast returns for season two
+slug: studs-terkel-archive-podcast-season-two
+published_at: '2022-10-14T05:52:36-07:00'
+repr_image: https://palewi.re/static/img/studs-terkel-radio-archive-podcast.png
+---
+<img src="/static/img/studs-terkel-radio-archive-podcast.png" alt="The Studs Terkel Radio Archive homepage, featuring a photograph of Terkel conducting an interview.">
+
+<p>The Studs Terkel Archive Podcast is back for season two.</p>
+
+<p>Each Friday it will deliver a curated interview from the legendary Chicago journalist's long-running radio broadcast.</p>
+
+<p>Subscribe at <a href="https://studs.show/">studs.show</a>.</p>
+
+<p>Our new season opens with a twin billing:</p>
+
+<ul>
+  <li>A brief 1964 interview with Martin Luther King Jr. in Mahalia Jackson's home</li>
+  <li>An in-depth talk with parents and students in Gage Park, which became a flashpoint of Chicago's desegregation struggle after a march led by King</li>
+</ul>
+
+<p>The pairing shows the two sides of Studs.</p>
+
+<p>He's rightfully famous for filling his books with the poetry, and profundity, uncovered in interviews with common people.</p>
+
+<p>His radio show, which ran for decades on Chicago's classical and folk music station, showcases something else.</p>
+
+<p>Studs was also an engaging interviewer of the leading lights of his time, eliciting fascinating discussions with well-known activists, artists and actors.</p>
+
+<p>I've dragged this season through the garden, loading it up with interviews I know you'll want to hear. That includes:</p>
+
+<ul>
+  <li>Louis Armstrong</li>
+  <li>Marlon Brando</li>
+  <li>Toni Morrison</li>
+  <li>Susan Sontag</li>
+  <li>Timothy Leary</li>
+</ul>
+
+<p>And many more!</p>
+
+<p>You can tune in using your favorite podcatcher at <a href="https://studs.show/">studs.show</a>. We support:</p>
+
+<ul>
+  <li><a href="https://studs.show/feed.xml">RSS</a></li>
+  <li><a href="https://podcasts.apple.com/us/podcast/studs-terkel-archive-podcast/id1547088563">Apple Podcasts</a></li>
+  <li><a href="https://podcasts.google.com/feed/aHR0cHM6Ly9zdHVkcy5zaG93L2ZlZWQueG1s?ep=14">Google Podcasts</a></li>
+  <li><a href="https://www.stitcher.com/show/studs-terkel-archive-podcast">Stitcher</a></li>
+</ul>
+
+<p>All episodes are drawn from the excellent archival work done at WFMT.</p>
+
+<p>If you want to learn more about Studs, <a href="https://studsterkel.wfmt.com/">this is a great place to start</a>.</p>
+
+<p>With audio interviewing again en vogue, it's a good time to revisit a master of the form.</p>
+
+<p>Whenever I listen, I'm struck by Studs' simplicity.</p>
+
+<p>He never tries to sound smart, to oversimplify or to shoehorn people into the sociological pigeonholes that often pass as analysis.</p>
+
+<p>Without resorting to formulaic questions and other gimmicks, he always manages to make the show about his guests, their ideas, their origins, their work and their passions.</p>
+
+<p>But don't take my word for it. Hear it for yourself. Subscribe today at <a href="https://studs.show/">studs.show</a>!</p>

--- a/coltrane/static/styles.css
+++ b/coltrane/static/styles.css
@@ -729,8 +729,12 @@ figure {
   font-weight: bold;
   margin: 1.5em 0 0.3em 0;
 }
-#detailbody ol, #detailbody ul, #detailbody li {
+#detailbody ol, #detailbody ul {
   margin-bottom: var(--space-body-copy);
+  margin-left: 0.8em;
+}
+#detailbody li {
+  margin-bottom: var(--space-list-item-block);
   margin-left: 0.8em;
 }
 #detailbody ul li {


### PR DESCRIPTION
## Summary

- reduce spacing between list items in post bodies
- preserve the larger paragraph-sized gap after each list

## Checks

- `make check`
- checked the season-two post at desktop and mobile widths