### PR TITLE
Add JazzLineup TRMNL recipe to apps index

### DIFF
--- a/coltrane/content/apps.yaml
+++ b/coltrane/content/apps.yaml
@@ -19,6 +19,10 @@ apps:
   type: personal
   url: https://kip.computer/
   description: The homepage of my AI assistant
+- title: JazzLineup.com NYC
+  type: personal
+  url: https://trmnl.com/recipes/385200
+  description: A TRMNL recipe that puts New York City jazz listings on an e-ink display
 - title: moneyinpolitics.wtf
   type: database
   url: https://moneyinpolitics.wtf/

--- a/coltrane/content/code.yaml
+++ b/coltrane/content/code.yaml
@@ -910,6 +910,10 @@ code:
   url: https://observablehq.com/@palewire/tinting-a-canvas-image
   description: How to overlay a color filter on top of a canvas image
   type: javascript
+- title: trmnl-jazz-lineup
+  url: https://github.com/kip-claw/trmnl-jazz-lineup
+  description: A TRMNL recipe that brings JazzLineup.com’s New York City jazz listings to an e-ink display
+  type: other
 - title: trump-tweets
   url: https://observablehq.com/collection/@palewire/trump-tweets
   description: Techniques for working President Donald Trump's posts on twitter.com


### PR DESCRIPTION
Adds the public JazzLineup.com NYC TRMNL recipe to the personal apps index, with its install-page link and a concise description.