### PR TITLE
Publish Fast First Python Notebook talk

### DIFF
--- a/coltrane/content/talks.yaml
+++ b/coltrane/content/talks.yaml
@@ -228,7 +228,7 @@ talks:
   location: Zoom
   date: '2022-09-24'
   video_url: https://www.youtube.com/watch?v=2RgPoy05AnA
-  guide_url: https://palewi.re/docs/first-python-notebook/_extra/fast-python-notebook/lab/
+  slug: fast-first-python-notebook
 - title: What is Big Local News?
   venue: 17º Congresso Internacional de Journalismo da Abraji
   location: São Paulo

--- a/coltrane/content_loaders.py
+++ b/coltrane/content_loaders.py
@@ -78,7 +78,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 from zoneinfo import ZoneInfo
 
 import yaml
@@ -208,6 +208,26 @@ class Talk:
             if self.title.startswith(prefix):
                 return self.title.removeprefix(prefix).lstrip()
         return self.title
+
+    @property
+    def youtube_embed_url(self) -> str:
+        """Return a privacy-enhanced YouTube embed URL when the recording is eligible."""
+        parsed = urlparse(self.video_url)
+        host = parsed.netloc.lower().removeprefix("www.").removeprefix("m.")
+        if host == "youtu.be":
+            video_id = parsed.path.lstrip("/").split("/", maxsplit=1)[0]
+        elif host == "youtube.com":
+            if parsed.path == "/watch":
+                video_id = parse_qs(parsed.query).get("v", [""])[0]
+            elif parsed.path.startswith(("/embed/", "/live/", "/shorts/")):
+                video_id = parsed.path.split("/")[2]
+            else:
+                return ""
+        else:
+            return ""
+        if re.fullmatch(r"[-\w]{11}", video_id) is None:
+            return ""
+        return f"https://www.youtube-nocookie.com/embed/{video_id}"
 
 
 @dataclass(frozen=True)

--- a/coltrane/static/styles.css
+++ b/coltrane/static/styles.css
@@ -827,12 +827,17 @@ nav .links li a:hover {
   font-weight: var(--font-weight-bold);
 }
 
-.talk-detail-deck {
+.talk-detail-deck,
+.talk-detail-video-embed {
   box-sizing: border-box;
   display: block;
   width: 100%;
   aspect-ratio: var(--talk-deck-aspect-ratio, 4 / 3);
   border: var(--border-rule);
+}
+
+.talk-detail-video-embed {
+  aspect-ratio: 16 / 9;
 }
 
 .talk-detail-text {

--- a/coltrane/templates/coltrane/talk_detail.html
+++ b/coltrane/templates/coltrane/talk_detail.html
@@ -72,6 +72,11 @@
         </details>
         {% endif %}
     </section>
+    {% elif object.youtube_embed_url %}
+    <section aria-labelledby="recording">
+        <h2 id="recording">Recording</h2>
+        <iframe class="talk-detail-video-embed" src="{{ object.youtube_embed_url }}" title="Recording of {{ object.title }}" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+    </section>
     {% endif %}
 
     {% if not object.deck_url %}

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -361,6 +361,7 @@ def test_talk_optional_fields_default_empty(tmp_path):
     assert talks[0].deck_aspect_ratio == ""
     assert talks[0].notes_text_url == ""
     assert talks[0].transcript_text_url == ""
+    assert talks[0].youtube_embed_url == ""
 
 
 def test_talk_detail_fields_and_slug_load(tmp_path):
@@ -394,6 +395,20 @@ def test_talk_detail_fields_and_slug_load(tmp_path):
     assert talk.notes_text_url == "/static/talks/a-talk/notes.txt"
     assert talk.transcript_template == "coltrane/talks/a-talk-transcript.html"
     assert talk.transcript_text_url == "/static/talks/a-talk/transcript.txt"
+
+
+def test_talk_derives_privacy_enhanced_youtube_embed_url(tmp_path):
+    p = tmp_path / "talks.yaml"
+    p.write_text(
+        "talks:\n"
+        "  - title: A talk\n"
+        "    venue: V\n"
+        "    location: L\n"
+        "    date: '2024-01-01'\n"
+        "    video_url: https://www.youtube.com/watch?v=2RgPoy05AnA\n"
+    )
+
+    assert load_talks(p)[0].youtube_embed_url == "https://www.youtube-nocookie.com/embed/2RgPoy05AnA"
 
 
 def test_talk_archive_url_must_be_a_wayback_snapshot(tmp_path):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -198,6 +198,19 @@ def test_harnessing_ai_talk_page_is_video_only(client):
     assert 'aria-labelledby="slides"' not in content
 
 
+def test_fast_first_python_notebook_talk_embeds_youtube_recording(client):
+    response = client.get("/talks/fast-first-python-notebook/")
+    talk = next(talk for talk in load_talks() if talk.slug == "fast-first-python-notebook")
+
+    assert response.status_code == 200
+    assert talk.guide_url == ""
+    content = response.content.decode()
+    assert "<h1>Fast First Python Notebook</h1>" in content
+    assert 'src="https://www.youtube-nocookie.com/embed/2RgPoy05AnA"' in content
+    assert 'title="Recording of Fast First Python Notebook"' in content
+    assert 'referrerpolicy="strict-origin-when-cross-origin"' in content
+
+
 def test_ire_resource_center_talk_page_has_local_deck_and_downloads(client):
     response = client.get("/talks/ire-resource-center/")
 


### PR DESCRIPTION
## Summary
- publish a permanent page for the Fast First Python Notebook talk
- embed the YouTube recording with YouTube's privacy-enhanced player
- remove the former guide link

## Validation
- `make check`