### PR TITLE
Publish Harnessing AI talk video

### DIFF
--- a/.github/skills/publish-talk/SKILL.md
+++ b/.github/skills/publish-talk/SKILL.md
@@ -129,6 +129,45 @@ npm exec -- wrangler r2 object put \
   --content-type video/mp4
 ```
 
+Wrangler only accepts files up to 300 MiB. For a larger recording, use
+`boto3`'s multipart upload support with the repository's configured R2
+credentials, then verify the stored size and content type:
+
+```bash
+uv run --env-file .env python - <<'PY'
+import os
+from pathlib import Path
+
+import boto3
+from boto3.s3.transfer import TransferConfig
+
+path = Path("/absolute/path/to/video.mp4")
+bucket = "palewire-talk-media"
+key = "talks/<slug>/video.mp4"
+client = boto3.client(
+    "s3",
+    endpoint_url=os.environ.get("R2_ENDPOINT_URL")
+    or f"https://{os.environ['R2_ACCOUNT_ID']}.r2.cloudflarestorage.com",
+    aws_access_key_id=os.environ["R2_ACCESS_KEY_ID"],
+    aws_secret_access_key=os.environ["R2_SECRET_ACCESS_KEY"],
+    region_name="auto",
+)
+client.upload_file(
+    str(path),
+    bucket,
+    key,
+    ExtraArgs={"ContentType": "video/mp4"},
+    Config=TransferConfig(
+        multipart_threshold=8 * 1024 * 1024,
+        multipart_chunksize=16 * 1024 * 1024,
+    ),
+)
+metadata = client.head_object(Bucket=bucket, Key=key)
+assert metadata["ContentLength"] == path.stat().st_size
+assert metadata["ContentType"] == "video/mp4"
+PY
+```
+
 The static-site Worker serves video from
 `/media/talks/<slug>/video.mp4`, with byte-range support. Keep captions in
 the repository's static assets so they are committed and baked with the site.

--- a/coltrane/content/talks.yaml
+++ b/coltrane/content/talks.yaml
@@ -91,7 +91,10 @@ talks:
   location: Zoom
   date: '2025-06-25'
   video_url: https://www.youtube.com/watch?v=pvarfN4F19g
-  slides_url: https://sabew.org/event/harnessing-ai-how-journalists-can-reap-the-benefits-and-avoid-the-pitfalls-of-emerging-ai-tools/
+  slug: harnessing-ai
+  short_title: Harnessing AI
+  local_video_url: /media/talks/harnessing-ai/video.mp4
+  poster_url: /media/talks/harnessing-ai/poster.jpg
 - title: Journalism in the visual age
   venue: Canva meetup
   location: New York City

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -120,7 +120,7 @@ def test_list_pages_use_page_specific_metadata_descriptions(client, page, expect
         ("/code/", "00e42adbf42c8f4caff7270c01ae0a5efbf87271c64b8f54d7fb9c56c7401557"),
         ("/guides/", "d0ce6e3ca42af59d07b3fa71e04ef5051de41202012b6fdc9b9ac535216b06b3"),
         ("/docs/", "bced3578a4a815d297afebd115ce705f82f366e5807eab902af66ad5f332a5b3"),
-        ("/talks/", "f646b271577601ab35412a041bdf94290f034b079d2893307efd2431a8177773"),
+        ("/talks/", "6220e551abf42eb39e6233a728ac265bbf0b3a717fe69b956b2f7c0ddaedd0bd"),
         ("/bots/", "9e2991194a5be838f4ff33d1b5403065a752c57e235a28e7253399772dd63b41"),
     ],
 )
@@ -183,6 +183,19 @@ def test_talk_detail_page_uses_configured_byline_and_deck_ratio(client):
     assert 'style="--talk-deck-aspect-ratio: 16 / 9;"' in content
     assert ">Downloads<" in content
     assert "Original sources" not in content
+
+
+def test_harnessing_ai_talk_page_is_video_only(client):
+    response = client.get("/talks/harnessing-ai/")
+    talk = next(talk for talk in load_talks() if talk.slug == "harnessing-ai")
+
+    assert response.status_code == 200
+    assert talk.slides_url == ""
+    content = response.content.decode()
+    assert "<h1>Harnessing AI</h1>" in content
+    assert 'src="/media/talks/harnessing-ai/video.mp4"' in content
+    assert 'poster="/media/talks/harnessing-ai/poster.jpg"' in content
+    assert 'aria-labelledby="slides"' not in content
 
 
 def test_ire_resource_center_talk_page_has_local_deck_and_downloads(client):


### PR DESCRIPTION
## Summary

- publish a video-only page for the SABEW “Harnessing AI” panel
- remove the external materials link
- serve the preserved recording and poster from the private talk-media R2 bucket
- document multipart R2 uploads for recordings over Wrangler’s 300 MiB limit

## Checks

- `make check`
- `make static-worker-validate`