### PR TITLE
Center top navigation vertically

### DIFF
--- a/coltrane/static/styles.css
+++ b/coltrane/static/styles.css
@@ -594,10 +594,13 @@ a:active {
 /* The header */
 nav {
   display: block;
-  margin-top: 0.75em;
-  margin-bottom: 0.5em;
+  margin: 0.625em 0;
   font-size: 1em;
   line-height: 1.7em;
+}
+nav > .row {
+  display: flex;
+  align-items: center;
 }
 nav .shingle {
   font-size: 1.7em;
@@ -638,8 +641,6 @@ nav .links li a:hover {
 }
 @media (max-width: 550px) {
   nav > .row {
-    display: flex;
-    align-items: center;
     justify-content: space-between;
     flex-wrap: nowrap;
     overflow: visible;

--- a/coltrane/static/styles.css
+++ b/coltrane/static/styles.css
@@ -764,6 +764,7 @@ nav .links li a:hover {
 
 .topbar {
   border-bottom: var(--border-topbar);
+  margin-top: 0.625em;
   margin-bottom: 20px;
 }
 


### PR DESCRIPTION
## Summary

- use one centered flex row for the masthead and navigation at every viewport width
- give the header equal vertical spacing above and below
- preserve the existing mobile drawer behavior

## Verification

- desktop: 12.5px above and below, 0.5px center difference
- mobile: 8.5px above and below, exact center alignment
- tested at 1440px, 390px and 320px with no overflow
- `make check`