### PR TITLE
Fix navigation and bot markup

### DIFF
--- a/coltrane/templates/coltrane/bot_list.html
+++ b/coltrane/templates/coltrane/bot_list.html
@@ -61,7 +61,7 @@
         {% for object in object_list %}
             <div class="row">
                 <article class="listitem twelvecol last">
-                    • {{ object.title }} (<a target="_blank" href="{{ object.mastodon_url }}">Mastodon &raquo;</a> <a target="_blank" href="{{ object.twitter_url }}">Twitter &raquo;</a>)
+                    • {{ object.title }} (<a target="_blank" href="{{ object.mastodon_url }}">Mastodon &raquo;</a>{% if object.twitter_url %} <a target="_blank" href="{{ object.twitter_url }}">Twitter &raquo;</a>{% endif %})
                 </article>
             </div>
         {% endfor %}

--- a/coltrane/templates/coltrane/nav.html
+++ b/coltrane/templates/coltrane/nav.html
@@ -1,4 +1,3 @@
-<nav>
     <div class="row">
         <div class="fivecol">
             <div class="shingle">
@@ -45,7 +44,6 @@
             </div>
         </div>
     </div>
-</nav>
 <div class="row topbar">
     <div class="twelvecol last"></div>
 </div>

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -69,11 +69,24 @@ def test_public_list_pages_are_available_without_database(client, page):
 
 def test_mobile_navigation_has_menu_disclosure(client):
     content = client.get("/apps/").content.decode()
+    assert content.count("<nav") == 1
+    assert '<nav aria-label="Primary">' in content
     assert '<div class="nav-menu">' in content
     assert 'popovertarget="mobile-nav-links"' in content
     assert '<div id="mobile-nav-links" class="nav-drawer" popover>' in content
     assert 'aria-label="Close menu"' in content
     assert '<span class="hamburger" aria-hidden="true">' in content
+
+
+def test_bots_omit_empty_twitter_link(client):
+    content = client.get("/bots/").content.decode()
+
+    assert (
+        '@RandomPigeonGPT (<a target="_blank" href="https://mastodon.palewi.re/@RandomPigeonGPT">Mastodon &raquo;</a>)'
+        in content
+    )
+    assert 'href="">Twitter' not in content
+    assert 'href="https://twitter.com/divineanndvorak">Twitter &raquo;</a>' in content
 
 
 @pytest.mark.parametrize(("old_path", "new_path"), [("/work/", "/clips/")])


### PR DESCRIPTION
## Summary
- remove the nested navigation landmark while preserving the primary-navigation label
- omit Twitter links for bots with no Twitter URL
- cover both rendered markup cases

## Validation
- `make check`