### PR TITLE
Fix IRE Resource Center deck embed

### DIFF
--- a/workers/static-site/src/index.ts
+++ b/workers/static-site/src/index.ts
@@ -24,6 +24,8 @@ const CANONICAL_HOST = "palewi.re";
 const SIBLING_HOSTS = new Set(["www.palewi.re", "palewire.com", "www.palewire.com"]);
 const USERNAME_DESTINATION = "https://mastodon.palewi.re/@palewire";
 const SECURITY_TXT_PATH = "/.well-known/security.txt";
+const IRE_RESOURCE_CENTER_DECK_PATH = "/static/talks/ire-resource-center/";
+const IRE_RESOURCE_CENTER_SCRIPT_HASH = "'sha256-DMbYlXrnLW14j2GxDuz+ZgtHhA88TY8qe5iEQIAvWbc='";
 const CONTENT_SECURITY_POLICY = [
   "base-uri 'self'",
   "default-src 'self'",
@@ -37,6 +39,10 @@ const CONTENT_SECURITY_POLICY = [
   "media-src 'self' https://palewire.s3.amazonaws.com",
   "object-src 'none'",
 ].join("; ");
+const IRE_RESOURCE_CENTER_CONTENT_SECURITY_POLICY = CONTENT_SECURITY_POLICY.replace(
+  "script-src 'self'",
+  `script-src 'self' ${IRE_RESOURCE_CENTER_SCRIPT_HASH}`,
+);
 const SECURITY_HEADERS = {
   "content-security-policy": CONTENT_SECURITY_POLICY,
   "permissions-policy": "camera=(), geolocation=(), microphone=(), payment=(), usb=()",
@@ -60,7 +66,11 @@ function withSecurityHeaders(response: Response, request: Request): Response {
   for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
     headers.set(name, value);
   }
-  if (new URL(request.url).protocol === "https:") {
+  const url = new URL(request.url);
+  if (url.pathname === IRE_RESOURCE_CENTER_DECK_PATH) {
+    headers.set("content-security-policy", IRE_RESOURCE_CENTER_CONTENT_SECURITY_POLICY);
+  }
+  if (url.protocol === "https:") {
     headers.set("strict-transport-security", "max-age=31536000; includeSubDomains; preload");
   }
   return new Response(response.body, {

--- a/workers/static-site/tests/index.test.ts
+++ b/workers/static-site/tests/index.test.ts
@@ -145,6 +145,14 @@ describe("static site Worker", () => {
     expect(response.headers.get("strict-transport-security")).toContain("max-age=31536000");
   });
 
+  it("allows the IRE Resource Center deck's hashed startup script", async () => {
+    const response = await handleRequest(request("/static/talks/ire-resource-center/"), { ASSETS: assets });
+
+    expect(response.headers.get("content-security-policy")).toContain(
+      "script-src 'self' 'sha256-DMbYlXrnLW14j2GxDuz+ZgtHhA88TY8qe5iEQIAvWbc='",
+    );
+  });
+
   it("applies the security policy to redirects and health responses", async () => {
     const redirectResponse = await handleRequest(request("/"), { ASSETS: assets });
     const healthResponse = await handleRequest(request("/health/"), { ASSETS: assets });


### PR DESCRIPTION
## Summary
- allow the local IRE Resource Center deck's hashed Svelte startup script
- keep the existing strict script policy on every other response
- add a static-site Worker test for the scoped policy

## Testing
- `make check`
- `npm --prefix workers/static-site run test`
- `npm --prefix workers/static-site run validate`
- `make worker-test`
- `make worker-validate`
- `make legacy-worker-test`
- `make legacy-worker-validate`