### PR TITLE
Tighten mobile talk header spacing

### DIFF
--- a/coltrane/static/styles.css
+++ b/coltrane/static/styles.css
@@ -889,6 +889,10 @@ nav .links li a:hover {
 }
 
 @media (max-width: 550px) {
+  .talk-detail header {
+    gap: 8px;
+  }
+
   .talk-transcript li {
     grid-template-columns: 1fr;
     gap: 0.15em;


### PR DESCRIPTION
## Summary
- reduce the mobile gap between the talk subtitle and byline by 4px

## Validation
- make check