### PR TITLE
Harden feed and CSP headers

### DIFF
--- a/coltrane/content/posts-manifest.json
+++ b/coltrane/content/posts-manifest.json
@@ -45,11 +45,11 @@
       "sha256": "b04f99be41d447b0122f24b97066e5f6aa6f02ad6e76e0b4cf8b4f2b3c9a0162"
     },
     {
-      "body_sha256": "ce9d2239b40d8d5f0c8b88d971a83821939760124de265e00ebdb28740984464",
+      "body_sha256": "6b46f01bea9bb094614fd3cac76e78fc77320d11aa9231cbeffd98658d6b2d8e",
       "path": "posts/2008-04-20--python-recipe-grab-a-page-scrape-a-table-download-a-file.md",
       "permalink": "/posts/2008/04/20/python-recipe-grab-a-page-scrape-a-table-download-a-file/",
       "published_at": "2008-04-20T13:43:13-07:00",
-      "sha256": "94d71d3aa98342125f2d0c1ea0589348ddacb62637cac446509f3faa02add4d6"
+      "sha256": "8a7a6937b9e49a219e6413b75cf90e169a8361c914b3364a43abb392d117a944"
     },
     {
       "body_sha256": "208d4f338bda7b4842b6a2949051161e3c29589738763b01f4cbeddda414872a",
@@ -87,11 +87,11 @@
       "sha256": "2643f706a49abcf371bb2aa9e5de0e29b21aa4effd7144c59eceebd27c490950"
     },
     {
-      "body_sha256": "52fd0ad2c3b5ac12cd56ab93c6e0d09a0de6f951a32c29e79905189d5f2dfe08",
+      "body_sha256": "ac8c895ea34148af23d5e6e51fc69c30d6658b559aa45084bf56a7a71cac8dab",
       "path": "posts/2008-06-01--bens-hip-hop-twitter-bot.md",
       "permalink": "/posts/2008/06/01/bens-hip-hop-twitter-bot/",
       "published_at": "2008-06-01T03:56:05-07:00",
-      "sha256": "fb72d619d933223685f62c6b31efe2725f54d841fa98be6820ded4600f5c5886"
+      "sha256": "f23e8aba3057c8cded41be71da8dcff9a301099f87cb8bc15d8a7755c5eca505"
     },
     {
       "body_sha256": "cf7a8b58ec6e075e1409bf91a45363f5009f75bc412cb1e02e0abe3c0ab3fd89",
@@ -108,11 +108,11 @@
       "sha256": "7e1fd470d0f4730ff492cf1ab30e2ec2a4404fe3f7425c78ac9fc68fbc8b9cd3"
     },
     {
-      "body_sha256": "ad671cb98afa3ff26ae6e0d9e10af554480ef7de37c788899e99301ad9e9cd08",
+      "body_sha256": "c95a900929efd0d20f00136fe09f6c0b5c55cb77158ef596456a9a9cc5199e92",
       "path": "posts/2008-07-06--permalinks-low-rent-data-viz-and-other-stupid-caspio-tricks.md",
       "permalink": "/posts/2008/07/06/permalinks-low-rent-data-viz-and-other-stupid-caspio-tricks/",
       "published_at": "2008-07-06T20:20:33-07:00",
-      "sha256": "1caf7939b7f364cdfb5e544a27fbec51dc12a25951c8b64b55d6af84579b5997"
+      "sha256": "d106e4d1fe2b303896adf4842746e6facd28aa793037c47dfb72bfa1af3c435c"
     },
     {
       "body_sha256": "4f4ca05a12364ffd666951b3e6188dba798ed1b8ecfa0fddebcf6ee3a6bfd5b2",
@@ -143,11 +143,11 @@
       "sha256": "8ea75f9da288d898ebf5230fc740b59d014e70fc61459d9e78dd49df6e415820"
     },
     {
-      "body_sha256": "853b6ebe2bce023c24dedf3e18b85c10bf6db97358958d75412c67df1e52efc5",
+      "body_sha256": "50f1e084cd377a6533bfe96459c50f22d8f699cb52aa91c80fd19140781519c4",
       "path": "posts/2009-03-04--openlayers-recipe-how-to-map-proportional-symbols.md",
       "permalink": "/posts/2009/03/04/openlayers-recipe-how-to-map-proportional-symbols/",
       "published_at": "2009-03-04T11:04:00-08:00",
-      "sha256": "473ce40fafce9e885a8d8b1033b1c47f249a7b87557787c306a6ad0d0f48ee92"
+      "sha256": "e74525c6cfc4791983ab0263e40409449942ef8a4c894ec0ccaf73f1569b02f8"
     },
     {
       "body_sha256": "28108187d4bf5ba2ce4902b2189454a819e8b41b418d98a502a54e7190433f70",
@@ -311,11 +311,11 @@
       "sha256": "431479aff5e2cfe1be89a730d2db600ca3f3d3c1812a25fcb379d5d78a3bd1b3"
     },
     {
-      "body_sha256": "90d1522bbc6f257435153577c9dc3bfc9779bc9c1e94385d6414624398fc6e99",
+      "body_sha256": "0a622e1d2103cff33b343ffa6403b6ee5a60583f7ea97f3bc9ef5c9e749a0bdc",
       "path": "posts/2012-03-26--leaflet-recipe-hover-events-features-and-polygons.md",
       "permalink": "/posts/2012/03/26/leaflet-recipe-hover-events-features-and-polygons/",
       "published_at": "2012-03-26T13:47:10-07:00",
-      "sha256": "000b865aa1ec67ebee075a1ef07588ea357d91d8230afafe9319cdf62b69df39"
+      "sha256": "8667636f9291c241156d3b241e96b573292edca6638d468ce3161d7ca0628829"
     },
     {
       "body_sha256": "52508620f5b3e90abbe71fc152fad1771da269a3c2801813c296c330b50bdf61",
@@ -493,7 +493,7 @@
       "sha256": "568ae2a319b6bf239f507326e7dc1a5f5ac5b7725a022abe45264e1e690cd669"
     }
   ],
-  "posts_fingerprint_sha256": "c41f46b51ae7853593a0384bdef6bfbaa60236ee87541dbb4dbc0378ccc9f227",
+  "posts_fingerprint_sha256": "4ba29ba51de06463b3a52de539abd9b27a3e70d4b309a8f8975f413252a06b56",
   "production_inventory": {
     "draft": 94,
     "hidden": 0,

--- a/coltrane/content/posts/2008-04-20--python-recipe-grab-a-page-scrape-a-table-download-a-file.md
+++ b/coltrane/content/posts/2008-04-20--python-recipe-grab-a-page-scrape-a-table-download-a-file.md
@@ -484,4 +484,4 @@ outfile.close()</pre>
 
 
 
-<img src="http://www.palewire.com/images/oreilly_lat.gif" alt="The Reporter's Python Cookbook" border=1/>
+<img src="https://palewire.s3.amazonaws.com/img/oreilly_lat.gif" alt="The Reporter's Python Cookbook" border=1/>

--- a/coltrane/content/posts/2008-06-01--bens-hip-hop-twitter-bot.md
+++ b/coltrane/content/posts/2008-06-01--bens-hip-hop-twitter-bot.md
@@ -8,7 +8,7 @@ wordpress_id: 126
 
 
 
-<img src="http://www.palewire.com/images/mistadobalina.png" alt="Screenshot of the @mistadobalina Twitter bot" />
+<img src="https://palewire.s3.amazonaws.com/img/mistadobalina.png" alt="Screenshot of the @mistadobalina Twitter bot" />
 
 
 

--- a/coltrane/content/posts/2008-07-06--permalinks-low-rent-data-viz-and-other-stupid-caspio-tricks.md
+++ b/coltrane/content/posts/2008-07-06--permalinks-low-rent-data-viz-and-other-stupid-caspio-tricks.md
@@ -60,7 +60,7 @@ wordpress_id: 134
 
 
 
-<img src="http://www.palewire.com/images/form-step1.png" alt="Caspio advanced options with URL parameters enabled" />
+<img src="https://palewire.s3.amazonaws.com/img/form-step1.png" alt="Caspio advanced options with URL parameters enabled" />
 
 
 
@@ -68,7 +68,7 @@ wordpress_id: 134
 
 
 
-<img src="http://www.palewire.com/images/form-step2.png" alt="Caspio setting to use an external URL parameter instead of its search form" />
+<img src="https://palewire.s3.amazonaws.com/img/form-step2.png" alt="Caspio setting to use an external URL parameter instead of its search form" />
 
 
 
@@ -76,7 +76,7 @@ wordpress_id: 134
 
 
 
-<img src="http://www.palewire.com/images/form-step3.png" alt="Caspio setting that selects the name field for a search" />
+<img src="https://palewire.s3.amazonaws.com/img/form-step3.png" alt="Caspio setting that selects the name field for a search" />
 
 
 
@@ -84,7 +84,7 @@ wordpress_id: 134
 
 
 
-<img src="http://www.palewire.com/images/form-step4a.png" alt="Caspio settings for a name URL parameter and contains matching" />
+<img src="https://palewire.s3.amazonaws.com/img/form-step4a.png" alt="Caspio settings for a name URL parameter and contains matching" />
 
 
 
@@ -92,7 +92,7 @@ wordpress_id: 134
 
 
 
-<img src="http://www.palewire.com/images/form-step4b.png" alt="Caspio settings for blank variables and unmatched searches" />
+<img src="https://palewire.s3.amazonaws.com/img/form-step4b.png" alt="Caspio settings for blank variables and unmatched searches" />
 
 
 
@@ -140,7 +140,7 @@ wordpress_id: 134
 
 
 
-<img src="http://www.palewire.com/images/mini-grid.png" alt="Los Angeles Times charity fundraising efficiency grid" />
+<img src="https://palewire.s3.amazonaws.com/img/mini-grid.png" alt="Los Angeles Times charity fundraising efficiency grid" />
 
 
 

--- a/coltrane/content/posts/2009-03-04--openlayers-recipe-how-to-map-proportional-symbols.md
+++ b/coltrane/content/posts/2009-03-04--openlayers-recipe-how-to-map-proportional-symbols.md
@@ -9,7 +9,7 @@ published_at: '2009-03-04T11:04:00-08:00'
 
 <p>Today's L.A. Times has <a href="http://www.latimes.com/business/printedition/la-fallingroof-fl,0,4583412.flash">a nifty Flash map</a> made by my awesome coworkers that shows places in Southern California where real estate projects have stalled due to the recession.</p>
 
-<a href="http://www.palewire.com/openlayers-proportional-symbols/"><img src="http://www.palewire.com/openlayers-proportional-symbols/thumb.gif" alt="C'mon. Click it." /></a>
+<a href="http://www.palewire.com/openlayers-proportional-symbols/"><img src="https://palewire.s3.amazonaws.com/openlayers-proportional-symbols/thumb.gif" alt="C'mon. Click it." /></a>
 
 <p>So I took an hour this morning to see if I could replicate the Flash map in OL. Guess what, it's pretty easy! Click the thumbnail above and have a look. Or just click <a href="http://www.palewire.com/openlayers-proportional-symbols/">here</a>.</p>
 

--- a/coltrane/content/posts/2012-03-26--leaflet-recipe-hover-events-features-and-polygons.md
+++ b/coltrane/content/posts/2012-03-26--leaflet-recipe-hover-events-features-and-polygons.md
@@ -11,7 +11,7 @@ published_at: '2012-03-26T13:47:10-07:00'
 
 <p>The city of Los Angeles recently redrew its City Council districts. Below is a Leaflet map displaying the boundaries from the redistricting commission's final recommendation. I downloaded the lines as a <a href="http://en.wikipedia.org/wiki/Shapefile">shapefile</a> from <a href="http://redistricting2011.lacity.org/LACITY/proposedFinalMap.html">the commission's Web site</a> and converted them into <a href="http://en.wikipedia.org/wiki/GeoJSON">GeoJSON</a> format using <a href="http://en.wikipedia.org/wiki/Qgis">Quantum GIS</a>.</p>
 
-<iframe src="http://s3-us-west-1.amazonaws.com/palewire/leaflet-hover/before.html" frameborder=0 scrolling=no width=100% height=350px></iframe>
+<iframe src="https://s3-us-west-1.amazonaws.com/palewire/leaflet-hover/before.html" frameborder=0 scrolling=no width=100% height=350px></iframe>
 
 <p style="margin-top:10px">This kind of map can be accomplished by following the <a href="http://leaflet.cloudmade.com/examples/geojson.html">GeoJSON instructions</a> Leaflet already provides. One hundred percent of the code is below. I've annotated it to provide some clues to what's happening, but this is the baseline for making a static map run and I'm going to assume you get how it works. If you get stuck up, fire off a question in the comments or spend some time with <a href="http://leaflet.cloudmade.com/index.html">Leaflet's tutorial for beginners</a>.</p>
 
@@ -86,7 +86,7 @@ published_at: '2012-03-26T13:47:10-07:00'
 
 <p>Our goal is to make the same map as above, except with polygons that light up on hover and a popup that appears with metadata about the selected council district. Something like this.</p>
 
-<iframe src="http://s3-us-west-1.amazonaws.com/palewire/leaflet-hover/after.html" frameborder=0 scrolling=no width=100% height=350px></iframe>
+<iframe src="https://s3-us-west-1.amazonaws.com/palewire/leaflet-hover/after.html" frameborder=0 scrolling=no width=100% height=350px></iframe>
 
 <p style="margin-top:10px;">First add jQuery to the head of the page, so we can easily make the popup when the time comes.</p>
 

--- a/scripts/verify-static-site.sh
+++ b/scripts/verify-static-site.sh
@@ -53,7 +53,7 @@ request() {
 
 expect_security_headers() {
   grep -Fiq "content-security-policy: " "$headers_file"
-  grep -Fiq "frame-src 'self' https://datawrapper.dwcdn.net https://docs.google.com https://player.vimeo.com http://s3-us-west-1.amazonaws.com https://w.soundcloud.com" "$headers_file"
+  grep -Fiq "frame-src 'self' https://datawrapper.dwcdn.net https://docs.google.com https://player.vimeo.com https://s3-us-west-1.amazonaws.com https://w.soundcloud.com" "$headers_file"
   grep -Fiq "permissions-policy: camera=(), geolocation=(), microphone=(), payment=(), usb=()" "$headers_file"
 }
 
@@ -73,7 +73,7 @@ request "/docs/" 200
 request "/posts/2012/02/25/nicar-2012-things-i-said/" 200
 grep -Fq 'src="https://docs.google.com/' "$body_file"
 request "/posts/2012/03/26/leaflet-recipe-hover-events-features-and-polygons/" 200
-grep -Fq 'src="http://s3-us-west-1.amazonaws.com/' "$body_file"
+grep -Fq 'src="https://s3-us-west-1.amazonaws.com/' "$body_file"
 request "/posts/2017/09/09/what-i-learned/" 200
 grep -Fq 'src="https://player.vimeo.com/' "$body_file"
 request "/posts/2025/05/21/ire-podcast-transcript/" 200
@@ -82,7 +82,7 @@ request "/posts/2026/01/27/how-journalism-lost-its-culture-of-sharing/" 200
 grep -Fq 'src="https://datawrapper.dwcdn.net/6T1Lq/4/"' "$body_file"
 request "/posts/2010/03/10/google-charts-takes-tufte-challenge/" 404
 request "/posts/2008/07/06/permalinks-low-rent-data-viz-and-other-stupid-caspio-tricks/" 200
-grep -Fq 'src="http://www.palewire.com/' "$body_file"
+grep -Fq 'src="https://palewire.s3.amazonaws.com/img/form-step1.png"' "$body_file"
 request "/posts/2018/04/14/my-times/" 200
 grep -Fq 'src="//palewire.s3.amazonaws.com/latimes-tour/1.jpg"' "$body_file"
 grep -Fq 'src="//palewire.s3.amazonaws.com/latimes-tour/9track.mp4"' "$body_file"
@@ -93,6 +93,9 @@ request "/this-page-does-not-exist/" 404
 grep -Fq 'id="error-heading">404<' "$body_file"
 request "/feeds/posts/" 200
 grep -Fiq 'content-type: application/rss+xml; charset=utf-8' "$headers_file"
+request "/feeds/posts.json" 200
+grep -Fiq 'content-type: application/feed+json; charset=utf-8' "$headers_file"
+grep -Fq '"version": "https://jsonfeed.org/version/1.1"' "$body_file"
 request "/static/styles.css" 200
 test -s "$body_file"
 request "/static/favicon.ico" 200

--- a/tests/test_verify_scripts.py
+++ b/tests/test_verify_scripts.py
@@ -86,27 +86,29 @@ count=$((count + 1))
 printf '%s' "$count" > "$FAKE_CURL_COUNT"
 status=200
 location=
+content_type='application/rss+xml; charset=utf-8'
 test "$count" -ne 1 || status=404
 case "$url" in
+  */feeds/posts.json) content_type='application/feed+json; charset=utf-8' ;;
   */posts/2010/03/10/google-charts-takes-tufte-challenge/) status=404 ;;
   */this-page-does-not-exist/) status=404 ;;
   https://palewi.re/) status=302; location=/who-is-ben-welsh/ ;;
   https://palewi.re/favicon.ico) status=302; location=/static/favicon.ico ;;
   https://palewi.re/@palewire) status=302; location=https://mastodon.palewi.re/@palewire ;;
 esac
-printf "HTTP/2 %s\\ncontent-type: application/rss+xml; charset=utf-8\\ncontent-security-policy: base-uri 'self'; frame-src 'self' https://datawrapper.dwcdn.net https://docs.google.com https://player.vimeo.com http://s3-us-west-1.amazonaws.com https://w.soundcloud.com\\npermissions-policy: camera=(), geolocation=(), microphone=(), payment=(), usb=()\\n" "$status" > "$headers_file"
+printf "HTTP/2 %s\\ncontent-type: %s\\ncontent-security-policy: base-uri 'self'; frame-src 'self' https://datawrapper.dwcdn.net https://docs.google.com https://player.vimeo.com https://s3-us-west-1.amazonaws.com https://w.soundcloud.com\\npermissions-policy: camera=(), geolocation=(), microphone=(), payment=(), usb=()\\n" "$status" "$content_type" > "$headers_file"
 test -z "$location" || printf "location: %s\\n" "$location" >> "$headers_file"
 printf "\\n" >> "$headers_file"
 cat > "$body_file" <<'EOF'
 {"status":"ok"}
+{"version": "https://jsonfeed.org/version/1.1"}
 <link rel="canonical" href="https://palewi.re/who-is-ben-welsh/" />
 <iframe src="https://docs.google.com/"></iframe>
-<iframe src="http://s3-us-west-1.amazonaws.com/"></iframe>
+<iframe src="https://s3-us-west-1.amazonaws.com/"></iframe>
 <iframe src="https://player.vimeo.com/"></iframe>
 <iframe src="https://w.soundcloud.com/"></iframe>
 <iframe src="https://datawrapper.dwcdn.net/6T1Lq/4/"></iframe>
-<iframe src="http://chart.apis.google.com/"></iframe>
-<iframe src="http://www.palewire.com/"></iframe>
+<img src="https://palewire.s3.amazonaws.com/img/form-step1.png">
 <img src="//palewire.s3.amazonaws.com/latimes-tour/1.jpg">
 <video src="//palewire.s3.amazonaws.com/latimes-tour/9track.mp4"></video>
 <sitemapindex></sitemapindex>

--- a/workers/static-site/README.md
+++ b/workers/static-site/README.md
@@ -6,8 +6,8 @@ origins explicit:
 - Google Fonts for styles and fonts.
 - Google Slides, Vimeo, SoundCloud, and the archived S3 Leaflet examples for
   historical iframes.
-- The canonical `palewi.re`, Google Charts, legacy `www.palewire.com`, and
-  `palewire.s3.amazonaws.com` hosts for historical images and videos.
+- The canonical `palewi.re` and `palewire.s3.amazonaws.com` hosts for
+  historical images and videos.
 
 Inline styles remain enabled because published post HTML uses them. Executable
 scripts are limited to the site itself. The Permissions Policy disables only

--- a/workers/static-site/src/index.ts
+++ b/workers/static-site/src/index.ts
@@ -15,8 +15,8 @@ const CONTENT_SECURITY_POLICY = [
   "default-src 'self'",
   "form-action 'self'",
   "frame-ancestors 'none'",
-  "frame-src 'self' https://datawrapper.dwcdn.net https://docs.google.com https://player.vimeo.com http://s3-us-west-1.amazonaws.com https://w.soundcloud.com",
-  "img-src 'self' https://palewi.re http://chart.apis.google.com http://www.palewire.com https://palewire.s3.amazonaws.com",
+  "frame-src 'self' https://datawrapper.dwcdn.net https://docs.google.com https://player.vimeo.com https://s3-us-west-1.amazonaws.com https://w.soundcloud.com",
+  "img-src 'self' https://palewi.re https://palewire.s3.amazonaws.com",
   "font-src 'self' https://fonts.gstatic.com",
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
   "script-src 'self'",
@@ -81,6 +81,17 @@ async function serveFeed(request: Request, assets: StaticAssets): Promise<Respon
   });
 }
 
+async function serveJsonFeed(request: Request, assets: StaticAssets): Promise<Response> {
+  const response = await assets.fetch(request);
+  const headers = new Headers(response.headers);
+  headers.set("content-type", "application/feed+json; charset=utf-8");
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
 async function serveSecurityTxt(request: Request, assets: StaticAssets): Promise<Response> {
   const response = await assets.fetch(request);
   const headers = new Headers(response.headers);
@@ -113,6 +124,9 @@ export async function handleRequest(request: Request, environment: WorkerEnviron
   }
   if (url.pathname === "/feeds/posts/") {
     return withSecurityHeaders(await serveFeed(request, environment.ASSETS), request);
+  }
+  if (url.pathname === "/feeds/posts.json") {
+    return withSecurityHeaders(await serveJsonFeed(request, environment.ASSETS), request);
   }
   if (url.pathname === SECURITY_TXT_PATH) {
     return withSecurityHeaders(await serveSecurityTxt(request, environment.ASSETS), request);

--- a/workers/static-site/tests/index.test.ts
+++ b/workers/static-site/tests/index.test.ts
@@ -62,6 +62,24 @@ describe("static site Worker", () => {
     await expect(response.text()).resolves.toContain("/feeds/posts/index.xml");
   });
 
+  it("serves the JSON Feed with its feed content type and security headers", async () => {
+    const content = '{"version":"https://jsonfeed.org/version/1.1"}';
+    const response = await handleRequest(request("/feeds/posts.json"), {
+      ASSETS: {
+        async fetch(assetRequest) {
+          expect(new URL(assetRequest.url).pathname).toBe("/feeds/posts.json");
+          return new Response(content, {
+            headers: { "content-type": "application/json; charset=utf-8" },
+          });
+        },
+      },
+    });
+
+    expect(response.headers.get("content-type")).toBe("application/feed+json; charset=utf-8");
+    expect(response.headers.get("content-security-policy")).toContain("frame-ancestors 'none'");
+    await expect(response.text()).resolves.toBe(content);
+  });
+
   it("serves security.txt directly as plain text", async () => {
     const response = await handleRequest(request("/.well-known/security.txt"), {
       ASSETS: {
@@ -85,7 +103,7 @@ describe("static site Worker", () => {
 
     expect(await response.text()).toBe("https://palewi.re/who-is-ben-welsh/");
     expect(response.headers.get("content-security-policy")).toBe(
-      "base-uri 'self'; default-src 'self'; form-action 'self'; frame-ancestors 'none'; frame-src 'self' https://datawrapper.dwcdn.net https://docs.google.com https://player.vimeo.com http://s3-us-west-1.amazonaws.com https://w.soundcloud.com; img-src 'self' https://palewi.re http://chart.apis.google.com http://www.palewire.com https://palewire.s3.amazonaws.com; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self'; media-src 'self' https://palewire.s3.amazonaws.com; object-src 'none'",
+      "base-uri 'self'; default-src 'self'; form-action 'self'; frame-ancestors 'none'; frame-src 'self' https://datawrapper.dwcdn.net https://docs.google.com https://player.vimeo.com https://s3-us-west-1.amazonaws.com https://w.soundcloud.com; img-src 'self' https://palewi.re https://palewire.s3.amazonaws.com; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self'; media-src 'self' https://palewire.s3.amazonaws.com; object-src 'none'",
     );
     expect(response.headers.get("permissions-policy")).toBe(
       "camera=(), geolocation=(), microphone=(), payment=(), usb=()",


### PR DESCRIPTION
## Summary
- Serve `/feeds/posts.json` as `application/feed+json; charset=utf-8` while preserving its body and Worker security headers.
- Remove the unused Google Charts and legacy `www.palewire.com` image CSP sources; require HTTPS for the archived S3 iframe host.
- Update current historical media embeds to verified HTTPS S3 resources and extend production verification for the JSON Feed.

## Source audit
- A generated-site scan found no remaining HTTP `src` attributes.
- `https://s3-us-west-1.amazonaws.com/palewire/leaflet-hover/before.html` and `after.html` each returned HTTP 200.
- All former `www.palewire.com` image sources returned HTTP 200 from their confirmed `palewire.s3.amazonaws.com` replacements, including the preserved OpenLayers thumbnail.
- No rendered resource uses `chart.apis.google.com`; its HTTPS endpoint returned HTTP 404.

## Validation
- `make static-worker-test`
- `make static-worker-validate`
- `make check`