### PR TITLE
Link archived pages and guides from talks

### DIFF
--- a/.github/skills/publish-talk/SKILL.md
+++ b/.github/skills/publish-talk/SKILL.md
@@ -32,6 +32,13 @@ talk as a catalog entry rather than creating an empty detail page:
 
 The talks list will link to both the external source and its archived copy.
 
+## Link a related guide
+
+When a first-party guide is the useful companion to a talk, add its URL as
+`guide_url`. Do not add `slug`, local assets, or a Wayback snapshot unless
+other talk materials also require them. The talks list labels this link
+“Guide.”
+
 ## Create the page assets
 
 Create a directory named for the talk slug:

--- a/.github/skills/publish-talk/SKILL.md
+++ b/.github/skills/publish-talk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: publish-talk
-description: Create or update a permanent, first-party talk page from a presentation and recording. Use whenever adding a talk detail page, locally hosting a talk deck, or publishing a talk transcript or captions.
+description: Create or update a permanent talk page or archived external talk link. Use whenever adding a talk detail page, locally hosting a talk deck, publishing a talk transcript or captions, or preserving an external talk page.
 ---
 
 # Publish a talk page
@@ -20,6 +20,17 @@ the site. Keep the work focused on one talk at a time.
   The page displays the remaining title as its subtitle.
 - Do not deploy the Worker or alter Cloudflare routes as part of this
   workflow.
+
+## Link an external-only talk
+
+When no approved deck, recording, or other local asset is available, keep the
+talk as a catalog entry rather than creating an empty detail page:
+
+1. Keep the external event or materials URL in `slides_url` or `video_url`.
+2. Find or create a Wayback Machine snapshot and add it as `archive_url`.
+3. Do not set `slug` or add local talk assets.
+
+The talks list will link to both the external source and its archived copy.
 
 ## Create the page assets
 
@@ -84,6 +95,13 @@ poster_url: /media/talks/example-talk/poster.jpg
 Only add URLs for assets that exist. The Downloads section should use the
 same labels as the page: `Slides PDF`, `Recording video`, `Extracted slide
 text`, and `Timestamped transcript`.
+
+For an external-only talk, use only the source and Wayback URLs:
+
+```yaml
+slides_url: https://example.org/event
+archive_url: https://web.archive.org/web/20260101000000/https://example.org/event
+```
 
 ## Upload recording media
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,7 @@ talks:
     date: "2024-06-15"       # YYYY-MM-DD
     video_url: "https://..." # optional
     slides_url: "https://..." # optional
+    guide_url: "https://..." # optional related guide
     archive_url: "https://web.archive.org/web/..." # optional Wayback snapshot
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,7 @@ talks:
     date: "2024-06-15"       # YYYY-MM-DD
     video_url: "https://..." # optional
     slides_url: "https://..." # optional
+    archive_url: "https://web.archive.org/web/..." # optional Wayback snapshot
 ```
 
 Ordered by descending date.

--- a/coltrane/content/talks.yaml
+++ b/coltrane/content/talks.yaml
@@ -37,6 +37,7 @@ talks:
   location: Zoom
   date: '2026-03-10'
   slides_url: https://www.poynter.org/shop/reporting-editing/todays-news-for-tomorrow/
+  archive_url: https://web.archive.org/web/20260610235645/https://www.poynter.org/shop/reporting-editing/todays-news-for-tomorrow/
 - title: First PMTiles Map
   venue: NICAR
   location: Indianapolis

--- a/coltrane/content/talks.yaml
+++ b/coltrane/content/talks.yaml
@@ -42,7 +42,7 @@ talks:
   venue: NICAR
   location: Indianapolis
   date: '2026-03-07'
-  slides_url: https://palewi.re/docs/first-pmtiles-map/
+  guide_url: https://palewi.re/docs/first-pmtiles-map/
 - title: Introducing the new IRE Resource Center
   venue: NICAR
   location: Indianapolis

--- a/coltrane/content/talks.yaml
+++ b/coltrane/content/talks.yaml
@@ -52,12 +52,12 @@ talks:
   venue: NICAR
   location: Indianapolis
   date: '2026-03-05'
-  slides_url: https://palewi.re/docs/first-llm-classifier/
+  guide_url: https://palewi.re/docs/first-llm-classifier/
 - title: Go big with Github Actions
   venue: IRE Watchdog Workshop
   location: New York
   date: '2026-01-24'
-  slides_url: https://palewi.re/docs/go-big-with-github-actions/
+  guide_url: https://palewi.re/docs/go-big-with-github-actions/
 - title: 'Storytelling with graphics: From raw data to reader impact'
   venue: Observable webinar
   location: Zoom
@@ -107,17 +107,17 @@ talks:
   venue: NICAR
   location: Minneapolis
   date: '2025-03-08'
-  slides_url: https://palewi.re/docs/first-llm-classifier/
+  guide_url: https://palewi.re/docs/first-llm-classifier/
 - title: First Athena Query
   venue: NICAR
   location: Minneapolis
   date: '2025-03-07'
-  slides_url: https://palewi.re/docs/first-athena-query/
+  guide_url: https://palewi.re/docs/first-athena-query/
 - title: Go big with GitHub Actions
   venue: NICAR
   location: Minneapolis
   date: '2025-03-06'
-  slides_url: https://palewi.re/docs/go-big-with-github-actions/
+  guide_url: https://palewi.re/docs/go-big-with-github-actions/
 - title: FOIA Fellowship
   venue: DePaul University Center for Journalism Integrity & Excellence
   location: Zoom
@@ -162,17 +162,17 @@ talks:
   venue: NICAR
   location: Baltimore
   date: '2024-03-09'
-  video_url: https://palewi.re/docs/first-python-notebook/
+  guide_url: https://palewi.re/docs/first-python-notebook/
 - title: First Automated Chart
   venue: NICAR
   location: Baltimore
   date: '2024-03-08'
-  slides_url: https://palewi.re/docs/first-automated-chart/
+  guide_url: https://palewi.re/docs/first-automated-chart/
 - title: First Visual Story
   venue: NICAR
   location: Baltimore
   date: '2024-03-07'
-  slides_url: https://palewi.re/docs/first-visual-story/
+  guide_url: https://palewi.re/docs/first-visual-story/
 - title: Have a little fun with FOIA
   venue: National FOIA Summit 23
   location: Zoom
@@ -181,12 +181,12 @@ talks:
   venue: NICAR
   location: New Orleans
   date: '2023-03-07'
-  slides_url: https://palewi.re/docs/first-visual-story/
+  guide_url: https://palewi.re/docs/first-visual-story/
 - title: First Visual Story
   venue: NICAR
   location: Nashville
   date: '2023-03-04'
-  slides_url: https://palewi.re/docs/first-visual-story/
+  guide_url: https://palewi.re/docs/first-visual-story/
 - title: Introducing moneyinpolitics.wtf
   venue: NICAR
   location: Nashville
@@ -196,13 +196,13 @@ talks:
   venue: NICAR
   location: Nashville
   date: '2023-03-03'
-  slides_url: https://palewi.re/docs/first-python-notebook/
+  guide_url: https://palewi.re/docs/first-python-notebook/
 - title: First Pull Request
   venue: the e.e. cummings free poetry archive
   location: Zoom
   date: '2022-12-10'
   video_url: https://www.youtube.com/watch?v=E5cVRseyEOA
-  slides_url: https://palewi.re/docs/first-pull-request/
+  guide_url: https://palewi.re/docs/first-pull-request/
 - title: How do we make FOI fun?
   venue: National FOIA Summit 22
   location: Zoom
@@ -212,7 +212,7 @@ talks:
   location: Zoom
   date: '2022-09-24'
   video_url: https://www.youtube.com/watch?v=2RgPoy05AnA
-  slides_url: https://palewi.re/docs/first-python-notebook/_extra/fast-python-notebook/lab/
+  guide_url: https://palewi.re/docs/first-python-notebook/_extra/fast-python-notebook/lab/
 - title: What is Big Local News?
   venue: 17º Congresso Internacional de Journalismo da Abraji
   location: São Paulo
@@ -243,17 +243,17 @@ talks:
   venue: NICAR
   location: Atlanta
   date: '2022-03-05'
-  slides_url: https://palewi.re/docs/first-visual-story/
+  guide_url: https://palewi.re/docs/first-visual-story/
 - title: First GitHub Scraper
   venue: NICAR
   location: Atlanta
   date: '2022-03-04'
-  slides_url: https://palewi.re/docs/first-github-scraper/
+  guide_url: https://palewi.re/docs/first-github-scraper/
 - title: First Python Notebook
   venue: NICAR
   location: Atlanta
   date: '2022-03-03'
-  slides_url: https://palewi.re/docs/first-python-notebook/
+  guide_url: https://palewi.re/docs/first-python-notebook/
 - title: The state of local data journalism
   venue: The Data Journalism Podcast
   location: Zoom
@@ -309,7 +309,7 @@ talks:
   venue: NICAR
   location: New Orleans
   date: '2020-03-06'
-  slides_url: https://palewi.re/docs/first-python-notebook/
+  guide_url: https://palewi.re/docs/first-python-notebook/
 - title: First Observable notebook
   venue: NICAR
   location: New Orleans

--- a/coltrane/content_loaders.py
+++ b/coltrane/content_loaders.py
@@ -177,6 +177,7 @@ class Talk:
     video_url: str = ""
     local_video_url: str = ""
     slides_url: str = ""
+    archive_url: str = ""
     slug: str = ""
     short_title: str = ""
     byline: str = ""
@@ -325,6 +326,21 @@ def _optional_http_url(record: dict, field_name: str, path: str, title: str) -> 
     parsed = urlparse(value)
     if value and (parsed.scheme not in {"http", "https"} or not parsed.netloc or any(char.isspace() for char in value)):
         raise ContentError(f"{path}: doc '{title}' {field_name} must be an HTTP(S) URL, got {value!r}")
+    return value
+
+
+def _optional_wayback_url(record: dict, field_name: str, path: str) -> str:
+    """Return an optional Wayback Machine snapshot URL."""
+    value = _optional_str(record, field_name, path)
+    if not value:
+        return ""
+    parsed = urlparse(value)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or parsed.netloc != "web.archive.org"
+        or any(char.isspace() for char in value)
+    ):
+        raise ContentError(f"{path}: field '{field_name}' must be a web.archive.org HTTP(S) URL, got {value!r}")
     return value
 
 
@@ -631,6 +647,7 @@ def load_talks(path: Path | None = None) -> list[Talk]:
                 video_url=video_url,
                 local_video_url=_optional_str(record, "local_video_url", label),
                 slides_url=slides_url,
+                archive_url=_optional_wayback_url(record, "archive_url", label),
                 slug=slug,
                 short_title=_optional_str(record, "short_title", label),
                 byline=_optional_str(record, "byline", label),

--- a/coltrane/content_loaders.py
+++ b/coltrane/content_loaders.py
@@ -177,6 +177,7 @@ class Talk:
     video_url: str = ""
     local_video_url: str = ""
     slides_url: str = ""
+    guide_url: str = ""
     archive_url: str = ""
     slug: str = ""
     short_title: str = ""
@@ -647,6 +648,7 @@ def load_talks(path: Path | None = None) -> list[Talk]:
                 video_url=video_url,
                 local_video_url=_optional_str(record, "local_video_url", label),
                 slides_url=slides_url,
+                guide_url=_optional_str(record, "guide_url", label),
                 archive_url=_optional_wayback_url(record, "archive_url", label),
                 slug=slug,
                 short_title=_optional_str(record, "short_title", label),

--- a/coltrane/templates/coltrane/talk_list.html
+++ b/coltrane/templates/coltrane/talk_list.html
@@ -67,9 +67,10 @@
                 <article class="listitem twelvecol last">
                     <time datetime="{{ object.date|date:"Y-m-d" }}">{{ object.date|date:"N" }}</time> •
                     {% if object.slug %}<a href="{{ object.get_absolute_url }}">{% endif %}“{{ object.title }}”{% if object.slug %}</a>{% endif %} at {{ object.venue }}{% if object.location %} in {{ object.location }}{% endif %}
-                    {% if object.video_url or object.slides_url or object.archive_url %}(
-                        {% if object.video_url %}<a target="_blank" href="{{ object.video_url }}">Video &raquo;</a>{% if object.slides_url or object.archive_url %} · {% endif %}{% endif %}
-                        {% if object.slides_url %}<a target="_blank" href="{{ object.slides_url }}">Materials &raquo;</a>{% if object.archive_url %} · {% endif %}{% endif %}
+                    {% if object.video_url or object.slides_url or object.guide_url or object.archive_url %}(
+                        {% if object.video_url %}<a target="_blank" href="{{ object.video_url }}">Video &raquo;</a>{% if object.slides_url or object.guide_url or object.archive_url %} · {% endif %}{% endif %}
+                        {% if object.slides_url %}<a target="_blank" href="{{ object.slides_url }}">Materials &raquo;</a>{% if object.guide_url or object.archive_url %} · {% endif %}{% endif %}
+                        {% if object.guide_url %}<a href="{{ object.guide_url }}">Guide &raquo;</a>{% if object.archive_url %} · {% endif %}{% endif %}
                         {% if object.archive_url %}<a target="_blank" href="{{ object.archive_url }}">Archived page &raquo;</a>{% endif %}
                     ){% endif %}
                 </article>

--- a/coltrane/templates/coltrane/talk_list.html
+++ b/coltrane/templates/coltrane/talk_list.html
@@ -67,7 +67,11 @@
                 <article class="listitem twelvecol last">
                     <time datetime="{{ object.date|date:"Y-m-d" }}">{{ object.date|date:"N" }}</time> •
                     {% if object.slug %}<a href="{{ object.get_absolute_url }}">{% endif %}“{{ object.title }}”{% if object.slug %}</a>{% endif %} at {{ object.venue }}{% if object.location %} in {{ object.location }}{% endif %}
-                    {% if object.video_url or object.slides_url %}({% if object.video_url %}<a target="_blank" href="{{ object.video_url }}">Video &raquo;</a>{% if object.slides_url %} {% endif %}{% endif %}{% if object.slides_url %}<a target="_blank" href="{{ object.slides_url }}">Materials &raquo;</a>{% endif %}){% endif %}
+                    {% if object.video_url or object.slides_url or object.archive_url %}(
+                        {% if object.video_url %}<a target="_blank" href="{{ object.video_url }}">Video &raquo;</a>{% if object.slides_url or object.archive_url %} · {% endif %}{% endif %}
+                        {% if object.slides_url %}<a target="_blank" href="{{ object.slides_url }}">Materials &raquo;</a>{% if object.archive_url %} · {% endif %}{% endif %}
+                        {% if object.archive_url %}<a target="_blank" href="{{ object.archive_url }}">Archived page &raquo;</a>{% endif %}
+                    ){% endif %}
                 </article>
             </li>
         {% endfor %}

--- a/preservation-review-baseline.json
+++ b/preservation-review-baseline.json
@@ -15,7 +15,6 @@
     {"source_url": "https://api.soundcloud.com/tracks/2099172090", "code": "local-media-untracked", "reason": "Historical media source awaiting recovery in issue #396."},
     {"source_url": "https://asu.zoom.us/rec/play/ShKHBZ4M8nipdXFKuZHUaU0FDM8nywZotv5ryyeIvDH4WjGEmDQzvzpVMX10k3XUZ8D-OvEiKhMcilaA.-JekNP08WWLe764M?autoplay=true", "code": "local-media-untracked", "reason": "Historical media source awaiting recovery in issue #396."},
     {"source_url": "https://journalismcourses.org/product/first-python-notebook-data-analysis-on-deadline/", "code": "local-media-untracked", "reason": "Historical media source awaiting recovery in issue #396."},
-    {"source_url": "https://palewi.re/docs/first-python-notebook/", "code": "local-media-untracked", "reason": "Historical media source awaiting recovery in issue #396."},
     {"source_url": "https://palewire.s3.amazonaws.com/latimes-tour/9track.mp4", "code": "local-media-untracked", "reason": "Historical media source awaiting recovery in issue #396."},
     {"source_url": "https://palewire.s3.amazonaws.com/latimes-tour/button.mp4", "code": "local-media-untracked", "reason": "Historical media source awaiting recovery in issue #396."},
     {"source_url": "https://palewire.s3.amazonaws.com/latimes-tour/handle.mp4", "code": "local-media-untracked", "reason": "Historical media source awaiting recovery in issue #396."},

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -352,6 +352,7 @@ def test_talk_optional_fields_default_empty(tmp_path):
     talks = load_talks(p)
     assert talks[0].video_url == ""
     assert talks[0].slides_url == ""
+    assert talks[0].archive_url == ""
     assert talks[0].slug == ""
     assert talks[0].deck_url == ""
     assert talks[0].short_title == ""
@@ -392,6 +393,21 @@ def test_talk_detail_fields_and_slug_load(tmp_path):
     assert talk.notes_text_url == "/static/talks/a-talk/notes.txt"
     assert talk.transcript_template == "coltrane/talks/a-talk-transcript.html"
     assert talk.transcript_text_url == "/static/talks/a-talk/transcript.txt"
+
+
+def test_talk_archive_url_must_be_a_wayback_snapshot(tmp_path):
+    p = tmp_path / "talks.yaml"
+    p.write_text(
+        "talks:\n"
+        "  - title: T\n"
+        "    venue: V\n"
+        "    location: L\n"
+        "    date: '2024-01-01'\n"
+        "    archive_url: https://example.com/archive\n"
+    )
+
+    with pytest.raises(ContentError, match="archive_url"):
+        load_talks(p)
 
 
 @pytest.mark.parametrize("deck_aspect_ratio", ["16:9", "0 / 9", "16 / 0", "wide"])

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -352,6 +352,7 @@ def test_talk_optional_fields_default_empty(tmp_path):
     talks = load_talks(p)
     assert talks[0].video_url == ""
     assert talks[0].slides_url == ""
+    assert talks[0].guide_url == ""
     assert talks[0].archive_url == ""
     assert talks[0].slug == ""
     assert talks[0].deck_url == ""

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -120,7 +120,7 @@ def test_list_pages_use_page_specific_metadata_descriptions(client, page, expect
         ("/code/", "a8f1c5a32b4419dbfe2fb43fd6016efffb53a85a4118008a60d10ea442e93aed"),
         ("/guides/", "d0ce6e3ca42af59d07b3fa71e04ef5051de41202012b6fdc9b9ac535216b06b3"),
         ("/docs/", "bced3578a4a815d297afebd115ce705f82f366e5807eab902af66ad5f332a5b3"),
-        ("/talks/", "2b325a36519358db171fc85a4f063a6cc7c0bf4f6636cd0697fd7f572f7c389e"),
+        ("/talks/", "90a8bb3f7b0d8f2130b2a917d779590b79d7b795e2f655e415e84a627379dbd2"),
         ("/bots/", "9e2991194a5be838f4ff33d1b5403065a752c57e235a28e7253399772dd63b41"),
     ],
 )
@@ -214,6 +214,12 @@ def test_talk_list_links_to_archived_external_talk_pages(client):
         in content
     )
     assert "Archived page &raquo;" in content
+
+
+def test_talk_list_links_to_related_guides(client):
+    content = client.get("/talks/").content.decode()
+
+    assert 'href="https://palewi.re/docs/first-pmtiles-map/">Guide &raquo;</a>' in content
 
 
 def test_post_schema_is_a_blog_post_with_a_canonical_main_entity(client):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -120,7 +120,7 @@ def test_list_pages_use_page_specific_metadata_descriptions(client, page, expect
         ("/code/", "a8f1c5a32b4419dbfe2fb43fd6016efffb53a85a4118008a60d10ea442e93aed"),
         ("/guides/", "d0ce6e3ca42af59d07b3fa71e04ef5051de41202012b6fdc9b9ac535216b06b3"),
         ("/docs/", "bced3578a4a815d297afebd115ce705f82f366e5807eab902af66ad5f332a5b3"),
-        ("/talks/", "90a8bb3f7b0d8f2130b2a917d779590b79d7b795e2f655e415e84a627379dbd2"),
+        ("/talks/", "d17406751918536d8f660322a310a20653b6f3395f5423cc10d1efab8e798000"),
         ("/bots/", "9e2991194a5be838f4ff33d1b5403065a752c57e235a28e7253399772dd63b41"),
     ],
 )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -120,7 +120,7 @@ def test_list_pages_use_page_specific_metadata_descriptions(client, page, expect
         ("/code/", "a8f1c5a32b4419dbfe2fb43fd6016efffb53a85a4118008a60d10ea442e93aed"),
         ("/guides/", "d0ce6e3ca42af59d07b3fa71e04ef5051de41202012b6fdc9b9ac535216b06b3"),
         ("/docs/", "bced3578a4a815d297afebd115ce705f82f366e5807eab902af66ad5f332a5b3"),
-        ("/talks/", "3546bb185a7ace238b83d813235de99b57ab0b0831a369abebfa678a6e4a78e6"),
+        ("/talks/", "2b325a36519358db171fc85a4f063a6cc7c0bf4f6636cd0697fd7f572f7c389e"),
         ("/bots/", "9e2991194a5be838f4ff33d1b5403065a752c57e235a28e7253399772dd63b41"),
     ],
 )
@@ -203,6 +203,17 @@ def test_ire_resource_center_talk_page_has_local_deck_and_downloads(client):
     assert ">Extracted slide text<" in content
     assert ">Recording video<" in content
     assert ">Timestamped transcript<" in content
+
+
+def test_talk_list_links_to_archived_external_talk_pages(client):
+    content = client.get("/talks/").content.decode()
+
+    assert 'href="https://www.poynter.org/shop/reporting-editing/todays-news-for-tomorrow/"' in content
+    assert (
+        'href="https://web.archive.org/web/20260610235645/https://www.poynter.org/shop/reporting-editing/todays-news-for-tomorrow/"'
+        in content
+    )
+    assert "Archived page &raquo;" in content
 
 
 def test_post_schema_is_a_blog_post_with_a_canonical_main_entity(client):


### PR DESCRIPTION
## Summary
- add a Wayback link for talks that only have external materials
- add a first-party Guide link type for talks associated with published guides
- classify all 18 first-party guide links accordingly, while retaining the two IRE presentation links as materials

## Testing
- `make check`