### PR TITLE
Add bots page to sitemap

### DIFF
--- a/coltrane/sitemaps.py
+++ b/coltrane/sitemaps.py
@@ -22,6 +22,7 @@ class StaticSitemap(django_sitemaps.Sitemap):
         "guides": "/guides/",
         "posts": "/posts/",
         "talks": "/talks/",
+        "bots": "/bots/",
     }
     main_sitemaps = []
     for page in pages.keys():

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,6 +1,7 @@
 """Tests for public-facing pages and redirects."""
 
 from unittest.mock import patch
+from xml.etree import ElementTree
 
 import pytest
 from django.templatetags.static import static
@@ -264,3 +265,23 @@ def test_robots_txt_ok(client):
 
 def test_sitemap_index_ok(client):
     assert client.get("/sitemap.xml").status_code == 200
+
+
+def test_static_sitemap_lists_every_public_list_page(client):
+    response = client.get("/sitemap-static.xml")
+
+    assert response.status_code == 200
+    root = ElementTree.fromstring(response.content)
+    namespace = {"sitemap": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    urls = {entry.findtext("sitemap:loc", namespaces=namespace) for entry in root.findall("sitemap:url", namespace)}
+    assert urls == {
+        "http://testserver/who-is-ben-welsh/",
+        "http://testserver/posts/",
+        "http://testserver/clips/",
+        "http://testserver/apps/",
+        "http://testserver/code/",
+        "http://testserver/docs/",
+        "http://testserver/guides/",
+        "http://testserver/talks/",
+        "http://testserver/bots/",
+    }


### PR DESCRIPTION
## Summary
- include the public bots page in the static sitemap
- cover all public list pages with a sitemap test

## Validation
- `make check`