### PR TITLE
Remove broken talk link

### DIFF
--- a/coltrane/content/talks.yaml
+++ b/coltrane/content/talks.yaml
@@ -142,7 +142,6 @@ talks:
   venue: Knight Center at UT-Austin
   location: an online class
   date: '2024-05-11'
-  video_url: https://journalismcourses.org/product/first-python-notebook-data-analysis-on-deadline/
 - title: 'Bare Facts First: How Reuters uses Datawrapper to create, automate and disseminate
     hundreds of charts each week'
   venue: Data Visualization Society

--- a/preservation-review-baseline.json
+++ b/preservation-review-baseline.json
@@ -14,7 +14,6 @@
     {"source_url": "https://anchor.fm/ddjpodcast/episodes/Data-journalism-for-the-people--Ben-Welsh-and-MaryJo-Webster-on-the-state-of-local-data-journalism-e1e4ejq", "code": "local-media-untracked", "reason": "Historical media source awaiting recovery in issue #396."},
     {"source_url": "https://api.soundcloud.com/tracks/2099172090", "code": "local-media-untracked", "reason": "Historical media source awaiting recovery in issue #396."},
     {"source_url": "https://asu.zoom.us/rec/play/ShKHBZ4M8nipdXFKuZHUaU0FDM8nywZotv5ryyeIvDH4WjGEmDQzvzpVMX10k3XUZ8D-OvEiKhMcilaA.-JekNP08WWLe764M?autoplay=true", "code": "local-media-untracked", "reason": "Historical media source awaiting recovery in issue #396."},
-    {"source_url": "https://journalismcourses.org/product/first-python-notebook-data-analysis-on-deadline/", "code": "local-media-untracked", "reason": "Historical media source awaiting recovery in issue #396."},
     {"source_url": "https://palewire.s3.amazonaws.com/latimes-tour/9track.mp4", "code": "local-media-untracked", "reason": "Historical media source awaiting recovery in issue #396."},
     {"source_url": "https://palewire.s3.amazonaws.com/latimes-tour/button.mp4", "code": "local-media-untracked", "reason": "Historical media source awaiting recovery in issue #396."},
     {"source_url": "https://palewire.s3.amazonaws.com/latimes-tour/handle.mp4", "code": "local-media-untracked", "reason": "Historical media source awaiting recovery in issue #396."},

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -120,7 +120,7 @@ def test_list_pages_use_page_specific_metadata_descriptions(client, page, expect
         ("/code/", "00e42adbf42c8f4caff7270c01ae0a5efbf87271c64b8f54d7fb9c56c7401557"),
         ("/guides/", "d0ce6e3ca42af59d07b3fa71e04ef5051de41202012b6fdc9b9ac535216b06b3"),
         ("/docs/", "bced3578a4a815d297afebd115ce705f82f366e5807eab902af66ad5f332a5b3"),
-        ("/talks/", "6220e551abf42eb39e6233a728ac265bbf0b3a717fe69b956b2f7c0ddaedd0bd"),
+        ("/talks/", "707bfd57f661f117bd76689e4086a85d1367dc34a7f1aa179e012c8e773ace62"),
         ("/bots/", "9e2991194a5be838f4ff33d1b5403065a752c57e235a28e7253399772dd63b41"),
     ],
 )


### PR DESCRIPTION
## Summary

- Remove the unavailable video link from the First Python Notebook talk
- Update the media-review baseline and talks-page text snapshot