### PR TITLE
Require release changelog categories

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,8 @@
 
 ## Changelog
 
-<!-- Apply exactly one of these labels before merging. -->
+<!-- Required: apply exactly one changelog category before merging. The Lint
+     check will fail until exactly one is applied. See RELEASING.md. -->
 
 - [ ] `feature`
 - [ ] `improvement`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,6 +29,16 @@ make check
 
 This runs Ruff lint + format check, **ty static type analysis**, and pytest with coverage.
 
+## Releases
+
+Apply exactly one changelog category to every pull request: `feature`,
+`improvement`, `fix`, `maintenance`, or `skip-changelog`. The required Lint
+check enforces this. `enhancement` counts as an improvement; Dependabot's
+`dependencies` and `github_actions` labels count as maintenance. Read
+`RELEASING.md` before creating a release. GitHub Releases are the site's
+public changelog. Use semantic versions, create a draft from the deployed
+`main` commit, and publish only after the production smoke test passes.
+
 ## Key conventions
 
 - **Packaging**: `uv` + `pyproject.toml` + `uv.lock`. Never use `pip install` directly.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,25 @@ jobs:
       - name: Install dev dependencies
         run: make install
 
+      - name: Verify changelog label
+        if: github.event_name == 'pull_request'
+        env:
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          category_count="$(
+            jq '[
+              any(.[]; . == "feature"),
+              any(.[]; . == "improvement" or . == "enhancement"),
+              any(.[]; . == "fix"),
+              any(.[]; . == "maintenance" or . == "dependencies" or . == "github_actions"),
+              any(.[]; . == "skip-changelog")
+            ] | map(select(.)) | length' <<< "$PR_LABELS"
+          )"
+          test "$category_count" -eq 1 || {
+            echo "Apply exactly one changelog category: feature, improvement, fix, maintenance, or skip-changelog." >&2
+            exit 1
+          }
+
       - name: Check with Ruff
         run: make lint
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,15 @@ When creating browser-framed lead art for a post from a public URL, load the
 Run `make check`. This is the same set of lint, type, Django, and test checks
 used by CI.
 
+Before opening or merging a pull request, apply exactly one changelog category:
+`feature`, `improvement`, `fix`, `maintenance`, or `skip-changelog`. The
+required Lint check rejects pull requests without exactly one category.
+`enhancement` counts as an improvement; Dependabot's `dependencies` and
+`github_actions` labels count as maintenance. Read `RELEASING.md` before
+creating a GitHub release. Releases use semantic versions, point to the
+deployed `main` commit, and are published only after the production smoke test
+passes.
+
 Worker changes also require `make worker-test`, `make worker-validate`,
 `make legacy-worker-test`, and `make legacy-worker-validate`. Production
 Wrangler configs keep `workers_dev` and `preview_urls` disabled; the named

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -42,8 +42,9 @@ Use semantic version numbers:
   as `v3.0.0`.
 
 The first recorded release is tagged `v2`. Treat it as `v2.0.0` when choosing
-the next version. Do not update the version in `pyproject.toml`; that describes
-the local Python project, not the deployed website.
+the next version. The next major site upgrade will be `v3.0.0`. Do not update
+the version in `pyproject.toml`; that describes the local Python project, not
+the deployed website.
 
 ## Release checklist
 


### PR DESCRIPTION
## Summary

Make the semantic-release process required for contributors and agents. The required Lint check now rejects pull requests without exactly one release-note category, while treating `enhancement` and Dependabot labels as their matching categories.

The release guide identifies the next major site upgrade as `v3.0.0`.

## Testing

- [x] `make check` passes locally

## Changelog

- [ ] `feature`
- [ ] `improvement`
- [ ] `fix`
- [x] `maintenance`
- [ ] `skip-changelog`

## Deployment notes

N/A