### PR TITLE
Add Reuters maize climate story

### DIFF
--- a/coltrane/content/clips.yaml
+++ b/coltrane/content/clips.yaml
@@ -1,4 +1,9 @@
 clips:
+- title: Climate shocks hit EU maize heartland in Hungary and Romania
+  type: story
+  date: '2026-09-02'
+  url: https://www.reuters.com/business/environment/climate-shocks-hit-eu-maize-heartland-hungary-romania-2026-09-02/
+  archive_exemption: Wayback capture failed with HTTP 520
 - title: geodataframe-to-pmtiles
   type: software
   date: '2026-08-21'

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -115,7 +115,7 @@ def test_list_pages_use_page_specific_metadata_descriptions(client, page, expect
     ("page", "expected_digest"),
     [
         ("/posts/", "1504b00891fbbd026584b629915c526c35f023d60c058cedeb044849d05d401b"),
-        ("/clips/", "16aa691f7161c2aa69d9d104d96e4b31cb5302f3d349b5619899fd7e935d9333"),
+        ("/clips/", "e86a3449abdb69b5ad81d3775dcdf0158864679fac01e07b6fb2a12690ca468e"),
         ("/apps/", "bb938e968fc7a05c6adb5bf151b896f84a80fad31e0313c3b294b4d6eb9e38bd"),
         ("/code/", "9d0bdeabde841710207e0f021dcabc1bbcc74b81d84d3a11696c08866c7df547"),
         ("/guides/", "d0ce6e3ca42af59d07b3fa71e04ef5051de41202012b6fdc9b9ac535216b06b3"),


### PR DESCRIPTION
Adds the September 2 Reuters story to the story index.

Wayback returned HTTP 520 during capture and has no existing snapshot, so the clip records that specific archive exemption.