### PR TITLE
Fix redirect canary deployment verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,10 +482,10 @@ instead of proxying to an origin. This Worker does not fetch a same-zone origin,
 that redirect matches never create a subrequest.
 
 The production smoke workflow runs the same verifier after deployment. It
-checks every exact rule, two representative cases for
-each dynamic rule, the exact `Location`, the Worker marker, and adjacent
-non-legacy paths. It uses a 20-second curl timeout and waits 15 seconds between
-up to four marker checks for route propagation.
+checks every exact rule, two representative cases for each dynamic rule, the
+exact `Location`, the Worker marker, and adjacent non-legacy paths. Canary and
+production verification use a 20-second curl timeout and wait 15 seconds
+between up to four marker checks for route propagation.
 
 Use a dedicated Cloudflare token for deployment, restricted to the owning
 account and `palewi.re` zone. It needs only **Account > Workers Scripts >

--- a/scripts/verify-legacy-redirect-canary.sh
+++ b/scripts/verify-legacy-redirect-canary.sh
@@ -4,14 +4,20 @@ set -eu
 
 base_url=${BASE_URL:-https://palewi.re}
 timeout=${CURL_MAX_TIME:-20}
+attempts=${WORKER_MARKER_ATTEMPTS:-4}
+wait_seconds=${WORKER_MARKER_WAIT_SECONDS:-15}
 
 case "$base_url" in
   http://*|https://*) ;;
   *) echo "BASE_URL must start with http:// or https://." >&2; exit 1 ;;
 esac
-case "$timeout" in
-  *[!0-9]*|"") echo "CURL_MAX_TIME must be a positive integer." >&2; exit 1 ;;
+case "$timeout:$attempts:$wait_seconds" in
+  *[!0-9:]*|*::*) echo "CURL_MAX_TIME, WORKER_MARKER_ATTEMPTS, and WORKER_MARKER_WAIT_SECONDS must be integers." >&2; exit 1 ;;
 esac
+if [ "$timeout" -eq 0 ] || [ "$attempts" -eq 0 ]; then
+  echo "CURL_MAX_TIME and WORKER_MARKER_ATTEMPTS must be positive." >&2
+  exit 1
+fi
 
 headers_file=$(mktemp "${TMPDIR:-/tmp}/palewire-legacy-canary-headers.XXXXXX")
 cleanup() {
@@ -19,13 +25,22 @@ cleanup() {
 }
 trap cleanup EXIT HUP INT TERM
 
-status=$(curl --silent --show-error --max-time "$timeout" --dump-header "$headers_file" --output /dev/null --write-out '%{http_code}' "${base_url%/}/legacy-redirects-canary")
-headers=$(tr '[:upper:]' '[:lower:]' < "$headers_file" | tr -d '\r')
-
-if [ "$status" != "204" ] || ! printf '%s\n' "$headers" | grep -Fqx "x-palewire-legacy-redirect: cloudflare-worker-v1"; then
-  echo "same-zone legacy redirect canary did not return its marker." >&2
-  sed -n '1,12p' "$headers_file" >&2
-  exit 1
-fi
+attempt=1
+while :; do
+  status=$(curl --silent --show-error --max-time "$timeout" --dump-header "$headers_file" --output /dev/null --write-out '%{http_code}' "${base_url%/}/legacy-redirects-canary")
+  headers=$(tr '[:upper:]' '[:lower:]' < "$headers_file" | tr -d '\r')
+  if [ "$status" = "204" ] &&
+    printf '%s\n' "$headers" | grep -Fqx "x-palewire-legacy-redirect: cloudflare-worker-v1"; then
+    break
+  fi
+  if [ "$attempt" -ge "$attempts" ]; then
+    echo "same-zone legacy redirect canary did not return its marker." >&2
+    sed -n '1,12p' "$headers_file" >&2
+    exit 1
+  fi
+  echo "same-zone legacy redirect canary not yet visible; waiting $wait_seconds seconds before retry $((attempt + 1)) of $attempts." >&2
+  sleep "$wait_seconds"
+  attempt=$((attempt + 1))
+done
 
 echo "same-zone legacy redirect canary: HTTP 204"

--- a/scripts/verify-legacy-redirects.sh
+++ b/scripts/verify-legacy-redirects.sh
@@ -58,7 +58,10 @@ verify_all() {
 verify_untouched() {
   for expected in \
     "/who-is-ben-welsh/:200" \
-    "/work/:200" \
+    "/apps/:200" \
+    "/clips/:200" \
+    "/code/:200" \
+    "/guides/:200" \
     "/docs/:200" \
     "/posts/:200"
   do

--- a/scripts/verify-static-site.sh
+++ b/scripts/verify-static-site.sh
@@ -44,7 +44,10 @@ request "/who-is-ben-welsh/" 200
 grep -Fq '<link rel="canonical" href="https://palewi.re/who-is-ben-welsh/"' "$body_file"
 expect_security_headers
 request "/posts/" 200
-request "/work/" 200
+request "/clips/" 200
+request "/apps/" 200
+request "/code/" 200
+request "/guides/" 200
 request "/talks/" 200
 request "/docs/" 200
 request "/posts/2012/02/25/nicar-2012-things-i-said/" 200

--- a/tests/test_verify_scripts.py
+++ b/tests/test_verify_scripts.py
@@ -1,0 +1,74 @@
+"""Tests for production verification shell scripts."""
+
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _write_executable(path: Path, contents: str) -> None:
+    path.write_text(contents, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_legacy_canary_retries_during_route_propagation(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    count_path = tmp_path / "curl-count"
+    _write_executable(
+        bin_dir / "curl",
+        """#!/bin/sh
+headers_file=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dump-header) headers_file=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+count=0
+test ! -f "$FAKE_CURL_COUNT" || count=$(cat "$FAKE_CURL_COUNT")
+count=$((count + 1))
+printf '%s' "$count" > "$FAKE_CURL_COUNT"
+if [ "$count" -eq 1 ]; then
+  printf 'HTTP/2 404\\r\\n\\r\\n' > "$headers_file"
+  printf '404'
+else
+  printf 'HTTP/2 204\\r\\nx-palewire-legacy-redirect: cloudflare-worker-v1\\r\\n\\r\\n' > "$headers_file"
+  printf '204'
+fi
+""",
+    )
+    _write_executable(bin_dir / "sleep", "#!/bin/sh\nexit 0\n")
+    env = {
+        **os.environ,
+        "FAKE_CURL_COUNT": str(count_path),
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "WORKER_MARKER_ATTEMPTS": "2",
+        "WORKER_MARKER_WAIT_SECONDS": "0",
+    }
+
+    result = subprocess.run(
+        ["sh", str(ROOT / "scripts" / "verify-legacy-redirect-canary.sh")],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert count_path.read_text(encoding="utf-8") == "2"
+    assert "waiting 0 seconds before retry 2 of 2" in result.stderr
+    assert "same-zone legacy redirect canary: HTTP 204" in result.stdout
+
+
+def test_production_verifiers_cover_new_navigation() -> None:
+    static_verifier = (ROOT / "scripts" / "verify-static-site.sh").read_text(encoding="utf-8")
+    redirect_verifier = (ROOT / "scripts" / "verify-legacy-redirects.sh").read_text(encoding="utf-8")
+
+    for path in ("/apps/", "/clips/", "/code/", "/guides/"):
+        assert f'request "{path}" 200' in static_verifier
+        assert f'"{path}:200"' in redirect_verifier
+    assert 'request "/work/"' not in static_verifier
+    assert '"/work/:200"' not in redirect_verifier


### PR DESCRIPTION
## Summary

- retry same-zone canary verification while Cloudflare routes propagate
- update production verifiers for Apps, Clips, Code and Guides
- stop treating the redirected `/work/` path as a static page
- add regression coverage for the observed 404-to-204 canary transition

## Validation

- `uv run pytest tests/test_verify_scripts.py -q --no-cov`
- `make check`
- `make legacy-worker-test`
- `make legacy-worker-validate`