### PR TITLE
Remove obsolete Big Local News materials link

### DIFF
--- a/coltrane/content/talks.yaml
+++ b/coltrane/content/talks.yaml
@@ -233,7 +233,6 @@ talks:
   venue: 17º Congresso Internacional de Journalismo da Abraji
   location: São Paulo
   date: '2022-08-06'
-  slides_url: https://docs.google.com/presentation/d/e/2PACX-1vSafvmUAXIPgtCmwjgDXx5g1JIRd1li_Uueuu7rzFxV1npB91ylw8evdTyyRenxf7uMARPpC9GM6bAx/pub?start=false&loop=false&delayms=60000&slide=id.g142fc79cdb2_0_0
 - title: First Python Notebook
   venue: JSK Connect Master Class
   location: Zoom

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -346,6 +346,14 @@ def test_talks_sorted_descending_date():
     assert dates == sorted(dates, reverse=True)
 
 
+def test_big_local_news_talk_has_no_unavailable_materials():
+    talk = next(talk for talk in load_talks() if talk.title == "What is Big Local News?")
+
+    assert talk.video_url == ""
+    assert talk.slides_url == ""
+    assert talk.archive_url == ""
+
+
 def test_talk_optional_fields_default_empty(tmp_path):
     p = tmp_path / "talks.yaml"
     p.write_text("talks:\n  - title: T\n    venue: V\n    location: L\n    date: '2024-01-01'\n")

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -120,7 +120,7 @@ def test_list_pages_use_page_specific_metadata_descriptions(client, page, expect
         ("/code/", "00e42adbf42c8f4caff7270c01ae0a5efbf87271c64b8f54d7fb9c56c7401557"),
         ("/guides/", "d0ce6e3ca42af59d07b3fa71e04ef5051de41202012b6fdc9b9ac535216b06b3"),
         ("/docs/", "bced3578a4a815d297afebd115ce705f82f366e5807eab902af66ad5f332a5b3"),
-        ("/talks/", "6220e551abf42eb39e6233a728ac265bbf0b3a717fe69b956b2f7c0ddaedd0bd"),
+        ("/talks/", "d88acd95b02667369574d9005ab60d2830906dc3f42c9b8b9dbff00ce3a9f5ee"),
         ("/bots/", "9e2991194a5be838f4ff33d1b5403065a752c57e235a28e7253399772dd63b41"),
     ],
 )


### PR DESCRIPTION
Removes the dead Google Slides materials link from “What is Big Local News?” so the talk appears as a plain catalog entry.

Updates the talks-page visible-text checksum and adds coverage that this entry has no unavailable materials.