### PR TITLE
Retry static verification during deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,8 @@ The production smoke workflow runs the same verifier after deployment. It
 checks every exact rule, two representative cases for each dynamic rule, the
 exact `Location`, the Worker marker, and adjacent non-legacy paths. Canary and
 production verification use a 20-second curl timeout and wait 15 seconds
-between up to four marker checks for route propagation.
+between bounded retries for route propagation. Static-site verification also
+retries temporary status mismatches while newly deployed assets propagate.
 
 Use a dedicated Cloudflare token for deployment, restricted to the owning
 account and `palewi.re` zone. It needs only **Account > Workers Scripts >

--- a/scripts/verify-static-site.sh
+++ b/scripts/verify-static-site.sh
@@ -4,14 +4,20 @@ set -eu
 
 base_url=${BASE_URL:-https://palewi.re}
 timeout=${CURL_MAX_TIME:-20}
+attempts=${SITE_VERIFY_ATTEMPTS:-5}
+wait_seconds=${SITE_VERIFY_WAIT_SECONDS:-15}
 
 case "$base_url" in
   http://*|https://*) ;;
   *) echo "BASE_URL must start with http:// or https://." >&2; exit 1 ;;
 esac
-case "$timeout" in
-  *[!0-9]*|"") echo "CURL_MAX_TIME must be a positive integer." >&2; exit 1 ;;
+case "$timeout:$attempts:$wait_seconds" in
+  *[!0-9:]*|*::*) echo "CURL_MAX_TIME, SITE_VERIFY_ATTEMPTS, and SITE_VERIFY_WAIT_SECONDS must be integers." >&2; exit 1 ;;
 esac
+if [ "$timeout" -eq 0 ] || [ "$attempts" -eq 0 ]; then
+  echo "CURL_MAX_TIME and SITE_VERIFY_ATTEMPTS must be positive." >&2
+  exit 1
+fi
 
 headers_file=$(mktemp "${TMPDIR:-/tmp}/palewire-static-site-headers.XXXXXX")
 body_file=$(mktemp "${TMPDIR:-/tmp}/palewire-static-site-body.XXXXXX")
@@ -23,12 +29,26 @@ trap cleanup EXIT HUP INT TERM
 request() {
   path=$1
   expected_status=$2
-  curl --silent --show-error --max-time "$timeout" --dump-header "$headers_file" --output "$body_file" "${base_url%/}${path}"
-  status=$(awk '/^HTTP\// { code=$2 } END { print code }' "$headers_file")
-  test "$status" = "$expected_status" || {
-    echo "$path: expected HTTP $expected_status, received $status." >&2
-    exit 1
-  }
+  attempt=1
+  while :; do
+    : > "$headers_file"
+    : > "$body_file"
+    if curl --silent --show-error --max-time "$timeout" --dump-header "$headers_file" --output "$body_file" "${base_url%/}${path}"; then
+      status=$(awk '/^HTTP\// { code=$2 } END { print code }' "$headers_file")
+    else
+      status=000
+    fi
+    if [ "$status" = "$expected_status" ]; then
+      break
+    fi
+    if [ "$attempt" -ge "$attempts" ]; then
+      echo "$path: expected HTTP $expected_status, received $status." >&2
+      exit 1
+    fi
+    echo "$path: received HTTP $status while deployment propagates; waiting $wait_seconds seconds before retry $((attempt + 1)) of $attempts." >&2
+    sleep "$wait_seconds"
+    attempt=$((attempt + 1))
+  done
 }
 
 expect_security_headers() {

--- a/tests/test_verify_scripts.py
+++ b/tests/test_verify_scripts.py
@@ -57,10 +57,83 @@ fi
         check=False,
     )
 
-    assert result.returncode == 0
+    assert result.returncode == 0, result.stderr
     assert count_path.read_text(encoding="utf-8") == "2"
     assert "waiting 0 seconds before retry 2 of 2" in result.stderr
     assert "same-zone legacy redirect canary: HTTP 204" in result.stdout
+
+
+def test_static_site_retries_during_asset_propagation(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    count_path = tmp_path / "curl-count"
+    _write_executable(
+        bin_dir / "curl",
+        """#!/bin/sh
+headers_file=
+body_file=
+url=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dump-header) headers_file=$2; shift 2 ;;
+    --output) body_file=$2; shift 2 ;;
+    *) url=$1; shift ;;
+  esac
+done
+count=0
+test ! -f "$FAKE_CURL_COUNT" || count=$(cat "$FAKE_CURL_COUNT")
+count=$((count + 1))
+printf '%s' "$count" > "$FAKE_CURL_COUNT"
+status=200
+location=
+test "$count" -ne 1 || status=404
+case "$url" in
+  */this-page-does-not-exist/) status=404 ;;
+  https://palewi.re/) status=302; location=/who-is-ben-welsh/ ;;
+  https://palewi.re/favicon.ico) status=302; location=/static/favicon.ico ;;
+  https://palewi.re/@palewire) status=302; location=https://mastodon.palewi.re/@palewire ;;
+esac
+printf "HTTP/2 %s\\ncontent-type: application/rss+xml; charset=utf-8\\ncontent-security-policy: base-uri 'self'; frame-src 'self' https://datawrapper.dwcdn.net https://docs.google.com https://player.vimeo.com http://s3-us-west-1.amazonaws.com https://w.soundcloud.com\\npermissions-policy: camera=(), geolocation=(), microphone=(), payment=(), usb=()\\n" "$status" > "$headers_file"
+test -z "$location" || printf "location: %s\\n" "$location" >> "$headers_file"
+printf "\\n" >> "$headers_file"
+cat > "$body_file" <<'EOF'
+{"status":"ok"}
+<link rel="canonical" href="https://palewi.re/who-is-ben-welsh/" />
+<iframe src="https://docs.google.com/"></iframe>
+<iframe src="http://s3-us-west-1.amazonaws.com/"></iframe>
+<iframe src="https://player.vimeo.com/"></iframe>
+<iframe src="https://w.soundcloud.com/"></iframe>
+<iframe src="https://datawrapper.dwcdn.net/6T1Lq/4/"></iframe>
+<iframe src="http://chart.apis.google.com/"></iframe>
+<iframe src="http://www.palewire.com/"></iframe>
+<img src="//palewire.s3.amazonaws.com/latimes-tour/1.jpg">
+<video src="//palewire.s3.amazonaws.com/latimes-tour/9track.mp4"></video>
+<sitemapindex></sitemapindex>
+<h1 id="error-heading">404</h1>
+EOF
+exit 0
+""",
+    )
+    _write_executable(bin_dir / "sleep", "#!/bin/sh\nexit 0\n")
+    env = {
+        **os.environ,
+        "FAKE_CURL_COUNT": str(count_path),
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "SITE_VERIFY_ATTEMPTS": "2",
+        "SITE_VERIFY_WAIT_SECONDS": "0",
+    }
+
+    result = subprocess.run(
+        ["sh", str(ROOT / "scripts" / "verify-static-site.sh")],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "while deployment propagates; waiting 0 seconds before retry 2 of 2" in result.stderr
 
 
 def test_production_verifiers_cover_new_navigation() -> None:


### PR DESCRIPTION
## Summary

- retry temporary static-site status mismatches while Cloudflare assets propagate
- cover the observed first-request 404 with a regression test
- retain bounded failure after five attempts

## Validation

- `uv run pytest tests/test_verify_scripts.py -q --no-cov`
- `make check`
- `make worker-test`
- `make worker-validate`
- `make legacy-worker-test`
- `make legacy-worker-validate`
- production static-site and redirect verification