### PR TITLE
Remove stale built-site quality baselines

### DIFF
--- a/scripts/built_site_quality_baseline.txt
+++ b/scripts/built_site_quality_baseline.txt
@@ -51,11 +51,3 @@ image-alt	posts/2018/04/14/my-times/index.html	image is missing an alt attribute
 image-alt	posts/2018/04/14/my-times/index.html	image is missing an alt attribute
 image-alt	posts/2018/04/14/my-times/index.html	image is missing an alt attribute
 image-alt	posts/2018/04/14/my-times/index.html	image is missing an alt attribute
-missing-generated-page	posts/2008/03/24/go-snoop-yourself/index.html	a[href="&eurl=http://dandelionsalad.wordpress.com/2008/03/20/olbermann-obamas-passport-breach/"] targets absent generated page /posts/2008/03/24/go-snoop-yourself/&eurl=http:/dandelionsalad.wordpress.com/2008/03/20/olbermann-obamas-passport-breach/
-missing-generated-page	posts/2009/07/29/new-improved-even-more-conspicuous-consumption/index.html	a[href="/ticker/page/1/"] targets absent generated page /ticker/page/1/
-missing-generated-page	posts/2009/08/01/django-recipe-make-django-tagging-cloud-all-models/index.html	a[href="/tags/"] targets absent generated page /tags/
-missing-generated-page	posts/2010/11/07/django-recipe-twitter-style-infinite-scroll/index.html	a[href="/tracks/page/1/"] targets absent generated page /tracks/page/1/
-missing-generated-page	posts/2021/05/09/public-art-on-la-light-rail-line/index.html	a[href="Andromeda (M31) galaxy"] targets absent generated page /posts/2021/05/09/public-art-on-la-light-rail-line/Andromeda (M31) galaxy
-missing-generated-page	work/index.html	a[href="LAFD union leader says suspending hiring program 'patently unfair'"] targets absent generated page /work/LAFD union leader says suspending hiring program 'patently unfair'
-missing-generated-page	work/index.html	a[href="cedar-rapids-buildings-unsafe-after-derecho-2020"] targets absent generated page /work/cedar-rapids-buildings-unsafe-after-derecho-2020
-missing-local-asset	work/index.html	a[href="https://palewi.re/docs/news-homepages/openai-gptbot-robotstxt.html"] targets absent local asset /docs/news-homepages/openai-gptbot-robotstxt.html


### PR DESCRIPTION
Removes the eight resolved built-site quality baseline entries: five post-link fixes from #481 and three entries from the retired /work/ page.

The remaining baseline contains only 52 documented image-alt findings for the historical My Times post.

Validation:
- make check-built-site
- make report-built-site-quality
- make check