### PR TITLE
Add security.txt expiration monitor

### DIFF
--- a/.github/workflows/security-txt-expiration.yaml
+++ b/.github/workflows/security-txt-expiration.yaml
@@ -1,0 +1,77 @@
+name: Check security.txt expiration
+
+on:
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-txt-expiration
+  cancel-in-progress: false
+
+jobs:
+  check-expiration:
+    name: Check expiration
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      renewal_needed: ${{ steps.expiration.outputs.renewal_needed }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          python-version: "3.12"
+
+      - name: Install checker dependencies
+        run: uv sync --locked --group dev
+
+      - name: Check security.txt expiration
+        id: expiration
+        run: uv run python scripts/security_txt_expiry.py --github-output "$GITHUB_OUTPUT"
+
+  manage-renewal-issue:
+    name: Manage renewal issue
+    needs: check-expiration
+    if: needs.check-expiration.outputs.renewal_needed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE_TITLE: Renew security.txt before expiration
+      ISSUE_BODY: |
+        Renew the `security.txt` record before it expires:
+
+        - Confirm the security contact.
+        - Set a new future `Expires:` date within one year.
+        - Deploy the change.
+        - Smoke-test https://palewi.re/.well-known/security.txt.
+    steps:
+      - name: Create or reopen renewal issue
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          existing_issue="$(
+            gh issue list --repo "$GITHUB_REPOSITORY" --state all --search "$ISSUE_TITLE in:title" \
+              --limit 100 --json number,title,state |
+              jq -r --arg title "$ISSUE_TITLE" \
+                '[.[] | select(.title == $title)] | sort_by(.number) | last |
+                if . then "\(.number)\t\(.state)" else empty end'
+          )"
+
+          if [[ -n "$existing_issue" ]]; then
+            IFS=$'\t' read -r issue_number issue_state <<< "$existing_issue"
+            if [[ "$issue_state" == "CLOSED" ]]; then
+              gh issue reopen "$issue_number" --repo "$GITHUB_REPOSITORY"
+            fi
+            gh issue edit "$issue_number" --repo "$GITHUB_REPOSITORY" --body "$ISSUE_BODY"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$ISSUE_TITLE" --body "$ISSUE_BODY"
+          fi

--- a/scripts/security_txt_expiry.py
+++ b/scripts/security_txt_expiry.py
@@ -1,0 +1,79 @@
+"""Check whether the site's security.txt record needs renewal."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import click
+
+DEFAULT_PATH = Path(__file__).resolve().parents[1] / "coltrane" / "templates" / "security.txt"
+RENEWAL_WINDOW = timedelta(days=90)
+
+
+class SecurityTxtError(RuntimeError):
+    """Raised when security.txt expiration metadata cannot be used."""
+
+
+def parse_timestamp(value: str, label: str) -> datetime:
+    """Parse an ISO 8601 timestamp and return it in UTC."""
+    try:
+        timestamp = datetime.fromisoformat(value.strip())
+    except ValueError as error:
+        raise SecurityTxtError(f"{label} must be a valid ISO 8601 timestamp") from error
+    if timestamp.tzinfo is None:
+        raise SecurityTxtError(f"{label} must include a UTC offset")
+    return timestamp.astimezone(UTC)
+
+
+def parse_expires_timestamp(content: str) -> datetime:
+    """Return the one required Expires field from security.txt."""
+    values = [line.partition(":")[2] for line in content.splitlines() if line.partition(":")[0] == "Expires"]
+    if not values:
+        raise SecurityTxtError("security.txt is missing its required Expires field")
+    if len(values) > 1:
+        raise SecurityTxtError("security.txt must contain only one Expires field")
+    if not values[0].strip():
+        raise SecurityTxtError("security.txt Expires field must not be empty")
+    return parse_timestamp(values[0], "security.txt Expires field")
+
+
+def renewal_needed(expires_at: datetime, now: datetime) -> bool:
+    """Return whether an unexpired expiration falls within the renewal window."""
+    if now.tzinfo is None:
+        raise SecurityTxtError("current time must include a UTC offset")
+    expires_at = expires_at.astimezone(UTC)
+    now = now.astimezone(UTC)
+    if expires_at <= now:
+        raise SecurityTxtError(f"security.txt expired at {expires_at.isoformat()}")
+    return expires_at - now <= RENEWAL_WINDOW
+
+
+@click.command()
+@click.option(
+    "--path", type=click.Path(path_type=Path, exists=True, dir_okay=False), default=DEFAULT_PATH, show_default=True
+)
+@click.option(
+    "--github-output",
+    type=click.Path(path_type=Path, dir_okay=False),
+    help="Write the renewal_needed value to a GitHub Actions output file.",
+)
+@click.option("--now", help="ISO 8601 current time, for a reproducible manual check.")
+def cli(path: Path, github_output: Path | None, now: str | None) -> None:
+    """Check security.txt expiration and report whether renewal is needed."""
+    try:
+        expires_at = parse_expires_timestamp(path.read_text(encoding="utf-8"))
+        current_time = parse_timestamp(now, "--now") if now else datetime.now(UTC)
+        needs_renewal = renewal_needed(expires_at, current_time)
+        if github_output:
+            with github_output.open("a", encoding="utf-8") as output_file:
+                output_file.write(f"renewal_needed={str(needs_renewal).lower()}\n")
+    except (OSError, SecurityTxtError) as error:
+        raise click.ClickException(str(error)) from error
+
+    click.echo(f"security.txt expires at {expires_at.isoformat()}")
+    click.echo(f"Renewal needed: {str(needs_renewal).lower()}")
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/test_security_txt_expiry.py
+++ b/tests/test_security_txt_expiry.py
@@ -1,0 +1,68 @@
+"""Tests for the security.txt expiration monitor."""
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from scripts import security_txt_expiry
+
+
+def test_parse_expires_timestamp_normalizes_to_utc() -> None:
+    expires_at = security_txt_expiry.parse_expires_timestamp(
+        "Contact: mailto:security@example.com\nExpires: 2027-08-01T02:00:00+02:00\n"
+    )
+
+    assert expires_at == datetime(2027, 8, 1, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    ("content", "message"),
+    [
+        ("Contact: mailto:security@example.com\n", "missing"),
+        ("Expires: \n", "must not be empty"),
+        ("Expires: not-a-timestamp\n", "valid ISO 8601"),
+        ("Expires: 2027-08-01T00:00:00\n", "include a UTC offset"),
+        ("Expires: 2027-08-01T00:00:00Z\nExpires: 2027-09-01T00:00:00Z\n", "only one"),
+    ],
+)
+def test_parse_expires_timestamp_rejects_invalid_metadata(content: str, message: str) -> None:
+    with pytest.raises(security_txt_expiry.SecurityTxtError, match=message):
+        security_txt_expiry.parse_expires_timestamp(content)
+
+
+def test_renewal_needed_only_within_ninety_days() -> None:
+    now = datetime(2027, 1, 1, tzinfo=UTC)
+
+    assert security_txt_expiry.renewal_needed(now + timedelta(days=90), now)
+    assert not security_txt_expiry.renewal_needed(now + timedelta(days=91), now)
+
+
+def test_renewal_needed_rejects_expired_metadata() -> None:
+    now = datetime(2027, 1, 1, tzinfo=UTC)
+
+    with pytest.raises(security_txt_expiry.SecurityTxtError, match="expired"):
+        security_txt_expiry.renewal_needed(now, now)
+
+
+def test_cli_writes_github_output(tmp_path: Path) -> None:
+    security_txt = tmp_path / "security.txt"
+    output = tmp_path / "github-output"
+    security_txt.write_text("Expires: 2027-01-02T00:00:00Z\n", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        security_txt_expiry.cli,
+        [
+            "--path",
+            str(security_txt),
+            "--now",
+            "2027-01-01T00:00:00Z",
+            "--github-output",
+            str(output),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Renewal needed: true" in result.output
+    assert output.read_text(encoding="utf-8") == "renewal_needed=true\n"


### PR DESCRIPTION
## Summary

- Add a monthly, manually runnable check for `security.txt` expiration.
- Create or reopen one stable renewal issue only when expiration is within 90 days.
- Add tested parsing and date-threshold logic that fails on missing, invalid, or expired metadata.

## Validation

- `make check`

Related to #432. Issue #432 remains open until this workflow is merged and successfully runs.