### PR TITLE
Maintain Wayback coverage of public site pages

### DIFF
--- a/.github/workflows/site-archive.yaml
+++ b/.github/workflows/site-archive.yaml
@@ -1,0 +1,165 @@
+name: Site archive
+
+on:
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      lookup_only:
+        description: "Only verify existing snapshots; do not request captures"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: site-archive-data-writer
+  cancel-in-progress: false
+
+jobs:
+  archive:
+    name: Discover and archive
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    outputs:
+      ready: ${{ steps.fetch.outputs.ready }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      SAVEPAGENOW_ACCESS_KEY: ${{ secrets.SAVEPAGENOW_ACCESS_KEY }}
+      SAVEPAGENOW_SECRET_KEY: ${{ secrets.SAVEPAGENOW_SECRET_KEY }}
+      UV_NO_ENV_FILE: "1"
+      MANIFEST: .site-archive/manifest.json
+      STATE_TOKEN: .site-archive/state-token.json
+      SUMMARY: .site-archive/report.md
+    steps:
+      - name: Check out production source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Guard production-only checkout
+        run: |
+          if test "$GITHUB_EVENT_NAME" = workflow_dispatch && test "$GITHUB_REF" != refs/heads/main; then
+            echo "Site archive must run from main, not $GITHUB_REF." >&2
+            exit 1
+          fi
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          python-version: "3.12"
+
+      - name: Install Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+
+      - name: Bootstrap and build
+        run: |
+          make ci-bootstrap
+          make bake
+
+      - name: Fetch archive state
+        id: fetch
+        run: |
+          mkdir -p .site-archive
+          uv run python -m scripts.site_archive.branch fetch \
+            --path "$MANIFEST" --state-token "$STATE_TOKEN"
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
+      - name: Synchronize archive inventory
+        id: sync
+        continue-on-error: true
+        run: |
+          args=(
+            sync
+            --build-dir dist
+            --manifest "$MANIFEST"
+            --max-pages 100
+            --max-checks 100
+            --max-captures 10
+            --max-seconds 900
+            --summary "$SUMMARY"
+          )
+          if test "${{ inputs.lookup_only || false }}" = "true"; then
+            args+=(--lookup-only)
+          fi
+          uv run python -m scripts.site_archive "${args[@]}"
+
+      - name: Ensure a report exists
+        if: always() && steps.fetch.outputs.ready == 'true'
+        run: |
+          if test ! -s "$SUMMARY"; then
+            uv run python -m scripts.site_archive report --manifest "$MANIFEST" > "$SUMMARY"
+          fi
+
+      - name: Publish archive summary
+        if: always() && steps.fetch.outputs.ready == 'true'
+        run: cat "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload recovery checkpoint
+        if: always() && steps.fetch.outputs.ready == 'true'
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: site-archive-checkpoint
+          path: |
+            .site-archive/manifest.json
+            .site-archive/state-token.json
+            .site-archive/report.md
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Surface synchronization failure
+        if: steps.sync.outcome == 'failure'
+        run: |
+          echo "Archive synchronization reported errors; checkpoint was uploaded." >&2
+          exit 1
+
+  persist:
+    name: Persist archive state
+    needs: archive
+    if: always() && needs.archive.outputs.ready == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      UV_NO_ENV_FILE: "1"
+    steps:
+      - name: Check out production source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          python-version: "3.12"
+
+      - name: Install Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+
+      - name: Bootstrap persistence command
+        run: make ci-bootstrap
+
+      - name: Download recovery checkpoint
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: site-archive-checkpoint
+          path: .site-archive
+
+      - name: Persist checkpoint
+        run: |
+          uv run python -m scripts.site_archive.branch push \
+            --path .site-archive/manifest.json \
+            --state-token .site-archive/state-token.json

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ node_modules/
 .goals/
 .lead-art/
 .impeccable/
+.site-archive/
 *.cpuprofile
 
 # Collected static

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ TALK_ASSET_DIR := talks
 
 
 .PHONY: preservation-inventory report-built-site-quality
+.PHONY: site-archive-discover site-archive-verify site-archive-capture site-archive-sync site-archive-report
 
 # Use uv's parser instead of sourcing a dotenv file in the shell.
 define run-with-dotenv
@@ -71,6 +72,11 @@ help:
 	@echo "  fmt        Auto-format with Ruff"
 	@echo "  archive-clips  Archive clip URLs missing Wayback metadata"
 	@echo "  check-clip-archives  Confirm every clip has Wayback metadata"
+	@echo "  site-archive-discover  Discover public pages from dist/ and live site links"
+	@echo "  site-archive-verify  Look up existing Wayback snapshots without captures"
+	@echo "  site-archive-capture  Request captures for pages confirmed missing"
+	@echo "  site-archive-sync  Discover, check, and capture a resumable page batch"
+	@echo "  site-archive-report  Show saved page archive coverage without network access"
 	@echo "  preservation-inventory  Report page and media preservation state without network access"
 	@echo "  preservation-review  Reject new unreviewed external preservation gaps"
 	@echo "  media-archive-inventory  List discovered talk/post media without downloading anything"
@@ -189,6 +195,21 @@ archive-clips:
 
 check-clip-archives:
 	@"$$(command -v uv)" run python -m scripts.archive_clips check
+
+site-archive-discover:
+	@"$$(command -v uv)" run python -m scripts.site_archive discover
+
+site-archive-verify:
+	@"$$(command -v uv)" run python -m scripts.site_archive verify
+
+site-archive-capture:
+	@"$$(command -v uv)" run python -m scripts.site_archive capture
+
+site-archive-sync:
+	@"$$(command -v uv)" run python -m scripts.site_archive sync
+
+site-archive-report:
+	@"$$(command -v uv)" run python -m scripts.site_archive report
 
 preservation-inventory:
 	@"$$(command -v uv)" run python -m scripts.preservation_inventory $(if $(ARCHIVE_ROOT),--archive-root "$(ARCHIVE_ROOT)",)

--- a/README.md
+++ b/README.md
@@ -166,6 +166,25 @@ does not need an archive root, credentials, a network connection, or a media
 download. Its output names the exact clip, talk, or post location and the next
 Wayback, local-backup, checksum, and private-R2 action.
 
+## Site archive coverage
+
+The separate site archive tool inventories public palewi.re pages, including
+talk pages, hosted HTML decks, and same-site documentation. It checks Wayback
+before requesting missing captures and saves partial progress between runs:
+
+```bash
+make bake
+uv run python -m scripts.site_archive sync --lookup-only
+make site-archive-report
+```
+
+The weekly **Site archive** workflow saves its manifest on the
+`site-archive-data` branch without redeploying the site. Existing snapshots
+are sufficient; it does not recapture pages just because they are old.
+See [the site archive runbook](docs/site-archive.md) for credentials, manual
+captures, incomplete discovery, and recovery. A page snapshot does not
+guarantee that embedded media or interactive features have been preserved.
+
 ## Media archive (audio/video backup)
 
 `scripts/media_archive/` finds every playable audio/video source referenced

--- a/docs/preservation.md
+++ b/docs/preservation.md
@@ -2,6 +2,12 @@
 
 ## Purpose and boundaries
 
+For palewi.re's own public pages, use the separate
+[site archive workflow](site-archive.md). It includes same-site documentation
+and HTML slide decks, keeps a durable manifest on `site-archive-data`, and
+requests missing Wayback captures. Its coverage report is separate from the
+external-content inventory below, and it is not a replacement for media backup.
+
 The preservation inventory is a local, network-free view of two separate
 systems:
 

--- a/docs/site-archive.md
+++ b/docs/site-archive.md
@@ -1,0 +1,120 @@
+# Site archive
+
+The site archive is a small, resumable inventory of public `palewi.re` HTML
+pages and their Internet Archive availability. It is deliberately separate
+from deployment and required CI. The durable source of truth is
+`manifest.json` on the `site-archive-data` branch; the workflow also uploads
+each run's manifest, state token, and report as a recovery artifact.
+
+## Local commands
+
+The default manifest is `.site-archive/manifest.json`. Build the site first
+when using discovery (`make bake`).
+
+```sh
+uv run python -m scripts.site_archive discover \
+  --manifest .site-archive/manifest.json --build-dir dist
+uv run python -m scripts.site_archive verify \
+  --manifest .site-archive/manifest.json --max-checks 100
+uv run python -m scripts.site_archive capture \
+  --manifest .site-archive/manifest.json --max-captures 10
+uv run python -m scripts.site_archive report \
+  --manifest .site-archive/manifest.json
+uv run python -m scripts.site_archive sync \
+  --manifest .site-archive/manifest.json --max-pages 100 \
+  --max-checks 100 --max-captures 10 --max-seconds 900
+```
+
+The corresponding convenience targets are
+`make site-archive-discover`, `make site-archive-verify`,
+`make site-archive-capture`, `make site-archive-sync`, and
+`make site-archive-report`. Add `--lookup-only` to `sync` when no capture
+requests are allowed; lookup-only verification does not need Save Page Now
+credentials.
+
+Before submitting a capture, the tool checks that the page still serves public
+HTML and checks Wayback again. It saves the pending request before contacting
+the capture service, so an interrupted response does not lead to an immediate
+duplicate submission.
+
+## Durable branch persistence
+
+The branch commands use the authenticated `gh` CLI and never check out or
+modify another worktree:
+
+```sh
+uv run python -m scripts.site_archive.branch fetch \
+  --path .site-archive/manifest.json \
+  --state-token .site-archive/state-token.json
+uv run python -m scripts.site_archive.branch push \
+  --path .site-archive/manifest.json \
+  --state-token .site-archive/state-token.json
+```
+
+Only the `site-archive-data` branch is accepted; the repository defaults to
+`palewire/palewi.re`. `fetch` records the exact commit head in the state token. A genuinely absent
+branch produces an explicit missing token and a validated empty manifest.
+Permission, authentication, malformed-response, and other API failures are not interpreted
+as an absent branch.
+
+`push` refuses a branch that changed after `fetch`. The first write creates an
+orphan commit containing only `manifest.json`; later writes are non-forced
+updates with the fetched commit as parent. The commit carries the required
+Copilot App co-author trailer. Identical manifest bytes do not create an empty
+commit. A failed write leaves the local manifest untouched. Never force-push,
+delete, or manually edit the data branch. If a run has a stale token, fetch
+again and reconcile the local work before retrying.
+
+The workflow needs `contents: read` to fetch state and `contents: write` only
+for the persistence job. Scheduled and manual runs are serialized so archive
+writers cannot race each other. Configure
+`SAVEPAGENOW_ACCESS_KEY` and `SAVEPAGENOW_SECRET_KEY` as repository or
+environment secrets before enabling authenticated capture runs. They are
+available only to the archive job and are never printed or written to state.
+
+If the workflow fails after archive work, download its recovery artifact. Keep
+the manifest and token together, inspect the report, and use a fresh `fetch`
+before reconciling and pushing; do not force-push an artifact over a newer
+branch head. Fetch into a fresh local directory so the recovery copy is not
+overwritten. Reconcile its page records with the latest manifest, then push
+using the newly fetched token.
+
+After these code changes reach `main`, the weekly job runs on Mondays at
+06:17 UTC. For the first run, use **Run workflow** with **lookup_only** enabled
+to inspect the inventory without requesting captures. Then allow a small
+authenticated run and inspect its pending confirmations before increasing
+the capture limit. Local lookup-only commands work without credentials;
+authenticated local commands require both Save Page Now variables in the
+environment, or the worktree `.env` when using Make.
+
+## Reading results and limitations
+
+`unknown` means no archive lookup has completed, `missing` means a lookup
+confirmed no snapshot, `pending` means a capture request awaits independent
+confirmation, `archived` means a confirmed snapshot exists, and `blocked`
+means capture is not currently possible. Service failures and malformed
+responses are recorded as errors, not converted to `missing`; routine backlog
+is different from an outage or configuration failure.
+
+Discovery starts with the production build, the live sitemap, internal links,
+and same-site documentation catalogs. Public documentation navigation is
+followed when a sitemap is absent or unavailable. A docs sitemap returning
+403, 404, or 410 is reported as an optional discovery gap so navigation can
+continue; other discovery and service errors fail the run and remain visible
+in the report. A docs site published by another repository may still have
+unlinked pages that cannot be proven discoverable without that publisher's
+complete inventory. Interrupted scans keep their queue and known URLs for a
+later run.
+
+A blocked page is not submitted again automatically. Resolve the stated
+restriction first. To retry, fetch into a fresh directory, change that page's
+`archive_status` to `unknown`, and clear `last_error` and `next_retry_at` in the
+local manifest. Run verification before requesting another capture and push
+the resulting state with its fetched token. Never mark a page archived without
+confirmed snapshot evidence.
+
+A confirmed HTML snapshot does **not** guarantee that JavaScript applications,
+images, fonts, embedded video, downloadable PDFs, or other media will replay.
+Use the separate media-preservation tooling for audio and video. This project
+reuses any confirmed successful snapshot and does not refresh captures merely
+because a newer one might exist.

--- a/scripts/site_archive/__init__.py
+++ b/scripts/site_archive/__init__.py
@@ -1,0 +1,1 @@
+"""Check and maintain Wayback coverage of public palewi.re pages."""

--- a/scripts/site_archive/__main__.py
+++ b/scripts/site_archive/__main__.py
@@ -1,0 +1,5 @@
+"""Run the public-site archive command."""
+
+from scripts.site_archive.cli import cli
+
+cli()

--- a/scripts/site_archive/branch.py
+++ b/scripts/site_archive/branch.py
@@ -1,0 +1,805 @@
+"""Persist the site archive manifest on a dedicated Git branch."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import re
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+import click
+
+from scripts.site_archive.manifest import ArchiveError, Manifest, ManifestStore
+
+DEFAULT_REPOSITORY = "palewire/palewi.re"
+DEFAULT_BRANCH = "site-archive-data"
+REMOTE_MANIFEST = "manifest.json"
+COAUTHOR = "Copilot App <223556219+Copilot@users.noreply.github.com>"
+GH_TIMEOUT_SECONDS = 60
+_SHA = re.compile(r"^[0-9a-fA-F]{40}$")
+_REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+class BranchPersistenceError(RuntimeError):
+    """Raised when GitHub cannot safely read or update archive state."""
+
+
+@dataclass(frozen=True)
+class BranchToken:
+    """The immutable branch head observed by a fetch."""
+
+    repository: str
+    branch: str
+    head: str | None
+
+    @property
+    def missing(self) -> bool:
+        """Return whether the branch did not exist at fetch time.
+
+        Returns:
+            True for a token representing an absent branch.
+
+        Examples:
+            ``BranchToken("owner/repo", DEFAULT_BRANCH, None).missing`` is True.
+        """
+        return self.head is None
+
+
+@dataclass(frozen=True)
+class ApiResponse:
+    """The decoded JSON response and HTTP status returned by ``gh``."""
+
+    value: Any
+    status: int | None
+
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+class GitHubClient:
+    """Small GitHub REST client backed by the installed ``gh`` executable."""
+
+    def __init__(self, repository: str, runner: Runner | None = None):
+        """Create a client for one repository.
+
+        Args:
+            repository: ``owner/name`` repository identifier.
+            runner: Injectable subprocess runner used by tests.
+
+        Returns:
+            None.
+
+        Raises:
+            BranchPersistenceError: If the repository name is unsafe.
+
+        Examples:
+            ``GitHubClient(DEFAULT_REPOSITORY)`` uses the authenticated ``gh`` CLI.
+        """
+        validate_repository(repository)
+        self.repository = repository
+        self.runner = runner or subprocess.run
+
+    def request(self, endpoint: str, *, method: str = "GET", payload: dict[str, Any] | None = None) -> ApiResponse:
+        """Call a GitHub REST endpoint without interpolating JSON in a shell.
+
+        Args:
+            endpoint: Repository-relative API endpoint.
+            method: HTTP method.
+            payload: Optional JSON request body sent over standard input.
+
+        Returns:
+            Decoded response and the HTTP status when ``gh`` reported one.
+
+        Raises:
+            BranchPersistenceError: If ``gh`` is unavailable or the API rejects the request.
+
+        Examples:
+            ``client.request("git/ref/heads/site-archive-data")`` gets a ref.
+        """
+        if endpoint.startswith(("/", "-")) or any(part in endpoint for part in ("\x00", "\n", "\r")):
+            raise BranchPersistenceError("unsafe GitHub API endpoint")
+        api_endpoint = f"repos/{self.repository}" if not endpoint else f"repos/{self.repository}/{endpoint}"
+        command = ["gh", "api", api_endpoint, "--method", method]
+        stdin = None if payload is None else json.dumps(payload, separators=(",", ":"))
+        if payload is not None:
+            command.extend(["--input", "-"])
+        try:
+            result = self.runner(
+                command,
+                input=stdin,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=GH_TIMEOUT_SECONDS,
+            )
+        except OSError as error:
+            raise BranchPersistenceError(f"unable to run gh: {error}") from error
+        except subprocess.TimeoutExpired as error:
+            raise BranchPersistenceError(f"gh timed out after {GH_TIMEOUT_SECONDS} seconds") from error
+        if result.returncode != 0:
+            status = _response_status(result.stderr)
+            detail = _safe_error(result.stderr or result.stdout)
+            raise GitHubRequestError(detail, status)
+        try:
+            value = json.loads(result.stdout) if result.stdout else {}
+        except json.JSONDecodeError as error:
+            raise BranchPersistenceError("GitHub returned invalid JSON") from error
+        return ApiResponse(value, _response_status(result.stderr))
+
+    def repository_exists(self) -> None:
+        """Confirm that the repository is reachable before interpreting a missing ref.
+
+        Returns:
+            None.
+
+        Raises:
+            BranchPersistenceError: If the repository cannot be read.
+
+        Examples:
+            ``client.repository_exists()`` distinguishes a missing branch from a missing repository.
+        """
+        try:
+            self.request("")
+        except GitHubRequestError as error:
+            raise BranchPersistenceError(f"cannot access repository {self.repository}: {error}") from error
+
+    def ref(self, branch: str) -> str | None:
+        """Read a branch head, returning ``None`` only for a genuine absent ref.
+
+        Args:
+            branch: Validated branch name.
+
+        Returns:
+            Forty-character commit SHA, or ``None`` when the ref is absent.
+
+        Raises:
+            BranchPersistenceError: If the ref request fails for another reason.
+
+        Examples:
+            ``client.ref(DEFAULT_BRANCH)`` returns the current immutable head.
+        """
+        try:
+            response = self.request(f"git/ref/heads/{quote(branch, safe='')}")
+        except GitHubRequestError as error:
+            if error.status == 404:
+                return None
+            raise BranchPersistenceError(f"cannot read branch {branch}: {error}") from error
+        try:
+            sha = response.value["object"]["sha"]
+        except (KeyError, TypeError) as error:
+            raise BranchPersistenceError("GitHub returned a malformed branch ref") from error
+        if not isinstance(sha, str) or not _SHA.fullmatch(sha):
+            raise BranchPersistenceError("GitHub returned an invalid branch head")
+        return sha
+
+    def manifest(self, head: str) -> bytes:
+        """Read the manifest through an immutable commit ref.
+
+        Args:
+            head: Commit SHA to read.
+
+        Returns:
+            UTF-8 manifest bytes.
+
+        Raises:
+            BranchPersistenceError: If the file is absent, malformed, or unreadable.
+
+        Examples:
+            ``client.manifest(head)`` reads exactly the file at that commit.
+        """
+        try:
+            response = self.request(f"contents/{REMOTE_MANIFEST}?ref={quote(head, safe='')}")
+        except GitHubRequestError as error:
+            raise BranchPersistenceError(f"cannot read {REMOTE_MANIFEST} at {head}: {error}") from error
+        value = response.value
+        if not isinstance(value, dict):
+            raise BranchPersistenceError(f"GitHub returned no usable {REMOTE_MANIFEST}")
+        if value.get("encoding") == "none" and isinstance(value.get("sha"), str):
+            return self.blob(value["sha"])
+        if value.get("encoding") != "base64" or not isinstance(value.get("content"), str):
+            raise BranchPersistenceError(f"GitHub returned no usable {REMOTE_MANIFEST}")
+        try:
+            encoded = "".join(value["content"].split())
+            return base64.b64decode(encoded, validate=True)
+        except (binascii.Error, ValueError) as error:
+            raise BranchPersistenceError(f"GitHub returned invalid {REMOTE_MANIFEST} content") from error
+
+    def blob(self, sha: str) -> bytes:
+        """Read an immutable Git blob by SHA.
+
+        Args:
+            sha: Blob SHA returned by the contents endpoint.
+
+        Returns:
+            Decoded blob bytes.
+
+        Raises:
+            BranchPersistenceError: If the blob response is malformed or unreadable.
+
+        Examples:
+            ``client.blob("a" * 40)`` reads a large manifest without a contents-size limit.
+        """
+        if not _SHA.fullmatch(sha):
+            raise BranchPersistenceError("GitHub returned an invalid manifest blob SHA")
+        try:
+            response = self.request(f"git/blobs/{quote(sha, safe='')}")
+        except GitHubRequestError as error:
+            raise BranchPersistenceError(f"cannot read manifest blob {sha}: {error}") from error
+        value = response.value
+        if (
+            not isinstance(value, dict)
+            or value.get("encoding") != "base64"
+            or not isinstance(value.get("content"), str)
+        ):
+            raise BranchPersistenceError("GitHub returned no usable manifest blob")
+        try:
+            return base64.b64decode("".join(value["content"].split()), validate=True)
+        except (binascii.Error, ValueError) as error:
+            raise BranchPersistenceError("GitHub returned invalid manifest blob content") from error
+
+    def commit_tree(self, head: str) -> str:
+        """Read the tree SHA used as the base for an existing-branch update.
+
+        Args:
+            head: Parent commit SHA.
+
+        Returns:
+            Tree SHA.
+
+        Raises:
+            BranchPersistenceError: If the commit response is malformed.
+
+        Examples:
+            ``client.commit_tree(head)`` supplies ``base_tree`` for a child commit.
+        """
+        try:
+            response = self.request(f"git/commits/{quote(head, safe='')}")
+            tree = response.value["tree"]["sha"]
+        except (GitHubRequestError, KeyError, TypeError) as error:
+            raise BranchPersistenceError(f"cannot read commit tree for {head}") from error
+        if not isinstance(tree, str) or not _SHA.fullmatch(tree):
+            raise BranchPersistenceError("GitHub returned an invalid commit tree")
+        return tree
+
+    def create_blob(self, content: bytes) -> str:
+        """Create a UTF-8 blob through the Git database API.
+
+        Args:
+            content: Manifest bytes.
+
+        Returns:
+            New blob SHA.
+
+        Raises:
+            BranchPersistenceError: If GitHub rejects the blob.
+
+        Examples:
+            ``client.create_blob(b"{}")`` returns a blob identifier.
+        """
+        try:
+            response = self.request(
+                "git/blobs",
+                method="POST",
+                payload={"content": content.decode("utf-8"), "encoding": "utf-8"},
+            )
+            sha = response.value["sha"]
+        except (UnicodeDecodeError, GitHubRequestError, KeyError, TypeError) as error:
+            raise BranchPersistenceError("cannot create manifest blob") from error
+        return _require_sha(sha, "blob")
+
+    def create_tree(self, blob: str, base_tree: str | None) -> str:
+        """Create a tree containing only the manifest file.
+
+        Args:
+            blob: Manifest blob SHA.
+            base_tree: Existing tree SHA, or ``None`` for an orphan commit.
+
+        Returns:
+            New tree SHA.
+
+        Raises:
+            BranchPersistenceError: If GitHub rejects the tree.
+
+        Examples:
+            ``client.create_tree(blob, None)`` creates an orphan single-file tree.
+        """
+        payload: dict[str, Any] = {"tree": [{"path": REMOTE_MANIFEST, "mode": "100644", "type": "blob", "sha": blob}]}
+        if base_tree is not None:
+            payload["base_tree"] = base_tree
+        try:
+            response = self.request("git/trees", method="POST", payload=payload)
+            sha = response.value["sha"]
+        except (GitHubRequestError, KeyError, TypeError) as error:
+            raise BranchPersistenceError("cannot create manifest tree") from error
+        return _require_sha(sha, "tree")
+
+    def create_commit(self, tree: str, parent: str | None) -> str:
+        """Create a commit with the required co-author trailer.
+
+        Args:
+            tree: New tree SHA.
+            parent: Parent commit SHA, or ``None`` for an orphan.
+
+        Returns:
+            New commit SHA.
+
+        Raises:
+            BranchPersistenceError: If GitHub rejects the commit.
+
+        Examples:
+            ``client.create_commit(tree, None)`` creates the initial data commit.
+        """
+        payload: dict[str, Any] = {
+            "message": f"Update site archive manifest\n\nCo-authored-by: {COAUTHOR}",
+            "tree": tree,
+            "parents": [] if parent is None else [parent],
+        }
+        try:
+            response = self.request("git/commits", method="POST", payload=payload)
+            sha = response.value["sha"]
+        except (GitHubRequestError, KeyError, TypeError) as error:
+            raise BranchPersistenceError("cannot create manifest commit") from error
+        return _require_sha(sha, "commit")
+
+    def update_ref(self, branch: str, commit: str, *, create: bool) -> None:
+        """Create or update the data ref without force pushing.
+
+        Args:
+            branch: Validated data branch.
+            commit: New commit SHA.
+            create: Whether this is the initial ref creation.
+
+        Returns:
+            None.
+
+        Raises:
+            BranchPersistenceError: If GitHub rejects the ref update.
+
+        Examples:
+            ``client.update_ref(DEFAULT_BRANCH, commit, create=True)`` creates a new ref.
+        """
+        method = "POST" if create else "PATCH"
+        endpoint = "git/refs" if create else f"git/refs/heads/{quote(branch, safe='')}"
+        payload: dict[str, Any] = {"sha": commit}
+        if create:
+            payload["ref"] = f"refs/heads/{branch}"
+        else:
+            payload["force"] = False
+        try:
+            self.request(endpoint, method=method, payload=payload)
+        except GitHubRequestError as error:
+            raise BranchPersistenceError(
+                f"cannot {'create' if create else 'update'} branch {branch}: {error}"
+            ) from error
+
+
+class GitHubRequestError(BranchPersistenceError):
+    """A GitHub API failure with an optional HTTP status."""
+
+    def __init__(self, detail: str, status: int | None):
+        """Create an API error.
+
+        Args:
+            detail: Sanitized command error text.
+            status: Parsed HTTP status, if available.
+
+        Returns:
+            None.
+
+        Examples:
+            ``GitHubRequestError("forbidden", 403)`` describes a permission failure.
+        """
+        super().__init__(detail)
+        self.status = status
+
+
+def validate_repository(repository: str) -> str:
+    """Validate an owner/name repository identifier.
+
+    Args:
+        repository: Candidate repository identifier.
+
+    Returns:
+        The unchanged validated identifier.
+
+    Raises:
+        BranchPersistenceError: If the value could inject an API path.
+
+    Examples:
+        ``validate_repository(DEFAULT_REPOSITORY)`` returns the default repository.
+    """
+    if not isinstance(repository, str) or not _REPOSITORY.fullmatch(repository):
+        raise BranchPersistenceError("repository must be an owner/name identifier")
+    return repository
+
+
+def validate_branch(branch: str) -> str:
+    """Require the one branch reserved for archive persistence.
+
+    Args:
+        branch: Candidate branch name.
+
+    Returns:
+        The unchanged validated branch.
+
+    Raises:
+        BranchPersistenceError: If a different branch is requested.
+
+    Examples:
+        ``validate_branch(DEFAULT_BRANCH)`` returns ``site-archive-data``.
+    """
+    if branch != DEFAULT_BRANCH:
+        raise BranchPersistenceError(f"branch must be {DEFAULT_BRANCH}")
+    return branch
+
+
+def _require_sha(value: Any, label: str) -> str:
+    """Validate a Git object identifier returned by the API.
+
+    Args:
+        value: API value to inspect.
+        label: Object type used in the error.
+
+    Returns:
+        The validated SHA.
+
+    Raises:
+        BranchPersistenceError: If the value is not a full SHA.
+
+    Examples:
+        ``_require_sha("a" * 40, "blob")`` returns the blob SHA.
+    """
+    if not isinstance(value, str) or not _SHA.fullmatch(value):
+        raise BranchPersistenceError(f"GitHub returned an invalid {label} SHA")
+    return value
+
+
+def _response_status(text: str) -> int | None:
+    """Extract an HTTP status from a diagnostic emitted by ``gh``.
+
+    Args:
+        text: ``gh`` diagnostic text.
+
+    Returns:
+        Parsed status code, or ``None`` when no status is present.
+
+    Examples:
+        ``_response_status("HTTP 404")`` returns ``404``.
+    """
+    match = re.search(r"\bHTTP(?:/[\d.]+)?\s+(\d{3})\b|\bHTTP\s+(\d{3})\b", text or "", re.IGNORECASE)
+    if not match:
+        return None
+    return int(match.group(1) or match.group(2))
+
+
+def _safe_error(text: str) -> str:
+    """Keep ``gh`` diagnostics concise and avoid accidentally echoing credentials.
+
+    Args:
+        text: Standard error or output from ``gh``.
+
+    Returns:
+        A single-line diagnostic.
+
+    Examples:
+        ``_safe_error("gh: Not Found\\n")`` returns ``"gh: Not Found"``.
+    """
+    value = " ".join(text.split())
+    return value[:500] or "GitHub API request failed"
+
+
+def _write_token(path: Path, token: BranchToken) -> None:
+    """Atomically save a fetch token.
+
+    Args:
+        path: Token file destination.
+        token: Observed branch state.
+
+    Returns:
+        None.
+
+    Raises:
+        BranchPersistenceError: If the token cannot be written.
+
+    Examples:
+        ``_write_token(Path("state-token.json"), token)`` checkpoints a head.
+    """
+    value = {"repository": token.repository, "branch": token.branch, "missing": token.missing, "head": token.head}
+    temporary = path.with_name(f".{path.name}.tmp")
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary.write_text(json.dumps(value, sort_keys=True) + "\n", encoding="utf-8")
+        temporary.replace(path)
+    except OSError as error:
+        raise BranchPersistenceError(f"cannot write state token {path}: {error}") from error
+
+
+def _read_token(path: Path) -> BranchToken:
+    """Load and validate a state token before writing any remote objects.
+
+    Args:
+        path: Token file path.
+
+    Returns:
+        Validated token.
+
+    Raises:
+        BranchPersistenceError: If the token is missing or malformed.
+
+    Examples:
+        ``_read_token(Path("state-token.json"))`` returns the fetched branch head.
+    """
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise BranchPersistenceError(f"{path}: malformed state token") from error
+    if not isinstance(value, dict) or set(value) != {"repository", "branch", "missing", "head"}:
+        raise BranchPersistenceError(f"{path}: malformed state token")
+    repository = value["repository"]
+    branch = value["branch"]
+    missing = value["missing"]
+    head = value["head"]
+    try:
+        validate_repository(repository)
+        validate_branch(branch)
+    except (BranchPersistenceError, TypeError) as error:
+        raise BranchPersistenceError(f"{path}: malformed state token") from error
+    if type(missing) is not bool or missing != (head is None):
+        raise BranchPersistenceError(f"{path}: malformed state token")
+    if head is not None and (not isinstance(head, str) or not _SHA.fullmatch(head)):
+        raise BranchPersistenceError(f"{path}: malformed state token")
+    return BranchToken(repository, branch, head)
+
+
+def _validate_manifest(path: Path) -> bytes:
+    """Validate and read a local manifest without changing it.
+
+    Args:
+        path: Manifest path.
+
+    Returns:
+        Exact UTF-8 bytes to persist.
+
+    Raises:
+        BranchPersistenceError: If local state is absent, unreadable, or invalid.
+
+    Examples:
+        ``_validate_manifest(Path(".site-archive/manifest.json"))`` returns its bytes.
+    """
+    try:
+        ManifestStore(path).load()
+        return path.read_bytes()
+    except (ArchiveError, OSError) as error:
+        raise BranchPersistenceError(f"{path}: invalid local manifest: {error}") from error
+
+
+def _ensure_distinct_paths(path: Path, state_token: Path) -> None:
+    """Reject overlapping manifest and optimistic-lock state paths.
+
+    Args:
+        path: Manifest path.
+        state_token: State-token path.
+
+    Returns:
+        None.
+
+    Raises:
+        BranchPersistenceError: If both paths identify the same file.
+
+    Examples:
+        ``_ensure_distinct_paths(Path("manifest.json"), Path("state.json"))`` succeeds.
+    """
+    try:
+        same_path = path.resolve(strict=False) == state_token.resolve(strict=False)
+    except OSError as error:
+        raise BranchPersistenceError(f"cannot resolve local state paths: {error}") from error
+    if same_path:
+        raise BranchPersistenceError("manifest and state-token paths must be different")
+
+
+def fetch(path: Path, state_token: Path, repository: str = DEFAULT_REPOSITORY, branch: str = DEFAULT_BRANCH) -> None:
+    """Fetch the immutable branch state into local files.
+
+    Args:
+        path: Local manifest destination.
+        state_token: State-token destination.
+        repository: GitHub ``owner/name`` repository.
+        branch: Reserved data branch.
+
+    Returns:
+        None.
+
+    Raises:
+        BranchPersistenceError: If the branch or manifest is not safely readable.
+
+    Examples:
+        ``fetch(Path("manifest.json"), Path("state-token.json"))`` fetches current data.
+    """
+    validate_repository(repository)
+    validate_branch(branch)
+    _ensure_distinct_paths(path, state_token)
+    client = GitHubClient(repository)
+    client.repository_exists()
+    head = client.ref(branch)
+    token = BranchToken(repository, branch, head)
+    if head is None:
+        if path.exists():
+            raise BranchPersistenceError(
+                f"{path}: branch is absent but a local manifest exists; refusing to discard it"
+            )
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            ManifestStore(path).save(Manifest())
+        except (ArchiveError, OSError) as error:
+            raise BranchPersistenceError(f"{path}: unable to initialize empty manifest: {error}") from error
+        _write_token(state_token, token)
+        click.echo(f"Branch {branch} is absent; starting with no remote manifest.")
+        return
+    content = client.manifest(head)
+    if path.exists():
+        try:
+            local_content = path.read_bytes()
+        except OSError as error:
+            raise BranchPersistenceError(f"{path}: unable to inspect local manifest: {error}") from error
+        if local_content != content:
+            raise BranchPersistenceError(
+                f"{path}: local manifest differs from branch; fetch into a fresh path for reconciliation"
+            )
+    temporary = path.with_name(f".{path.name}.fetch.tmp")
+    try:
+        temporary.parent.mkdir(parents=True, exist_ok=True)
+        temporary.write_bytes(content)
+        ManifestStore(temporary).load()
+        temporary.replace(path)
+    except (ArchiveError, OSError) as error:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError as cleanup_error:
+            raise BranchPersistenceError(
+                f"remote manifest at {head} is invalid and temporary cleanup failed: {cleanup_error}"
+            ) from cleanup_error
+        raise BranchPersistenceError(f"remote manifest at {head} is invalid: {error}") from error
+    _write_token(state_token, token)
+    click.echo(f"Fetched {REMOTE_MANIFEST} at {head}.")
+
+
+def push(path: Path, state_token: Path, repository: str = DEFAULT_REPOSITORY, branch: str = DEFAULT_BRANCH) -> None:
+    """Publish local state with an optimistic, non-forced ref update.
+
+    Args:
+        path: Local manifest path.
+        state_token: Token produced by :func:`fetch`.
+        repository: GitHub ``owner/name`` repository.
+        branch: Reserved data branch.
+
+    Returns:
+        None. Identical bytes produce no commit.
+
+    Raises:
+        BranchPersistenceError: If state is stale, malformed, or GitHub rejects a write.
+
+    Examples:
+        ``push(Path("manifest.json"), Path("state-token.json"))`` persists one checkpoint.
+    """
+    validate_repository(repository)
+    validate_branch(branch)
+    _ensure_distinct_paths(path, state_token)
+    token = _read_token(state_token)
+    if token.repository != repository or token.branch != branch:
+        raise BranchPersistenceError("state token does not match repository or branch")
+    content = _validate_manifest(path)
+    client = GitHubClient(repository)
+    client.repository_exists()
+    current = client.ref(branch)
+    if current != token.head:
+        raise BranchPersistenceError("branch changed since fetch; refusing stale write")
+    if current is not None and client.manifest(current) == content:
+        click.echo(f"{REMOTE_MANIFEST} is unchanged at {current}; no commit created.")
+        return
+    parent = current
+    base_tree = None if parent is None else client.commit_tree(parent)
+    blob = client.create_blob(content)
+    tree = client.create_tree(blob, base_tree)
+    commit = client.create_commit(tree, parent)
+    client.update_ref(branch, commit, create=parent is None)
+    _write_token(state_token, BranchToken(repository, branch, commit))
+    click.echo(f"Persisted {REMOTE_MANIFEST} at {commit}.")
+
+
+def _branch_option(value: str) -> str:
+    """Validate the Click branch option.
+
+    Args:
+        value: User-supplied branch name.
+
+    Returns:
+        The validated branch name.
+
+    Raises:
+        click.BadParameter: If the user selected another branch.
+
+    Examples:
+        ``_branch_option(DEFAULT_BRANCH)`` returns the reserved branch.
+    """
+    try:
+        return validate_branch(value)
+    except BranchPersistenceError as error:
+        raise click.BadParameter(str(error)) from error
+
+
+@click.group()
+def cli() -> None:
+    """Fetch and persist the site archive data branch.
+
+    Returns:
+        None.
+
+    Examples:
+        ``uv run python -m scripts.site_archive.branch fetch --help`` lists options.
+    """
+
+
+@cli.command(name="fetch")
+@click.option("--path", type=click.Path(path_type=Path), required=True)
+@click.option("--state-token", type=click.Path(path_type=Path), required=True)
+@click.option("--repo", "repository", default=DEFAULT_REPOSITORY, show_default=True)
+@click.option(
+    "--branch", default=DEFAULT_BRANCH, show_default=True, callback=lambda _ctx, _param, value: _branch_option(value)
+)
+def fetch_command(path: Path, state_token: Path, repository: str, branch: str) -> None:
+    """Fetch the branch manifest and checkpoint its exact head.
+
+    Args:
+        path: Local manifest destination.
+        state_token: State-token destination.
+        repository: GitHub repository.
+        branch: Reserved persistence branch.
+
+    Returns:
+        None.
+
+    Examples:
+        ``... branch fetch --path manifest.json --state-token state.json``.
+    """
+    try:
+        fetch(path, state_token, repository, branch)
+    except BranchPersistenceError as error:
+        raise click.ClickException(str(error)) from error
+
+
+@cli.command(name="push")
+@click.option("--path", type=click.Path(path_type=Path), required=True)
+@click.option("--state-token", type=click.Path(path_type=Path), required=True)
+@click.option("--repo", "repository", default=DEFAULT_REPOSITORY, show_default=True)
+@click.option(
+    "--branch", default=DEFAULT_BRANCH, show_default=True, callback=lambda _ctx, _param, value: _branch_option(value)
+)
+def push_command(path: Path, state_token: Path, repository: str, branch: str) -> None:
+    """Persist the local manifest with a non-forced optimistic update.
+
+    Args:
+        path: Local manifest path.
+        state_token: Token created by ``fetch``.
+        repository: GitHub repository.
+        branch: Reserved persistence branch.
+
+    Returns:
+        None.
+
+    Examples:
+        ``... branch push --path manifest.json --state-token state.json``.
+    """
+    try:
+        push(path, state_token, repository, branch)
+    except BranchPersistenceError as error:
+        raise click.ClickException(str(error)) from error
+
+
+if __name__ == "__main__":
+    cli()

--- a/scripts/site_archive/cli.py
+++ b/scripts/site_archive/cli.py
@@ -1,0 +1,455 @@
+"""Commands for resumable public-page archive maintenance."""
+
+from __future__ import annotations
+
+import time
+from collections import Counter
+from datetime import UTC, datetime
+from pathlib import Path
+
+import click
+import requests
+
+from scripts.site_archive.discovery import PageDiscovery, build_seeds
+from scripts.site_archive.manifest import ArchiveError, Manifest, ManifestStore, PageRecord, utc_now
+from scripts.site_archive.wayback import WaybackClient
+
+DEFAULT_MANIFEST = Path(".site-archive/manifest.json")
+
+
+def report_text(manifest: Manifest) -> str:
+    """Summarize known coverage without hiding unfinished discovery or errors.
+
+    Args:
+        manifest: Archive and discovery state to summarize.
+
+    Returns:
+        A Markdown report suitable for a terminal or Actions summary.
+
+    Examples:
+        ``print(report_text(Manifest()))`` displays an empty inventory.
+    """
+    pages = list(manifest.pages.values())
+    active = [page for page in pages if page.live_status != "redirect"]
+    counts = Counter(page.archive_status for page in active)
+    live_counts = Counter(page.live_status for page in pages)
+    errors = [page for page in active if page.last_check_status == "error"]
+    lines = [
+        "# Site archive coverage",
+        "",
+        "| Result | Pages |",
+        "| --- | ---: |",
+        f"| Known page URLs (excluding redirects) | {len(active)} |",
+        f"| Confirmed archives | {counts['archived']} |",
+        f"| Missing archives | {counts['missing']} |",
+        f"| Pending capture confirmations | {counts['pending']} |",
+        f"| Blocked captures | {counts['blocked']} |",
+        f"| Not yet checked | {counts['unknown']} |",
+        f"| Archive checks with errors | {len(errors)} |",
+        f"| Live HTML pages | {live_counts['live']} |",
+        f"| Live pages missing or unavailable | {live_counts['missing'] + live_counts['error']} |",
+        f"| Live pages not yet checked | {live_counts['unknown']} |",
+        f"| Redirect aliases (not separate pages) | {live_counts['redirect']} |",
+        f"| Discovery requests remaining | {len(manifest.discovery_queue)} |",
+        f"| Discovery problems | {len(manifest.discovery_errors)} |",
+        "",
+        f"Discovery sweep: {'finished without errors' if manifest.discovery_complete else 'unfinished or has gaps'}.",
+        "Confirmed archive counts retain earlier evidence when a newer check fails; inspect the errors below.",
+        "This inventory cannot prove coverage of unlinked pages published by other repositories.",
+        "A page snapshot does not guarantee preservation of scripts, images, embedded media, or downloads.",
+    ]
+    problems = [
+        *(f"{url}: {error}" for url, error in sorted(manifest.discovery_errors.items())),
+        *(f"{page.url}: {page.live_error}" for page in active if page.live_error),
+        *(
+            f"{page.url}: {page.last_error}"
+            for page in active
+            if page.last_error and (page.last_check_status == "error" or page.archive_status == "blocked")
+        ),
+    ]
+    problems = list(dict.fromkeys(problems))
+    if problems:
+        lines.extend(["", "## Problems", ""])
+        # Escape HTML so externally supplied error text cannot become summary markup.
+        for problem in problems[:50]:
+            lines.append(f"- {problem.replace('<', '&lt;').replace('>', '&gt;').replace(chr(10), ' ')}")
+        if len(problems) > 50:
+            lines.append(f"- {len(problems) - 50} more problems are recorded in the manifest.")
+    return "\n".join(lines) + "\n"
+
+
+def is_due(page: PageRecord) -> bool:
+    """Check whether a page is ready for another archive request.
+
+    Args:
+        page: Validated manifest record.
+
+    Returns:
+        True when no retry delay is active.
+
+    Examples:
+        ``is_due(PageRecord(url="https://palewi.re/posts/"))`` is True.
+    """
+    return not page.next_retry_at or datetime.fromisoformat(page.next_retry_at) <= datetime.now(UTC)
+
+
+class ArchiveRun:
+    """Coordinate discovery and archive requests with checkpointed progress."""
+
+    def __init__(self, path: Path):
+        """Load the manifest for a maintenance run.
+
+        Args:
+            path: Local manifest path.
+
+        Returns:
+            None.
+
+        Examples:
+            ``ArchiveRun(Path(".site-archive/manifest.json"))`` loads local state.
+        """
+        self.store = ManifestStore(path)
+        self.manifest = self.store.load()
+        self.failures: list[str] = []
+        self.wayback_failed = False
+
+    def verify(self, limit: int, deadline: float) -> None:
+        """Check live pages, prioritizing unknown state and older checks.
+
+        Args:
+            limit: Maximum page lookups.
+            deadline: Monotonic time at which to stop starting work.
+
+        Returns:
+            None. Updates and saves each attempted record.
+
+        Examples:
+            ``run.verify(10, time.monotonic() + 60)`` limits lookup work.
+        """
+        client = WaybackClient()
+        pages = sorted(
+            (
+                page
+                for page in self.manifest.pages.values()
+                if page.live_status == "live" and page.archive_status != "blocked" and is_due(page)
+            ),
+            key=lambda page: (bool(page.last_check_at), page.last_check_at, page.url),
+        )
+        for page in pages[:limit]:
+            if time.monotonic() >= deadline:
+                break
+            try:
+                client.verify(page)
+            except ArchiveError as error:
+                self.failures.append(f"{page.url}: {error}")
+            finally:
+                self.store.save(self.manifest)
+            # Stop this service batch rather than hammering an unavailable API.
+            if page.last_check_status == "error":
+                self.wayback_failed = True
+                break
+
+    def capture(self, limit: int, deadline: float) -> None:
+        """Request a limited number of missing page captures.
+
+        Args:
+            limit: Maximum capture candidates.
+            deadline: Monotonic time at which to stop starting work.
+
+        Returns:
+            None. Saves results, including failures, after each candidate.
+
+        Examples:
+            ``run.capture(1, time.monotonic() + 60)`` tries one missing page.
+        """
+        if self.wayback_failed:
+            click.echo("Skipping captures because Wayback lookups failed.")
+            return
+        client = WaybackClient(checkpoint=lambda: self.store.save(self.manifest))
+        pages = sorted(
+            (
+                page
+                for page in self.manifest.pages.values()
+                if page.live_status == "live" and page.archive_status == "missing" and is_due(page)
+            ),
+            key=lambda page: (page.last_submit_at, page.url),
+        )
+        for page in pages[:limit]:
+            if time.monotonic() >= deadline:
+                break
+            if not self.check_live(page):
+                break
+            failures_before = len(self.failures)
+            try:
+                client.capture(page)
+            except ArchiveError as error:
+                self.failures.append(f"{page.url}: {error}")
+            finally:
+                self.store.save(self.manifest)
+            if page.last_check_status == "error" or len(self.failures) > failures_before:
+                break
+
+    def check_live(self, page: PageRecord) -> bool:
+        """Confirm a queued page is still public HTML before submitting it.
+
+        Args:
+            page: Capture candidate whose earlier live check may be old.
+
+        Returns:
+            Whether the page currently serves successful HTML.
+
+        Examples:
+            A page removed since the previous run is not submitted to Wayback.
+        """
+        discovery = PageDiscovery(self.manifest, self.store)
+        try:
+            discovery.visit(page.url)
+        except (ArchiveError, requests.RequestException) as error:
+            page.live_status = "error"
+            page.live_checked_at = utc_now()
+            page.live_error = str(error)
+            self.manifest.discovery_errors[page.url] = str(error)
+            self.manifest.discovery_complete = False
+        finally:
+            discovery.session.close()
+            self.store.save(self.manifest)
+        if page.live_status != "live":
+            self.failures.append(f"{page.url}: capture deferred; live page is {page.live_status}")
+            return False
+        return True
+
+    def finish(self, summary: Path | None) -> None:
+        """Save progress and display a report before surfacing run failures.
+
+        Args:
+            summary: Optional Markdown report output path.
+
+        Returns:
+            None.
+
+        Raises:
+            ArchiveError: One or more requests failed during this run.
+
+        Examples:
+            ``run.finish(None)`` prints the report without writing a report file.
+        """
+        self.store.save(self.manifest)
+        text = report_text(self.manifest)
+        click.echo(text)
+        if summary:
+            summary.parent.mkdir(parents=True, exist_ok=True)
+            summary.write_text(text, encoding="utf-8")
+        if self.failures:
+            raise ArchiveError("\n".join(self.failures))
+
+
+@click.group()
+def cli() -> None:
+    """Discover, verify, capture, and report public-page archives.
+
+    \f
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        Run ``uv run python -m scripts.site_archive report``.
+    """
+
+
+@cli.command()
+@click.option("--manifest", type=click.Path(path_type=Path), default=DEFAULT_MANIFEST, show_default=True)
+def report(manifest: Path) -> None:
+    """Display saved archive state without making network requests.
+
+    \f
+    Args:
+        manifest: Local archive manifest.
+
+    Returns:
+        None.
+
+    Examples:
+        Run ``uv run python -m scripts.site_archive report``.
+    """
+    try:
+        click.echo(report_text(ManifestStore(manifest).load()))
+    except (ArchiveError, OSError) as error:
+        raise click.ClickException(str(error)) from error
+
+
+@cli.command()
+@click.option("--manifest", type=click.Path(path_type=Path), default=DEFAULT_MANIFEST, show_default=True)
+@click.option("--build-dir", type=click.Path(path_type=Path), default=Path("dist"), show_default=True)
+@click.option("--max-pages", type=click.IntRange(min=1), default=100, show_default=True)
+@click.option("--max-seconds", type=click.IntRange(min=1), default=900, show_default=True)
+@click.option("--summary", type=click.Path(path_type=Path))
+def discover(manifest: Path, build_dir: Path, max_pages: int, max_seconds: int, summary: Path | None) -> None:
+    """Find live pages without contacting the Internet Archive.
+
+    \f
+    Args:
+        manifest: Local state path.
+        build_dir: Existing static build.
+        max_pages: Maximum discovery requests.
+        max_seconds: Time budget in seconds.
+        summary: Optional report path.
+
+    Returns:
+        None.
+
+    Examples:
+        Run ``uv run python -m scripts.site_archive discover --max-pages 10``.
+    """
+    execute("discover", manifest, build_dir, max_pages, 0, 0, max_seconds, True, summary)
+
+
+@cli.command()
+@click.option("--manifest", type=click.Path(path_type=Path), default=DEFAULT_MANIFEST, show_default=True)
+@click.option("--max-checks", type=click.IntRange(min=1), default=100, show_default=True)
+@click.option("--max-seconds", type=click.IntRange(min=1), default=900, show_default=True)
+@click.option("--summary", type=click.Path(path_type=Path))
+def verify(manifest: Path, max_checks: int, max_seconds: int, summary: Path | None) -> None:
+    """Look up existing snapshots without requesting captures.
+
+    \f
+    Args:
+        manifest: Local state path.
+        max_checks: Maximum lookup candidates.
+        max_seconds: Time budget in seconds.
+        summary: Optional report path.
+
+    Returns:
+        None.
+
+    Examples:
+        Run ``uv run python -m scripts.site_archive verify --max-checks 10``.
+    """
+    execute("verify", manifest, Path("dist"), 0, max_checks, 0, max_seconds, True, summary)
+
+
+@cli.command()
+@click.option("--manifest", type=click.Path(path_type=Path), default=DEFAULT_MANIFEST, show_default=True)
+@click.option("--max-captures", type=click.IntRange(min=1), default=10, show_default=True)
+@click.option("--max-seconds", type=click.IntRange(min=1), default=900, show_default=True)
+@click.option("--summary", type=click.Path(path_type=Path))
+def capture(manifest: Path, max_captures: int, max_seconds: int, summary: Path | None) -> None:
+    """Request authenticated captures for pages confirmed missing.
+
+    \f
+    Args:
+        manifest: Local state path.
+        max_captures: Maximum capture candidates.
+        max_seconds: Time budget in seconds.
+        summary: Optional report path.
+
+    Returns:
+        None.
+
+    Examples:
+        Run ``uv run python -m scripts.site_archive capture --max-captures 1``.
+    """
+    execute("capture", manifest, Path("dist"), 0, 0, max_captures, max_seconds, False, summary)
+
+
+@cli.command()
+@click.option("--manifest", type=click.Path(path_type=Path), default=DEFAULT_MANIFEST, show_default=True)
+@click.option("--build-dir", type=click.Path(path_type=Path), default=Path("dist"), show_default=True)
+@click.option("--max-pages", type=click.IntRange(min=1), default=100, show_default=True)
+@click.option("--max-checks", type=click.IntRange(min=1), default=100, show_default=True)
+@click.option("--max-captures", type=click.IntRange(min=1), default=10, show_default=True)
+@click.option("--max-seconds", type=click.IntRange(min=1), default=900, show_default=True)
+@click.option("--lookup-only", is_flag=True, help="Never submit new capture requests.")
+@click.option("--summary", type=click.Path(path_type=Path))
+def sync(
+    manifest: Path,
+    build_dir: Path,
+    max_pages: int,
+    max_checks: int,
+    max_captures: int,
+    max_seconds: int,
+    lookup_only: bool,
+    summary: Path | None,
+) -> None:
+    """Discover pages, check snapshots, and optionally capture missing pages.
+
+    \f
+    Args:
+        manifest: Local state path.
+        build_dir: Existing static build.
+        max_pages: Maximum discovery requests.
+        max_checks: Maximum lookup candidates.
+        max_captures: Maximum capture candidates.
+        max_seconds: Shared time budget in seconds.
+        lookup_only: Whether to forbid capture requests.
+        summary: Optional report path.
+
+    Returns:
+        None.
+
+    Examples:
+        Run ``uv run python -m scripts.site_archive sync --lookup-only``.
+    """
+    execute("sync", manifest, build_dir, max_pages, max_checks, max_captures, max_seconds, lookup_only, summary)
+
+
+def execute(
+    action: str,
+    path: Path,
+    build_dir: Path,
+    max_pages: int,
+    max_checks: int,
+    max_captures: int,
+    max_seconds: int,
+    lookup_only: bool,
+    summary: Path | None,
+) -> None:
+    """Run selected phases and report even when a phase fails.
+
+    Args:
+        action: Command name selecting phases.
+        path: Local manifest path.
+        build_dir: Existing static build.
+        max_pages: Discovery request limit.
+        max_checks: Archive lookup limit.
+        max_captures: Capture candidate limit.
+        max_seconds: Total time budget.
+        lookup_only: Whether capture requests are forbidden.
+        summary: Optional report destination.
+
+    Returns:
+        None.
+
+    Raises:
+        click.ClickException: Input, persistence, or network work failed.
+
+    Examples:
+        Used by the Click commands rather than called directly.
+    """
+    try:
+        run = ArchiveRun(path)
+        start = time.monotonic()
+        deadline = start + max_seconds
+        try:
+            if action in {"discover", "sync"}:
+                discovery_deadline = start + max_seconds / 3 if action == "sync" else deadline
+                PageDiscovery(run.manifest, run.store).run(
+                    build_seeds(build_dir), limit=max_pages, deadline=discovery_deadline
+                )
+                run.failures.extend(
+                    f"{url}: {error}"
+                    for url, error in run.manifest.discovery_errors.items()
+                    if not (url.endswith("/sitemap.xml") and error in {"HTTP 403", "HTTP 404", "HTTP 410"})
+                )
+            if action in {"verify", "sync"}:
+                verify_deadline = start + max_seconds * 2 / 3 if action == "sync" and not lookup_only else deadline
+                run.verify(max_checks, verify_deadline)
+            if action in {"capture", "sync"} and not lookup_only:
+                run.capture(max_captures, deadline)
+        except ArchiveError as error:
+            run.failures.append(str(error))
+        run.finish(summary)
+    except (ArchiveError, OSError) as error:
+        raise click.ClickException(str(error)) from error

--- a/scripts/site_archive/discovery.py
+++ b/scripts/site_archive/discovery.py
@@ -1,0 +1,320 @@
+"""Discover public HTML pages without crawling outside palewi.re."""
+
+from __future__ import annotations
+
+import time
+import xml.etree.ElementTree as ElementTree
+from pathlib import Path
+from urllib.parse import unquote, urljoin, urlsplit, urlunsplit
+
+import requests
+
+from coltrane.content_loaders import load_docs
+from scripts.check_built_site import ERROR_PAGES, PageParser, public_url_for_page
+from scripts.site_archive.manifest import ArchiveError, Manifest, ManifestStore, utc_now
+
+ORIGIN = "https://palewi.re"
+USER_AGENT = "palewi.re archive inventory (https://github.com/palewire/palewi.re)"
+MAX_RESPONSE_BYTES = 5_000_000
+
+
+def normalize_url(value: str, base: str = f"{ORIGIN}/") -> str | None:
+    """Resolve a public same-site URL, excluding queries and unsafe paths.
+
+    Args:
+        value: Absolute URL or relative link.
+        base: Public page against which to resolve relative links.
+
+    Returns:
+        An HTTPS URL without a fragment, or None for an excluded link.
+
+    Examples:
+        >>> normalize_url("/posts/#latest")
+        'https://palewi.re/posts/'
+    """
+    try:
+        parsed = urlsplit(urljoin(base, value))
+        port = parsed.port
+    except ValueError:
+        return None
+    if (
+        parsed.scheme not in {"http", "https"}
+        or parsed.hostname not in {"palewi.re", "www.palewi.re"}
+        or parsed.username is not None
+        or parsed.password is not None
+        or port not in {None, 80 if parsed.scheme == "http" else 443}
+        or parsed.query
+        or any(character.isspace() or ord(character) < 32 for character in value)
+    ):
+        return None
+    path = parsed.path or "/"
+    decoded = unquote(path)
+    if "\\" in decoded or "//" in decoded or any(part in {".", ".."} for part in decoded.split("/")):
+        return None
+    return urlunsplit(("https", "palewi.re", path, "", ""))
+
+
+def is_page_url(url: str) -> bool:
+    """Distinguish public page links from downloads and operational endpoints.
+
+    Args:
+        url: Normalized public URL.
+
+    Returns:
+        Whether this URL is eligible for an HTML page check.
+
+    Examples:
+        >>> is_page_url("https://palewi.re/posts/")
+        True
+    """
+    path = urlsplit(url).path
+    if path in {"/", "/health/", "/404.html", "/500.html", "/search.html"}:
+        return False
+    if path.startswith(("/.well-known/", "/media/", "/feeds/")):
+        return False
+    if path.startswith("/static/") and not path.startswith("/static/talks/"):
+        return False
+    if any(part in {"_sources", "_static", "_downloads", "_app", "node_modules"} for part in path.split("/")):
+        return False
+    return Path(path).suffix.lower() in {"", ".html", ".htm"}
+
+
+def build_seeds(build_dir: Path) -> list[str]:
+    """Enumerate built pages and same-site documentation entrypoints.
+
+    Args:
+        build_dir: Existing Django Bakery output directory.
+
+    Returns:
+        Sorted unique expected pages and sitemap URLs.
+
+    Raises:
+        ArchiveError: The build is absent or contains no public HTML pages.
+
+    Examples:
+        Call ``build_seeds(Path("dist"))`` after ``make bake``.
+    """
+    if not build_dir.is_dir():
+        raise ArchiveError(f"{build_dir}: build directory is missing; run make bake")
+    urls: set[str] = set()
+    for path in build_dir.rglob("*.html"):
+        if path.name in ERROR_PAGES:
+            continue
+        relative = path.relative_to(build_dir).as_posix()
+        if relative.startswith("static/") and (not relative.startswith("static/talks/") or path.name != "index.html"):
+            continue
+        url = normalize_url(public_url_for_page(path, build_dir))
+        if url and is_page_url(url):
+            urls.add(url)
+    if not urls:
+        raise ArchiveError(f"{build_dir}: no public HTML pages found; run make bake")
+    for doc in load_docs():
+        url = normalize_url(doc.url)
+        if url and is_page_url(url):
+            urls.add(url)
+            urls.add(urljoin(url, "sitemap.xml"))
+    urls.add(f"{ORIGIN}/sitemap.xml")
+    return sorted(urls)
+
+
+class PageDiscovery:
+    """Traverse public pages and sitemaps with a persistent work queue."""
+
+    def __init__(self, manifest: Manifest, store: ManifestStore, *, timeout: float = 15, delay: float = 0.25):
+        """Configure one discovery run.
+
+        Args:
+            manifest: Mutable archive state.
+            store: Store used to checkpoint each result.
+            timeout: Per-request network timeout in seconds.
+            delay: Pause between requests in seconds.
+
+        Returns:
+            None.
+
+        Examples:
+            Use ``PageDiscovery(manifest, store).run(seeds, limit=100)``.
+        """
+        self.manifest = manifest
+        self.store = store
+        self.timeout = timeout
+        self.delay = delay
+        self.session = requests.Session()
+        self.session.headers["User-Agent"] = USER_AGENT
+
+    def enqueue(self, url: str) -> None:
+        """Queue a URL once during this discovery sweep.
+
+        Args:
+            url: Normalized same-site page or sitemap URL.
+
+        Returns:
+            None.
+
+        Examples:
+            ``discovery.enqueue("https://palewi.re/posts/")`` queues posts.
+        """
+        if url not in self.manifest.discovery_seen and url not in self.manifest.discovery_queue:
+            self.manifest.discovery_queue.append(url)
+            self.manifest.discovery_complete = False
+        if is_page_url(url):
+            self.manifest.page(url)
+
+    def run(self, seeds: list[str], *, limit: int = 100, deadline: float = float("inf")) -> int:
+        """Process a limited batch, retaining unfinished and failed work.
+
+        Args:
+            seeds: Expected build pages and public sitemap entrypoints.
+            limit: Maximum URLs to fetch.
+            deadline: Stop starting requests at this monotonic clock value.
+
+        Returns:
+            Number of URLs attempted.
+
+        Examples:
+            ``discovery.run(seeds, limit=10)`` handles at most ten URLs.
+        """
+        if not self.manifest.discovery_queue:
+            self.manifest.discovery_seen = []
+            self.manifest.discovery_errors = {}
+            self.manifest.discovery_started_at = utc_now()
+            # Revisit old pages too: a temporarily absent link must not erase them.
+            seeds = list(dict.fromkeys([*seeds, *self.manifest.pages]))
+        self.manifest.discovery_complete = False
+        for url in seeds:
+            self.enqueue(url)
+        attempted = 0
+        try:
+            while self.manifest.discovery_queue and attempted < limit and time.monotonic() < deadline:
+                url = self.manifest.discovery_queue[0]
+                defer = False
+                try:
+                    self.visit(url)
+                except (requests.RequestException, ArchiveError) as error:
+                    self.manifest.discovery_errors[url] = str(error)
+                    defer = isinstance(error, (requests.ConnectionError, requests.Timeout)) or (
+                        isinstance(error, requests.HTTPError)
+                        and error.response is not None
+                        and error.response.status_code in {429, 502, 503, 504}
+                    )
+                    if is_page_url(url):
+                        page = self.manifest.page(url)
+                        page.live_status = "error"
+                        page.live_checked_at = utc_now()
+                        page.live_error = str(error)
+                self.manifest.discovery_queue.pop(0)
+                if defer:
+                    self.manifest.discovery_queue.append(url)
+                else:
+                    self.manifest.discovery_seen.append(url)
+                attempted += 1
+                self.manifest.discovery_complete = (
+                    not self.manifest.discovery_queue and not self.manifest.discovery_errors
+                )
+                self.store.save(self.manifest)
+                if defer:
+                    break
+                if self.manifest.discovery_queue and attempted < limit and time.monotonic() < deadline:
+                    time.sleep(self.delay)
+        finally:
+            self.session.close()
+            self.store.save(self.manifest)
+        return attempted
+
+    def visit(self, url: str) -> None:
+        """Read one page without automatically following redirects.
+
+        Args:
+            url: Same-site URL selected from the queue.
+
+        Returns:
+            None. Updates page status and queues discovered links.
+
+        Raises:
+            ArchiveError: A response is invalid or too large.
+            requests.RequestException: The request fails.
+
+        Examples:
+            ``discovery.visit("https://palewi.re/posts/")`` reads its links.
+        """
+        page = self.manifest.page(url) if is_page_url(url) else None
+        if page:
+            page.live_checked_at = utc_now()
+            page.live_error = ""
+        with self.session.get(url, timeout=self.timeout, allow_redirects=False, stream=True) as response:
+            if response.status_code in {301, 302, 303, 307, 308}:
+                if page:
+                    page.live_status = "redirect"
+                destination = normalize_url(response.headers.get("Location", ""), url)
+                if not response.headers.get("Location"):
+                    raise ArchiveError(f"{url}: redirect has no Location")
+                if destination == url or destination in self.manifest.discovery_seen:
+                    if destination == url or (
+                        destination in self.manifest.pages
+                        and self.manifest.pages[destination].live_status == "redirect"
+                    ):
+                        raise ArchiveError(f"{url}: redirect cycle")
+                if destination and (is_page_url(destination) or destination.endswith(".xml")):
+                    self.enqueue(destination)
+                return
+            if response.status_code in {404, 410} or (response.status_code == 403 and url.endswith("/sitemap.xml")):
+                if page:
+                    page.live_status = "missing"
+                    page.live_error = f"Live page returned HTTP {response.status_code}"
+                self.manifest.discovery_errors[url] = f"HTTP {response.status_code}"
+                self.manifest.discovery_complete = False
+                return
+            response.raise_for_status()
+            content_type = response.headers.get("Content-Type", "").split(";")[0].strip().lower()
+            if content_type not in {"text/html", "application/xhtml+xml", "application/xml", "text/xml"}:
+                raise ArchiveError(f"{url}: expected HTML or sitemap XML, got {content_type!r}")
+            body = bytearray()
+            for chunk in response.iter_content(chunk_size=64_000):
+                body.extend(chunk)
+                if len(body) > MAX_RESPONSE_BYTES:
+                    raise ArchiveError(f"{url}: response exceeds {MAX_RESPONSE_BYTES} bytes")
+            if content_type in {"application/xml", "text/xml"}:
+                if page:
+                    raise ArchiveError(f"{url}: expected an HTML page, received XML")
+                self.read_sitemap(bytes(body), url)
+            else:
+                if not page:
+                    raise ArchiveError(f"{url}: expected a sitemap, received HTML")
+                page.live_status = "live"
+                parser = PageParser()
+                parser.feed(bytes(body).decode(response.encoding or "utf-8", errors="replace"))
+                for link in parser.links:
+                    destination = normalize_url(link.value, url)
+                    if link.tag == "a" and destination and is_page_url(destination):
+                        self.enqueue(destination)
+            self.manifest.discovery_errors.pop(url, None)
+
+    def read_sitemap(self, body: bytes, url: str) -> None:
+        """Read a sitemap index or URL set without visiting off-site entries.
+
+        Args:
+            body: Downloaded XML bytes.
+            url: Source sitemap URL.
+
+        Returns:
+            None. Adds same-site entries to the discovery queue.
+
+        Raises:
+            ArchiveError: XML is malformed or not a sitemap.
+
+        Examples:
+            ``discovery.read_sitemap(xml_bytes, sitemap_url)`` queues its URLs.
+        """
+        try:
+            root = ElementTree.fromstring(body)
+        except ElementTree.ParseError as error:
+            raise ArchiveError(f"{url}: malformed sitemap: {error}") from error
+        kind = root.tag.rsplit("}", 1)[-1]
+        if kind not in {"sitemapindex", "urlset"}:
+            raise ArchiveError(f"{url}: expected a sitemap index or URL set")
+        for element in root.iter():
+            if element.tag.rsplit("}", 1)[-1] != "loc" or not element.text:
+                continue
+            destination = normalize_url(element.text.strip(), url)
+            if destination and (is_page_url(destination) or kind == "sitemapindex"):
+                self.enqueue(destination)

--- a/scripts/site_archive/manifest.py
+++ b/scripts/site_archive/manifest.py
@@ -1,0 +1,494 @@
+"""Validated, durable state for public-page Wayback maintenance."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urlsplit, urlunsplit
+
+LIVE_STATUSES = {"unknown", "live", "missing", "redirect", "error"}
+ARCHIVE_STATUSES = {"unknown", "missing", "pending", "archived", "blocked"}
+CHECK_STATUSES = {"", "success", "error"}
+RECORD_FIELDS = {
+    "url",
+    "live_status",
+    "archive_status",
+    "archive_url",
+    "snapshot_at",
+    "last_check_at",
+    "last_check_status",
+    "last_verified_at",
+    "last_submit_at",
+    "pending_archive_url",
+    "attempts",
+    "next_retry_at",
+    "last_error",
+    "live_checked_at",
+    "live_error",
+}
+MANIFEST_FIELDS = {
+    "pages",
+    "discovery_queue",
+    "discovery_seen",
+    "discovery_errors",
+    "discovery_complete",
+    "discovery_started_at",
+}
+
+
+class ArchiveError(RuntimeError):
+    """Raised when archive state or an archive service response is invalid."""
+
+
+def utc_now() -> str:
+    """Return the current time as an ISO 8601 UTC string.
+
+    Returns:
+        Current UTC time with a ``Z`` suffix.
+
+    Examples:
+        ``utc_now().endswith("Z")`` is True.
+    """
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+@dataclass
+class PageRecord:
+    """Archive state for one normalized public page."""
+
+    url: str
+    live_status: str = "unknown"
+    archive_status: str = "unknown"
+    archive_url: str = ""
+    snapshot_at: str = ""
+    last_check_at: str = ""
+    last_check_status: str = ""
+    last_verified_at: str = ""
+    last_submit_at: str = ""
+    pending_archive_url: str = ""
+    attempts: int = 0
+    next_retry_at: str = ""
+    last_error: str = ""
+    live_checked_at: str = ""
+    live_error: str = ""
+
+
+@dataclass
+class Manifest:
+    """Persistent archive and discovery state."""
+
+    pages: dict[str, PageRecord] = field(default_factory=dict)
+    discovery_queue: list[str] = field(default_factory=list)
+    discovery_seen: list[str] = field(default_factory=list)
+    discovery_errors: dict[str, str] = field(default_factory=dict)
+    discovery_complete: bool = False
+    discovery_started_at: str = ""
+
+    def page(self, url: str) -> PageRecord:
+        """Get or create the record for a normalized public page.
+
+        Args:
+            url: Normalized ``https://palewi.re/`` page URL.
+
+        Returns:
+            The record held by this manifest.
+
+        Raises:
+            ArchiveError: The URL is outside the supported public scope.
+
+        Examples:
+            ``Manifest().page("https://palewi.re/posts/")`` creates a record.
+        """
+        _validate_page_url(url, "page URL")
+        if url not in self.pages:
+            self.pages[url] = PageRecord(url=url)
+        return self.pages[url]
+
+
+class ManifestStore:
+    """Read and atomically write validated archive manifests."""
+
+    def __init__(self, path: Path):
+        """Create a store for one JSON manifest.
+
+        Args:
+            path: Location of the JSON manifest.
+
+        Returns:
+            None.
+
+        Examples:
+            ``ManifestStore(Path(".site-archive/manifest.json"))``.
+        """
+        self.path = path
+
+    def load(self) -> Manifest:
+        """Load a manifest, returning an empty one only when it is absent.
+
+        Returns:
+            The validated saved manifest or an empty manifest.
+
+        Raises:
+            ArchiveError: JSON or manifest data is malformed.
+
+        Examples:
+            ``store.load().pages`` returns the saved page mapping.
+        """
+        if not self.path.exists() and not self.path.is_symlink():
+            return Manifest()
+        try:
+            value = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as error:
+            raise ArchiveError(f"{self.path}: invalid manifest JSON: {error}") from error
+        return _manifest_from_value(value, str(self.path))
+
+    def save(self, manifest: Manifest) -> None:
+        """Validate and atomically persist a manifest.
+
+        Args:
+            manifest: State to validate and write.
+
+        Returns:
+            None.
+
+        Raises:
+            ArchiveError: The manifest state is invalid.
+
+        Examples:
+            ``store.save(Manifest())`` writes an empty valid manifest.
+        """
+        value = _manifest_to_value(manifest)
+        _manifest_from_value(value, str(self.path))
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temporary_path = self.path.with_suffix(f"{self.path.suffix}.tmp")
+        try:
+            temporary_path.write_text(
+                json.dumps(value, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            temporary_path.replace(self.path)
+        except OSError as error:
+            raise ArchiveError(f"{self.path}: unable to save manifest: {error}") from error
+
+
+def _manifest_to_value(manifest: Manifest) -> dict[str, Any]:
+    """Convert a manifest into its sole supported JSON object shape.
+
+    Args:
+        manifest: Manifest instance to serialize.
+
+    Returns:
+        JSON-compatible state.
+
+    Examples:
+        ``_manifest_to_value(Manifest())["pages"]`` is an empty mapping.
+    """
+    if not isinstance(manifest, Manifest):
+        raise ArchiveError("manifest: expected a Manifest")
+    return {
+        "pages": {url: asdict(record) for url, record in manifest.pages.items()},
+        "discovery_queue": manifest.discovery_queue,
+        "discovery_seen": manifest.discovery_seen,
+        "discovery_errors": manifest.discovery_errors,
+        "discovery_complete": manifest.discovery_complete,
+        "discovery_started_at": manifest.discovery_started_at,
+    }
+
+
+def _manifest_from_value(value: Any, location: str) -> Manifest:
+    """Validate and construct a manifest from decoded JSON data.
+
+    Args:
+        value: Decoded JSON value.
+        location: Human-readable source path for errors.
+
+    Returns:
+        Fully validated manifest state.
+
+    Examples:
+        ``_manifest_from_value(data, "manifest.json")`` loads saved state.
+    """
+    if not isinstance(value, dict):
+        raise ArchiveError(f"{location}: manifest must be a JSON object")
+    _require_exact_fields(value, MANIFEST_FIELDS, location)
+    pages_value = value["pages"]
+    if not isinstance(pages_value, dict):
+        raise ArchiveError(f"{location}: pages must be an object")
+    pages: dict[str, PageRecord] = {}
+    for url, record_value in pages_value.items():
+        _validate_page_url(url, f"{location}: page key")
+        record = _record_from_value(record_value, f"{location}: page {url}")
+        if record.url != url:
+            raise ArchiveError(f"{location}: page key and record URL differ for {url}")
+        pages[url] = record
+    queue = _url_list(value["discovery_queue"], f"{location}: discovery_queue")
+    seen = _url_list(value["discovery_seen"], f"{location}: discovery_seen")
+    if len(set(queue)) != len(queue) or len(set(seen)) != len(seen):
+        raise ArchiveError(f"{location}: discovery queues cannot contain duplicate URLs")
+    if set(queue) & set(seen):
+        raise ArchiveError(f"{location}: a discovery URL cannot be queued and seen")
+    errors_value = value["discovery_errors"]
+    if not isinstance(errors_value, dict):
+        raise ArchiveError(f"{location}: discovery_errors must be an object")
+    errors: dict[str, str] = {}
+    for url, error in errors_value.items():
+        _validate_page_url(url, f"{location}: discovery error URL")
+        if not isinstance(error, str) or not error:
+            raise ArchiveError(f"{location}: discovery errors must be non-empty strings")
+        errors[url] = error
+    if type(value["discovery_complete"]) is not bool:
+        raise ArchiveError(f"{location}: discovery_complete must be a boolean")
+    if value["discovery_complete"] and (queue or errors):
+        raise ArchiveError(f"{location}: discovery cannot be complete with queued URLs or errors")
+    _validate_timestamp(value["discovery_started_at"], f"{location}: discovery_started_at")
+    return Manifest(
+        pages=pages,
+        discovery_queue=queue,
+        discovery_seen=seen,
+        discovery_errors=errors,
+        discovery_complete=value["discovery_complete"],
+        discovery_started_at=value["discovery_started_at"],
+    )
+
+
+def _record_from_value(value: Any, location: str) -> PageRecord:
+    """Validate and construct a page record from decoded JSON data.
+
+    Args:
+        value: Decoded page object.
+        location: Human-readable source location for errors.
+
+    Returns:
+        Fully validated page record.
+
+    Examples:
+        ``_record_from_value(data, "page")`` reads one saved page.
+    """
+    if not isinstance(value, dict):
+        raise ArchiveError(f"{location}: record must be an object")
+    _require_exact_fields(value, RECORD_FIELDS, location)
+    for field_name in ("url", "archive_url", "pending_archive_url", "last_error", "live_error"):
+        if not isinstance(value[field_name], str):
+            raise ArchiveError(f"{location}: {field_name} must be a string")
+    _validate_page_url(value["url"], f"{location}: url")
+    if not isinstance(value["live_status"], str) or value["live_status"] not in LIVE_STATUSES:
+        raise ArchiveError(f"{location}: invalid live_status")
+    if not isinstance(value["archive_status"], str) or value["archive_status"] not in ARCHIVE_STATUSES:
+        raise ArchiveError(f"{location}: invalid archive_status")
+    if not isinstance(value["last_check_status"], str) or value["last_check_status"] not in CHECK_STATUSES:
+        raise ArchiveError(f"{location}: invalid last_check_status")
+    if type(value["attempts"]) is not int or value["attempts"] < 0:
+        raise ArchiveError(f"{location}: attempts must be a non-negative integer")
+    for field_name in (
+        "last_check_at",
+        "last_verified_at",
+        "last_submit_at",
+        "next_retry_at",
+        "live_checked_at",
+    ):
+        _validate_timestamp(value[field_name], f"{location}: {field_name}")
+    _validate_snapshot_url(value["archive_url"], f"{location}: archive_url", value["url"])
+    _validate_snapshot_url(value["pending_archive_url"], f"{location}: pending_archive_url", value["url"])
+    if not isinstance(value["snapshot_at"], str):
+        raise ArchiveError(f"{location}: snapshot_at must be a string")
+    if value["snapshot_at"]:
+        _validate_wayback_timestamp(value["snapshot_at"], f"{location}: snapshot_at")
+    if value["archive_status"] == "archived" and (
+        not value["archive_url"] or not value["snapshot_at"] or not value["last_verified_at"]
+    ):
+        raise ArchiveError(f"{location}: archived records require archive_url, snapshot_at, and last_verified_at")
+    if value["archive_status"] == "pending" and not value["last_submit_at"]:
+        raise ArchiveError(f"{location}: pending records require last_submit_at")
+    if value["archive_url"] and value["snapshot_at"]:
+        snapshot_timestamp = urlsplit(value["archive_url"]).path.split("/")[2][:14]
+        if snapshot_timestamp != value["snapshot_at"]:
+            raise ArchiveError(f"{location}: snapshot_at does not match archive_url")
+    return PageRecord(**value)
+
+
+def _require_exact_fields(value: dict[str, Any], fields: set[str], location: str) -> None:
+    """Reject missing or unrecognized persisted fields.
+
+    Args:
+        value: Object whose keys are validated.
+        fields: Exact permitted field names.
+        location: Human-readable source location for errors.
+
+    Returns:
+        None.
+
+    Examples:
+        ``_require_exact_fields({"url": "x"}, {"url"}, "record")`` succeeds.
+    """
+    if set(value) != fields:
+        missing = sorted(fields - set(value))
+        extra = sorted(set(value) - fields)
+        details = [
+            *([f"missing {', '.join(missing)}"] if missing else []),
+            *([f"unknown {', '.join(extra)}"] if extra else []),
+        ]
+        raise ArchiveError(f"{location}: invalid fields ({'; '.join(details)})")
+
+
+def _url_list(value: Any, location: str) -> list[str]:
+    """Validate a list of normalized same-site discovery URLs.
+
+    Args:
+        value: Decoded candidate URL list.
+        location: Human-readable source location for errors.
+
+    Returns:
+        Copied validated URL list.
+
+    Examples:
+        ``_url_list(["https://palewi.re/sitemap.xml"], "queue")``.
+    """
+    if not isinstance(value, list):
+        raise ArchiveError(f"{location}: must be a list")
+    for url in value:
+        _validate_page_url(url, location)
+    return list(value)
+
+
+def _validate_page_url(url: Any, location: str) -> None:
+    """Validate one normalized URL within the public palewi.re scope.
+
+    Args:
+        url: Candidate URL.
+        location: Human-readable source location for errors.
+
+    Returns:
+        None.
+
+    Examples:
+        ``_validate_page_url("https://palewi.re/posts/", "page")``.
+    """
+    if not isinstance(url, str) or not url:
+        raise ArchiveError(f"{location}: must be a non-empty URL string")
+    try:
+        parsed = urlsplit(url)
+        port = parsed.port
+    except ValueError as error:
+        raise ArchiveError(f"{location}: invalid URL") from error
+    path = parsed.path or "/"
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != "palewi.re"
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is not None
+        or parsed.query
+        or parsed.fragment
+        or any(character.isspace() or ord(character) < 32 for character in url)
+        or "\\" in unquote(path)
+        or "//" in unquote(path)
+        or any(part in {".", ".."} for part in unquote(path).split("/"))
+        or urlunsplit(("https", "palewi.re", path, "", "")) != url
+    ):
+        raise ArchiveError(f"{location}: must be a normalized https://palewi.re/ URL")
+
+
+def _validate_snapshot_url(url: str, location: str, page_url: str) -> None:
+    """Validate a Wayback snapshot URL against its original page URL.
+
+    Args:
+        url: Optional HTTPS snapshot URL.
+        location: Human-readable source location for errors.
+        page_url: Normalized original public page URL.
+
+    Returns:
+        None.
+
+    Examples:
+        ``_validate_snapshot_url("", "record", "https://palewi.re/")``.
+    """
+    if not url:
+        return
+    try:
+        parsed = urlsplit(url)
+        port = parsed.port
+    except ValueError as error:
+        raise ArchiveError(f"{location}: invalid snapshot URL") from error
+    match = re.fullmatch(r"/web/(\d{14})(?:[a-z_]+)?/(https?://.+)", parsed.path)
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != "web.archive.org"
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is not None
+        or parsed.query
+        or parsed.fragment
+        or match is None
+    ):
+        raise ArchiveError(f"{location}: must be an HTTPS web.archive.org snapshot URL")
+    assert match is not None
+    _validate_wayback_timestamp(match.group(1), f"{location}: snapshot URL")
+    try:
+        original = urlsplit(match.group(2))
+        original_port = original.port
+    except ValueError as error:
+        raise ArchiveError(f"{location}: snapshot must match its page URL") from error
+    page = urlsplit(page_url)
+    if (
+        original.scheme not in {"http", "https"}
+        or original.hostname not in {"palewi.re", "www.palewi.re"}
+        or original.username is not None
+        or original.password is not None
+        or original_port not in {None, 80 if original.scheme == "http" else 443}
+        or original.query
+        or original.fragment
+        or original.path != page.path
+    ):
+        raise ArchiveError(f"{location}: snapshot must match its page URL")
+
+
+def _validate_wayback_timestamp(value: str, location: str) -> None:
+    """Validate a 14-digit timestamp as a real UTC calendar date.
+
+    Args:
+        value: Wayback timestamp in ``YYYYMMDDhhmmss`` form.
+        location: Human-readable source location for errors.
+
+    Returns:
+        None.
+
+    Examples:
+        ``_validate_wayback_timestamp("20260905120000", "snapshot")``.
+    """
+    if len(value) != 14 or not value.isdigit():
+        raise ArchiveError(f"{location}: snapshot_at must be a 14-digit Wayback timestamp")
+    try:
+        datetime.strptime(value, "%Y%m%d%H%M%S")
+    except ValueError as error:
+        raise ArchiveError(f"{location}: snapshot_at must be a real UTC timestamp") from error
+
+
+def _validate_timestamp(value: Any, location: str) -> None:
+    """Validate an optional ISO 8601 timestamp written in UTC.
+
+    Args:
+        value: Empty string or ISO UTC timestamp.
+        location: Human-readable source location for errors.
+
+    Returns:
+        None.
+
+    Examples:
+        ``_validate_timestamp("2026-09-05T12:00:00Z", "checked")``.
+    """
+    if not isinstance(value, str):
+        raise ArchiveError(f"{location}: must be an ISO UTC timestamp string")
+    if not value:
+        return
+    if not value.endswith(("Z", "+00:00")):
+        raise ArchiveError(f"{location}: must be a UTC timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ArchiveError(f"{location}: invalid ISO UTC timestamp") from error
+    if parsed.tzinfo is None or parsed.utcoffset() != UTC.utcoffset(parsed):
+        raise ArchiveError(f"{location}: must be a UTC timestamp")

--- a/scripts/site_archive/wayback.py
+++ b/scripts/site_archive/wayback.py
@@ -1,0 +1,554 @@
+"""Wayback availability checks and deliberate page-capture requests."""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from collections.abc import Callable, Mapping
+from datetime import UTC, datetime, timedelta
+from email.utils import parsedate_to_datetime
+from typing import Any, Protocol
+from urllib.parse import urlsplit
+
+import requests
+from savepagenow import BlockedByRobots
+from savepagenow import capture as save_capture
+from savepagenow.exceptions import BadGateway, TooManyRequests, UnknownError, WaybackRuntimeError
+
+from scripts.site_archive.manifest import ArchiveError, PageRecord
+
+AVAILABILITY_URL = "https://archive.org/wayback/available"
+USER_AGENT = "palewi.re site archiver (https://github.com/palewire/palewi.re)"
+PENDING_COOLDOWN = timedelta(hours=24)
+MAX_RETRY_DELAY = timedelta(hours=24)
+SNAPSHOT_PATH = re.compile(r"^/web/(\d{14})(?:[a-z_]+)?/(https?://.+)$")
+
+
+class HttpSession(Protocol):
+    """Subset of a requests session used by availability lookups."""
+
+    def get(self, url: str, **kwargs: object) -> requests.Response:
+        """Send one HTTP GET request.
+
+        Args:
+            url: Request URL.
+            **kwargs: Requests-compatible request options.
+
+        Returns:
+            HTTP response.
+
+        Examples:
+            ``session.get("https://archive.org/wayback/available")``.
+        """
+
+
+class WaybackClient:
+    """Maintain archive state using Wayback's availability and save APIs."""
+
+    def __init__(
+        self,
+        *,
+        timeout: float = 30.0,
+        capture_delay: float = 12.0,
+        lookup_delay: float = 1.0,
+        session: HttpSession | None = None,
+        capture_page: Callable[..., str] = save_capture,
+        clock: Callable[[], datetime] | None = None,
+        sleep: Callable[[float], None] = time.sleep,
+        monotonic: Callable[[], float] = time.monotonic,
+        checkpoint: Callable[[], None] | None = None,
+    ):
+        """Configure a rate-limited Wayback client.
+
+        Args:
+            timeout: Per-request timeout in seconds.
+            capture_delay: Minimum delay between capture submissions.
+            lookup_delay: Minimum delay between availability lookups.
+            session: Optional requests session for testing or customization.
+            capture_page: Save Page Now callable.
+            clock: UTC clock used for recorded timestamps.
+            sleep: Delay function used for rate limiting.
+            monotonic: Monotonic clock used for rate limiting.
+            checkpoint: Persist pending state before a capture request leaves the process.
+
+        Returns:
+            None.
+
+        Examples:
+            ``WaybackClient(timeout=10.0).verify(page)`` checks one page.
+        """
+        self.timeout = timeout
+        self.capture_delay = capture_delay
+        self.lookup_delay = lookup_delay
+        self.session = session or requests.Session()
+        self.capture_page = capture_page
+        self.clock = clock or (lambda: datetime.now(UTC))
+        self.sleep = sleep
+        self.monotonic = monotonic
+        self.checkpoint = checkpoint
+        self._last_lookup: float | None = None
+        self._last_capture: float | None = None
+
+    def verify(self, page: PageRecord) -> None:
+        """Check whether Wayback has a verified snapshot for a page.
+
+        Args:
+            page: Mutable page record to check.
+
+        Returns:
+            None. Updates confirmed coverage or a resumable error state.
+
+        Raises:
+            ArchiveError: Wayback returns malformed data or cannot be reached.
+
+        Examples:
+            ``client.verify(PageRecord(url="https://palewi.re/posts/"))``.
+        """
+        self._wait_for("lookup")
+        now = self._now()
+        try:
+            response = self.session.get(
+                AVAILABILITY_URL,
+                params={"url": page.url},
+                headers={"User-Agent": USER_AGENT},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            snapshot = _availability_snapshot(payload, page.url)
+        except (requests.RequestException, ValueError, ArchiveError) as error:
+            message = _safe_error(error, operation="availability check")
+            self._record_error(page, message, _retry_after(error, self._datetime()))
+            raise ArchiveError(f"{page.url}: {message}") from error
+
+        page.last_check_at = now
+        page.last_check_status = "success"
+        page.last_error = ""
+        page.next_retry_at = ""
+        page.attempts = 0
+        if snapshot is None:
+            if page.archive_status == "pending" and _pending_is_fresh(page, self._datetime()):
+                return
+            page.archive_status = "missing"
+            page.archive_url = ""
+            page.snapshot_at = ""
+            page.pending_archive_url = ""
+            return
+        snapshot_url, timestamp = snapshot
+        page.archive_status = "archived"
+        page.archive_url = snapshot_url
+        page.snapshot_at = timestamp
+        page.last_verified_at = now
+        page.pending_archive_url = ""
+
+    def capture(self, page: PageRecord) -> None:
+        """Submit a missing live page after checking Wayback one more time.
+
+        Args:
+            page: Mutable live record currently believed to be missing.
+
+        Returns:
+            None. A successful submission is recorded as pending confirmation.
+
+        Raises:
+            ArchiveError: Credentials, service data, or capture submission fail.
+
+        Examples:
+            ``client.capture(PageRecord(url="https://palewi.re/posts/", live_status="live", archive_status="missing"))``.
+        """
+        try:
+            _require_credentials()
+        except ArchiveError as error:
+            self._record_error(page, _safe_error(error, operation="capture"), None)
+            raise
+        if page.live_status != "live" or page.archive_status not in {"missing", "pending"}:
+            raise ArchiveError(f"{page.url}: only live pages missing an archive can be captured")
+        if page.archive_status == "pending" and _pending_is_fresh(page, self._datetime()):
+            return
+        self.verify(page)
+        if page.archive_status != "missing" or page.live_status != "live":
+            return
+
+        page.archive_status = "pending"
+        page.pending_archive_url = ""
+        page.last_submit_at = self._now()
+        page.last_error = ""
+        page.next_retry_at = ""
+        page.attempts = 0
+        self._wait_for("capture")
+        if self.checkpoint is not None:
+            self.checkpoint()
+        try:
+            snapshot_url = self.capture_page(
+                page.url,
+                user_agent=USER_AGENT,
+                accept_cache=True,
+                timeout=max(1, int(self.timeout)),
+                authenticate=True,
+            )
+            if not isinstance(snapshot_url, str):
+                raise ArchiveError("Wayback capture returned no snapshot URL")
+            normalized, _ = _validate_snapshot(snapshot_url, page.url)
+        except BlockedByRobots:
+            page.archive_status = "blocked"
+            page.last_error = "Wayback capture blocked by the publisher's robots policy"
+            page.next_retry_at = ""
+            page.last_check_status = "success"
+            return
+        except (
+            BadGateway,
+            TooManyRequests,
+            UnknownError,
+            WaybackRuntimeError,
+            requests.RequestException,
+            ArchiveError,
+        ) as error:
+            message = _safe_error(error, operation="capture")
+            self._record_error(page, message, _retry_after(error, self._datetime()))
+            raise ArchiveError(f"{page.url}: {message}") from error
+
+        page.archive_status = "pending"
+        page.pending_archive_url = normalized
+        page.last_submit_at = self._now()
+        page.last_error = ""
+        page.next_retry_at = ""
+        page.attempts = 0
+
+    def _wait_for(self, kind: str) -> None:
+        """Apply the configured finite delay before another API request.
+
+        Args:
+            kind: Either ``"lookup"`` or ``"capture"``.
+
+        Returns:
+            None.
+
+        Examples:
+            ``self._wait_for("lookup")`` spaces availability requests.
+        """
+        delay = self.lookup_delay if kind == "lookup" else self.capture_delay
+        previous = self._last_lookup if kind == "lookup" else self._last_capture
+        if previous is not None:
+            remaining = delay - (self.monotonic() - previous)
+            if remaining > 0:
+                self.sleep(min(remaining, MAX_RETRY_DELAY.total_seconds()))
+        if kind == "lookup":
+            self._last_lookup = self.monotonic()
+        else:
+            self._last_capture = self.monotonic()
+
+    def _now(self) -> str:
+        """Return the injected clock value in canonical UTC text.
+
+        Args:
+            None.
+
+        Returns:
+            ISO 8601 UTC timestamp.
+
+        Examples:
+            ``client._now().endswith("Z")`` is True.
+        """
+        value = self._datetime()
+        return value.isoformat().replace("+00:00", "Z")
+
+    def _datetime(self) -> datetime:
+        """Read and normalize the injected timezone-aware clock.
+
+        Args:
+            None.
+
+        Returns:
+            UTC datetime from the injected clock.
+
+        Examples:
+            ``client._datetime().tzinfo is UTC`` is True.
+        """
+        value = self.clock()
+        if value.tzinfo is None:
+            raise ArchiveError("Wayback clock must return a timezone-aware UTC datetime")
+        return value.astimezone(UTC)
+
+    def _record_error(self, page: PageRecord, message: str, retry_after: timedelta | None) -> None:
+        """Record a safe transient error and its next permitted retry time.
+
+        Args:
+            page: Mutable page record to update.
+            message: Sanitized user-visible failure summary.
+            retry_after: Optional server-requested retry interval.
+
+        Returns:
+            None.
+
+        Examples:
+            ``client._record_error(page, "Wayback lookup timed out", None)``.
+        """
+        page.last_check_at = self._now()
+        page.last_check_status = "error"
+        page.last_error = message
+        page.attempts += 1
+        delay = retry_after or timedelta(minutes=min(5 * 2 ** min(page.attempts - 1, 6), 360))
+        page.next_retry_at = (self._datetime() + delay).isoformat().replace("+00:00", "Z")
+
+
+def _availability_snapshot(payload: Any, page_url: str) -> tuple[str, str] | None:
+    """Extract a confirmed matching snapshot from an API response.
+
+    Args:
+        payload: Decoded Wayback availability response.
+        page_url: Requested canonical public page URL.
+
+    Returns:
+        Normalized snapshot URL and timestamp, or None when truly absent.
+
+    Examples:
+        ``_availability_snapshot({"archived_snapshots": {}}, url)`` is None.
+    """
+    if not isinstance(payload, dict):
+        raise ArchiveError("Wayback returned an invalid availability response")
+    snapshots = payload.get("archived_snapshots")
+    if not isinstance(snapshots, dict):
+        raise ArchiveError("Wayback availability response lacks archived_snapshots")
+    if not snapshots:
+        return None
+    closest = snapshots.get("closest")
+    if not isinstance(closest, dict):
+        raise ArchiveError("Wayback availability response has an invalid closest snapshot")
+    available = closest.get("available")
+    status = closest.get("status")
+    if type(available) is not bool or not isinstance(status, (int, str)):
+        raise ArchiveError("Wayback availability response has invalid availability fields")
+    if available is not True or status not in {200, "200"}:
+        return None
+    timestamp = closest.get("timestamp")
+    snapshot_url = closest.get("url")
+    if not isinstance(timestamp, str) or not re.fullmatch(r"\d{14}", timestamp):
+        raise ArchiveError("Wayback availability response has an invalid timestamp")
+    if not _is_wayback_timestamp(timestamp):
+        raise ArchiveError("Wayback availability response has an invalid timestamp")
+    if not isinstance(snapshot_url, str):
+        raise ArchiveError("Wayback availability response has an invalid snapshot URL")
+    normalized, path_timestamp = _validate_snapshot(snapshot_url, page_url)
+    if path_timestamp != timestamp:
+        raise ArchiveError("Wayback availability response has mismatched snapshot timestamps")
+    return normalized, timestamp
+
+
+def _validate_snapshot(snapshot_url: str, page_url: str) -> tuple[str, str]:
+    """Validate, normalize, and identify one same-page Wayback snapshot.
+
+    Args:
+        snapshot_url: Candidate Wayback snapshot URL.
+        page_url: Requested canonical public page URL.
+
+    Returns:
+        Normalized HTTPS snapshot URL and its timestamp.
+
+    Examples:
+        ``_validate_snapshot(snapshot, "https://palewi.re/")`` validates a snapshot.
+    """
+    try:
+        parsed = urlsplit(snapshot_url)
+        port = parsed.port
+    except ValueError as error:
+        raise ArchiveError("Wayback returned an invalid snapshot URL") from error
+    if (
+        parsed.scheme not in {"http", "https"}
+        or parsed.hostname != "web.archive.org"
+        or parsed.username is not None
+        or parsed.password is not None
+        or port not in {None, 80 if parsed.scheme == "http" else 443}
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ArchiveError("Wayback returned an invalid snapshot URL")
+    match = SNAPSHOT_PATH.fullmatch(parsed.path)
+    if not match:
+        raise ArchiveError("Wayback returned an invalid snapshot URL")
+    timestamp, original = match.groups()
+    if not _is_wayback_timestamp(timestamp):
+        raise ArchiveError("Wayback returned an invalid snapshot timestamp")
+    if not _same_original_url(original, page_url):
+        raise ArchiveError("Wayback snapshot does not match the requested page URL")
+    return f"https://web.archive.org{parsed.path}", timestamp
+
+
+def _same_original_url(candidate: str, page_url: str) -> bool:
+    """Compare source URLs allowing only HTTP/HTTPS and www equivalents.
+
+    Args:
+        candidate: Original URL embedded in a Wayback snapshot.
+        page_url: Canonical requested public page URL.
+
+    Returns:
+        Whether both URLs represent exactly the same page.
+
+    Examples:
+        ``_same_original_url("http://www.palewi.re/", "https://palewi.re/")`` is True.
+    """
+    try:
+        original = urlsplit(candidate)
+        page = urlsplit(page_url)
+        original_port = original.port
+        page_port = page.port
+    except ValueError:
+        return False
+    return (
+        original.scheme in {"http", "https"}
+        and original.hostname in {"palewi.re", "www.palewi.re"}
+        and original.username is None
+        and original.password is None
+        and original_port in {None, 80 if original.scheme == "http" else 443}
+        and not original.query
+        and not original.fragment
+        and original.path.rstrip("/") == page.path.rstrip("/")
+        and original.path.endswith("/") == page.path.endswith("/")
+        and page_port is None
+    )
+
+
+def _is_wayback_timestamp(value: str) -> bool:
+    """Check whether a 14-digit timestamp is a real calendar date.
+
+    Args:
+        value: Candidate ``YYYYMMDDhhmmss`` timestamp.
+
+    Returns:
+        Whether the timestamp parses as a real date and time.
+
+    Examples:
+        ``_is_wayback_timestamp("20260905120000")`` is True.
+    """
+    try:
+        datetime.strptime(value, "%Y%m%d%H%M%S")
+    except ValueError:
+        return False
+    return True
+
+
+def _pending_is_fresh(page: PageRecord, now: datetime) -> bool:
+    """Determine whether a capture submission remains in its confirmation window.
+
+    Args:
+        page: Page record with an optional submission timestamp.
+        now: Current UTC time.
+
+    Returns:
+        Whether the pending record should not be submitted again yet.
+
+    Examples:
+        ``_pending_is_fresh(page, datetime.now(UTC))`` guards repeat saves.
+    """
+    if not page.last_submit_at:
+        return False
+    try:
+        submitted = datetime.fromisoformat(page.last_submit_at.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return submitted + PENDING_COOLDOWN > now
+
+
+def _require_credentials() -> None:
+    """Require both Save Page Now credential environment variables.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        ``_require_credentials()`` permits authenticated capture work.
+    """
+    missing = [name for name in ("SAVEPAGENOW_ACCESS_KEY", "SAVEPAGENOW_SECRET_KEY") if not os.environ.get(name)]
+    if missing:
+        raise ArchiveError(f"{' and '.join(missing)} must be set to create new Wayback captures")
+
+
+def _retry_after(error: BaseException, now: datetime) -> timedelta | None:
+    """Extract a server retry interval without retaining arbitrary headers.
+
+    Args:
+        error: Requests or Save Page Now exception.
+        now: Current UTC time for HTTP-date conversion.
+
+    Returns:
+        Retry interval when a valid header exists, otherwise None.
+
+    Examples:
+        ``_retry_after(error, datetime.now(UTC))`` reads ``Retry-After``.
+    """
+    value = _response_header(error, "Retry-After")
+    if not isinstance(value, str):
+        return None
+    try:
+        return max(timedelta(), timedelta(seconds=int(value)))
+    except ValueError:
+        try:
+            retry_at = parsedate_to_datetime(value)
+        except (TypeError, ValueError):
+            return None
+        if retry_at.tzinfo is None:
+            return None
+        return max(timedelta(), retry_at.astimezone(UTC) - now)
+
+
+def _response_header(error: BaseException, name: str) -> object | None:
+    """Read one named header from supported exception response metadata.
+
+    Args:
+        error: Requests or Save Page Now exception.
+        name: Header name to retrieve.
+
+    Returns:
+        Header value, if safely available.
+
+    Examples:
+        ``_response_header(error, "Retry-After")`` returns a retry value.
+    """
+    response = getattr(error, "response", None)
+    headers = getattr(response, "headers", None)
+    if isinstance(headers, Mapping):
+        return headers.get(name)
+    if error.args and isinstance(error.args[0], Mapping):
+        return error.args[0].get(name)
+    return None
+
+
+def _safe_error(error: BaseException, *, operation: str) -> str:
+    """Convert known network exceptions to short non-sensitive status messages.
+
+    Args:
+        error: Caught service exception.
+        operation: Human-readable failed operation.
+
+    Returns:
+        Safe message suitable for a manifest and terminal output.
+
+    Examples:
+        ``_safe_error(requests.Timeout(), operation="capture")`` is safe to persist.
+    """
+    if isinstance(error, TooManyRequests):
+        return f"Wayback {operation} was rate limited (HTTP 429)"
+    if isinstance(error, BadGateway):
+        return f"Wayback {operation} failed (HTTP 502)"
+    if isinstance(error, UnknownError):
+        return f"Wayback {operation} failed (HTTP 520)"
+    if isinstance(error, WaybackRuntimeError):
+        return f"Wayback {operation} request failed"
+    if isinstance(error, requests.HTTPError):
+        response = getattr(error, "response", None)
+        status = getattr(response, "status_code", None)
+        return (
+            f"Wayback {operation} failed (HTTP {status})" if isinstance(status, int) else f"Wayback {operation} failed"
+        )
+    if isinstance(error, requests.Timeout):
+        return f"Wayback {operation} timed out"
+    if isinstance(error, requests.ConnectionError):
+        return f"Wayback {operation} connection failed"
+    if isinstance(error, requests.RequestException):
+        return f"Wayback {operation} request failed"
+    if isinstance(error, ValueError):
+        return f"Wayback {operation} returned invalid JSON"
+    return str(error)

--- a/tests/test_site_archive_branch.py
+++ b/tests/test_site_archive_branch.py
@@ -1,0 +1,621 @@
+"""Tests for safe site archive branch persistence."""
+
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from scripts.site_archive.branch import (
+    DEFAULT_BRANCH,
+    DEFAULT_REPOSITORY,
+    BranchPersistenceError,
+    cli,
+    fetch,
+    push,
+)
+from scripts.site_archive.manifest import Manifest, ManifestStore
+
+HEAD = "a" * 40
+TREE = "b" * 40
+BLOB = "c" * 40
+COMMIT = "d" * 40
+
+
+def manifest_bytes(tmp_path: Path) -> tuple[Path, bytes]:
+    """Create one valid manifest fixture.
+
+    Args:
+        tmp_path: Test directory.
+
+    Returns:
+        Manifest path and its exact persisted bytes.
+
+    Examples:
+        ``manifest_bytes(tmp_path)`` supplies a publishable state file.
+    """
+    path = tmp_path / "manifest.json"
+    ManifestStore(path).save(Manifest())
+    return path, path.read_bytes()
+
+
+class GhStub:
+    """Return deterministic responses for the GitHub REST calls."""
+
+    def __init__(self, *, head: str | None = HEAD, remote: bytes | None = None) -> None:
+        """Initialize a deterministic GitHub API fixture.
+
+        Args:
+            head: Current branch head, or ``None`` for an absent branch.
+            remote: Existing manifest bytes returned by the contents endpoint.
+
+        Returns:
+            None.
+
+        Examples:
+            ``GhStub(head=None)`` models a first persistence run.
+        """
+        self.head = head
+        self.remote = remote
+        self.calls: list[tuple[list[str], str | None]] = []
+
+    def __call__(self, command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        """Handle one ``gh api`` subprocess invocation.
+
+        Args:
+            command: Command arguments.
+            kwargs: Subprocess keyword arguments.
+
+        Returns:
+            A mocked completed process.
+
+        Examples:
+            ``stub(command, input=...)`` records JSON sent over stdin.
+        """
+        self.calls.append((command, kwargs.get("input")))
+        endpoint = command[2]
+        method = command[command.index("--method") + 1]
+        if endpoint in {"repos/palewire/palewi.re", "repos/palewire/palewi.re/"}:
+            return self.ok({})
+        if endpoint.endswith("/git/ref/heads/site-archive-data"):
+            if self.head is None:
+                return self.fail("gh: Not Found (HTTP 404)")
+            return self.ok({"object": {"sha": self.head}})
+        if endpoint.startswith("repos/palewire/palewi.re/contents/manifest.json"):
+            assert self.remote is not None
+            return self.ok(
+                {
+                    "encoding": "base64",
+                    "content": base64.b64encode(self.remote).decode(),
+                }
+            )
+        if endpoint.endswith(f"/git/commits/{HEAD}"):
+            return self.ok({"tree": {"sha": TREE}})
+        if endpoint.endswith("/git/blobs"):
+            return self.ok({"sha": BLOB})
+        if endpoint.endswith("/git/trees"):
+            return self.ok({"sha": TREE})
+        if endpoint.endswith("/git/commits"):
+            return self.ok({"sha": COMMIT})
+        if endpoint.endswith("/git/refs"):
+            assert method == "POST"
+            self.head = COMMIT
+            return self.ok({"ref": "refs/heads/site-archive-data"})
+        if endpoint.endswith("/git/refs/heads/site-archive-data"):
+            assert method == "PATCH"
+            payload = json.loads(self.calls[-1][1] or "{}")
+            assert payload["force"] is False
+            self.head = COMMIT
+            return self.ok({"object": {"sha": COMMIT}})
+        raise AssertionError(f"unexpected endpoint {endpoint}")
+
+    @staticmethod
+    def ok(value: object) -> subprocess.CompletedProcess[str]:
+        """Build a successful subprocess result.
+
+        Args:
+            value: JSON response.
+
+        Returns:
+            Completed process fixture.
+
+        Examples:
+            ``GhStub.ok({"sha": "..."})`` models a GitHub response.
+        """
+        return subprocess.CompletedProcess(["gh"], 0, json.dumps(value), "")
+
+    @staticmethod
+    def fail(stderr: str) -> subprocess.CompletedProcess[str]:
+        """Build a failed subprocess result.
+
+        Args:
+            stderr: Sanitized API error.
+
+        Returns:
+            Failed process fixture.
+
+        Examples:
+            ``GhStub.fail("HTTP 403")`` models a permission failure.
+        """
+        return subprocess.CompletedProcess(["gh"], 1, "", stderr)
+
+
+def token(path: Path, head: str | None = HEAD) -> None:
+    """Write a valid state token fixture.
+
+    Args:
+        path: Token destination.
+        head: Observed branch head, or ``None`` for absent branch.
+
+    Returns:
+        None.
+
+    Examples:
+        ``token(path)`` permits an update based on ``HEAD``.
+    """
+    path.write_text(
+        json.dumps({"repository": DEFAULT_REPOSITORY, "branch": DEFAULT_BRANCH, "missing": head is None, "head": head})
+        + "\n"
+    )
+
+
+def test_fetch_existing_head_is_immutable_and_validates_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fetch a manifest at the exact head and checkpoint it.
+
+    Args:
+        tmp_path: Test directory.
+        monkeypatch: Replaces the gh subprocess.
+
+    Returns:
+        None.
+
+    Examples:
+        A valid remote manifest replaces local state and records its head.
+    """
+    path = tmp_path / "manifest.json"
+    remote = ManifestStore(tmp_path / "remote.json")
+    remote.save(Manifest())
+    stub = GhStub(remote=(tmp_path / "remote.json").read_bytes())
+    monkeypatch.setattr("scripts.site_archive.branch.subprocess.run", stub)
+    fetch(path, tmp_path / "state-token.json")
+    assert path.read_bytes() == stub.remote
+    assert json.loads((tmp_path / "state-token.json").read_text())["head"] == HEAD
+
+
+def test_fetch_absent_branch_is_explicit_and_writes_empty_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Represent an absent branch without creating a fake remote state.
+
+    Args:
+        tmp_path: Test directory.
+        monkeypatch: Replaces the gh subprocess.
+
+    Returns:
+        None.
+
+    Examples:
+        A first run gets a missing token and a valid empty manifest.
+    """
+    stub = GhStub(head=None)
+    monkeypatch.setattr("scripts.site_archive.branch.subprocess.run", stub)
+    path = tmp_path / "manifest.json"
+    fetch(path, tmp_path / "state-token.json")
+    assert ManifestStore(path).load() == Manifest()
+    assert json.loads((tmp_path / "state-token.json").read_text())["missing"] is True
+
+
+def test_push_initial_commit_is_orphan_and_creates_ref_last(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Create the first branch commit with only the manifest file.
+
+    Args:
+        tmp_path: Test directory.
+        monkeypatch: Replaces the gh subprocess.
+
+    Returns:
+        None.
+
+    Examples:
+        An absent branch receives an orphan commit and a final ref creation.
+    """
+    path, _ = manifest_bytes(tmp_path)
+    state = tmp_path / "state-token.json"
+    token(state, None)
+    stub = GhStub(head=None)
+    monkeypatch.setattr("scripts.site_archive.branch.subprocess.run", stub)
+    push(path, state)
+    write_calls = [(command, value) for command, value in stub.calls if value is not None]
+    assert write_calls
+    assert all("--input" in command and command[command.index("--input") + 1] == "-" for command, _ in write_calls)
+    payloads = [json.loads(value) for command, value in stub.calls if value and "--method" in command]
+    commit = next(value for value in payloads if value.get("parents") == [])
+    assert commit["message"].endswith("Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>")
+    assert any(value.get("ref") == "refs/heads/site-archive-data" for value in payloads)
+    assert json.loads(state.read_text())["head"] == COMMIT
+
+
+def test_push_updates_existing_branch_without_force(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Create a child commit and PATCH the existing ref non-forcefully.
+
+    Args:
+        tmp_path: Test directory.
+        monkeypatch: Replaces the gh subprocess.
+
+    Returns:
+        None.
+
+    Examples:
+        A changed manifest advances an existing data branch.
+    """
+    path, content = manifest_bytes(tmp_path)
+    state = tmp_path / "state-token.json"
+    token(state)
+    stub = GhStub(remote=b"older manifest")
+    monkeypatch.setattr("scripts.site_archive.branch.subprocess.run", stub)
+    push(path, state)
+    assert path.read_bytes() == content
+    assert json.loads(state.read_text())["head"] == COMMIT
+    patch_command, patch_input = next(
+        (command, value) for command, value in stub.calls if command[2].endswith("/git/refs/heads/site-archive-data")
+    )
+    assert json.loads(patch_input or "{}")["force"] is False
+    assert "--input" in patch_command
+
+
+def test_push_concurrent_nonforce_rejection_preserves_local_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Leave local state intact when GitHub rejects a concurrent update.
+
+    Args:
+        tmp_path: Test directory.
+        monkeypatch: Replaces the gh subprocess.
+
+    Returns:
+        None.
+
+    Examples:
+        A non-fast-forward response does not roll back or overwrite local data.
+    """
+
+    class ConcurrentWriter(GhStub):
+        """Reject the final non-forced ref update."""
+
+        def __call__(self, command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            """Simulate another writer advancing the branch.
+
+            Args:
+                command: gh arguments.
+                kwargs: Subprocess options.
+
+            Returns:
+                Mocked API response.
+
+            Examples:
+                A PATCH receives an explicit non-fast-forward rejection.
+            """
+            if command[2].endswith("/git/refs/heads/site-archive-data"):
+                payload = json.loads(kwargs.get("input") or "{}")
+                assert payload["force"] is False
+                return self.fail("gh: Update is not a fast forward (HTTP 422)")
+            return super().__call__(command, **kwargs)
+
+    path, content = manifest_bytes(tmp_path)
+    state = tmp_path / "state-token.json"
+    token(state)
+    original_token = state.read_bytes()
+    stub = ConcurrentWriter(remote=b"older manifest")
+    monkeypatch.setattr("scripts.site_archive.branch.subprocess.run", stub)
+    with pytest.raises(BranchPersistenceError, match="cannot update branch"):
+        push(path, state)
+    assert path.read_bytes() == content
+    assert state.read_bytes() == original_token
+
+
+def test_push_refuses_stale_head_before_creating_objects(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reject a concurrent writer without creating blobs or commits.
+
+    Args:
+        tmp_path: Test directory.
+        monkeypatch: Replaces the gh subprocess.
+
+    Returns:
+        None.
+
+    Examples:
+        A changed remote ref is a visible conflict.
+    """
+    path, _ = manifest_bytes(tmp_path)
+    state = tmp_path / "state-token.json"
+    token(state)
+    stub = GhStub(head="e" * 40)
+    monkeypatch.setattr("scripts.site_archive.branch.subprocess.run", stub)
+    with pytest.raises(BranchPersistenceError, match="stale"):
+        push(path, state)
+    assert not any("/git/blobs" in command[2] for command, _ in stub.calls)
+
+
+def test_push_identical_bytes_does_not_create_empty_commit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Avoid a commit when the remote manifest bytes are unchanged.
+
+    Args:
+        tmp_path: Test directory.
+        monkeypatch: Replaces the gh subprocess.
+
+    Returns:
+        None.
+
+    Examples:
+        Re-running a successful checkpoint is idempotent.
+    """
+    path, content = manifest_bytes(tmp_path)
+    state = tmp_path / "state-token.json"
+    token(state)
+    stub = GhStub(remote=content)
+    monkeypatch.setattr("scripts.site_archive.branch.subprocess.run", stub)
+    push(path, state)
+    assert not any("/git/blobs" in command[2] for command, _ in stub.calls)
+
+
+def test_fetch_reads_large_manifest_through_immutable_blob(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Read a contents response that requires the Git blob endpoint.
+
+    Args:
+        tmp_path: Test directory.
+        monkeypatch: Replaces the gh subprocess.
+
+    Returns:
+        None.
+
+    Examples:
+        A contents ``encoding: none`` response still fetches the exact blob.
+    """
+    remote = ManifestStore(tmp_path / "remote.json")
+    remote.save(Manifest())
+    remote_bytes = (tmp_path / "remote.json").read_bytes()
+
+    class LargeContents(GhStub):
+        """Return a SHA-only contents response."""
+
+        def __call__(self, command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            """Serve the manifest through the immutable blob API.
+
+            Args:
+                command: gh arguments.
+                kwargs: Subprocess options.
+
+            Returns:
+                Mocked API response.
+
+            Examples:
+                Large files use ``encoding: none`` in Contents API responses.
+            """
+            self.calls.append((command, kwargs.get("input")))
+            if command[2].startswith("repos/palewire/palewi.re/contents/manifest.json"):
+                return self.ok({"encoding": "none", "content": "", "sha": BLOB})
+            if command[2].endswith(f"/git/blobs/{BLOB}"):
+                return self.ok({"encoding": "base64", "content": base64.b64encode(remote_bytes).decode()})
+            return super().__call__(command, **kwargs)
+
+    stub = LargeContents()
+    monkeypatch.setattr("scripts.site_archive.branch.subprocess.run", stub)
+    path = tmp_path / "manifest.json"
+    fetch(path, tmp_path / "state-token.json")
+    assert path.read_bytes() == remote_bytes
+    assert any(command[2].endswith(f"/git/blobs/{BLOB}") for command, _ in stub.calls)
+
+
+def test_fetch_refuses_unsaved_local_manifest_changes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Protect local edits rather than replacing them during fetch.
+
+    Args:
+        tmp_path: Test directory.
+        monkeypatch: Replaces the gh subprocess.
+
+    Returns:
+        None.
+
+    Examples:
+        A differing local file directs reconciliation to a fresh path.
+    """
+    path = tmp_path / "manifest.json"
+    path.write_text("local unsaved changes")
+    stub = GhStub(remote=b"remote")
+    monkeypatch.setattr("scripts.site_archive.branch.subprocess.run", stub)
+    with pytest.raises(BranchPersistenceError, match="fresh path"):
+        fetch(path, tmp_path / "state-token.json")
+    assert path.read_text() == "local unsaved changes"
+
+
+def test_manifest_and_token_paths_must_differ(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reject aliased manifest and token destinations before API access.
+
+    Args:
+        tmp_path: Test directory.
+        monkeypatch: Replaces the gh subprocess.
+
+    Returns:
+        None.
+
+    Examples:
+        ``fetch(path, path)`` is rejected before any write.
+    """
+    stub = GhStub()
+    monkeypatch.setattr("scripts.site_archive.branch.subprocess.run", stub)
+    path = tmp_path / "same.json"
+    with pytest.raises(BranchPersistenceError, match="must be different"):
+        fetch(path, path)
+    assert stub.calls == []
+
+
+def test_push_rejects_malformed_token_without_touching_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reject malformed optimistic-lock state before API writes.
+
+    Args:
+        tmp_path: Test directory.
+        monkeypatch: Replaces the gh subprocess.
+
+    Returns:
+        None.
+
+    Examples:
+        A malformed token cannot silently reset persistence state.
+    """
+    path, content = manifest_bytes(tmp_path)
+    state = tmp_path / "state-token.json"
+    state.write_text("{}")
+    stub = GhStub()
+    monkeypatch.setattr("scripts.site_archive.branch.subprocess.run", stub)
+    with pytest.raises(BranchPersistenceError, match="malformed"):
+        push(path, state)
+    assert path.read_bytes() == content
+    assert stub.calls == []
+
+
+def test_fetch_permission_error_is_not_treated_as_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Surface auth failures instead of initializing an empty branch.
+
+    Args:
+        tmp_path: Test directory.
+        monkeypatch: Replaces the gh subprocess.
+
+    Returns:
+        None.
+
+    Examples:
+        A 403 ref response fails the fetch command.
+    """
+
+    class Forbidden(GhStub):
+        """Return a permission failure for the branch ref."""
+
+        def __call__(self, command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            """Return a forbidden response after repository access.
+
+            Args:
+                command: gh arguments.
+                kwargs: Subprocess options.
+
+            Returns:
+                Mocked response.
+
+            Examples:
+                The branch lookup remains distinguishable from a 404.
+            """
+            if command[2].endswith("/git/ref/heads/site-archive-data"):
+                return self.fail("gh: Forbidden (HTTP 403)")
+            return super().__call__(command, **kwargs)
+
+    monkeypatch.setattr("scripts.site_archive.branch.subprocess.run", Forbidden())
+    with pytest.raises(BranchPersistenceError, match="403"):
+        fetch(tmp_path / "manifest.json", tmp_path / "state-token.json")
+
+
+def test_fetch_repository_not_found_is_not_treated_as_missing_branch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Require repository metadata before interpreting a ref 404.
+
+    Args:
+        tmp_path: Test directory.
+        monkeypatch: Replaces the gh subprocess.
+
+    Returns:
+        None.
+
+    Examples:
+        A repository-level 404 remains an access failure, not an empty branch.
+    """
+
+    class MissingRepository(GhStub):
+        """Return a repository-level not-found response."""
+
+        def __call__(self, command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            """Reject repository metadata lookup.
+
+            Args:
+                command: gh arguments.
+                kwargs: Subprocess options.
+
+            Returns:
+                Mocked response.
+
+            Examples:
+                The branch ref is never interpreted.
+            """
+            if command[2] == "repos/palewire/palewi.re":
+                return self.fail("gh: Not Found (HTTP 404)")
+            return super().__call__(command, **kwargs)
+
+    monkeypatch.setattr("scripts.site_archive.branch.subprocess.run", MissingRepository())
+    with pytest.raises(BranchPersistenceError, match="cannot access repository"):
+        fetch(tmp_path / "manifest.json", tmp_path / "state-token.json")
+    assert not (tmp_path / "manifest.json").exists()
+    assert not (tmp_path / "state-token.json").exists()
+
+
+def test_cli_rejects_other_branch() -> None:
+    """Keep persistence restricted to the dedicated data branch.
+
+    Returns:
+        None.
+
+    Examples:
+        A typo cannot redirect writes to another branch.
+    """
+    result = CliRunner().invoke(
+        cli,
+        ["fetch", "--path", "manifest.json", "--state-token", "state.json", "--branch", "main"],
+    )
+    assert result.exit_code != 0
+    assert "site-archive-data" in result.output
+
+
+def test_cli_registers_fetch_command(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Expose the advertised ``fetch`` command name in Click.
+
+    Args:
+        monkeypatch: Replaces the fetch implementation.
+        tmp_path: Test directory.
+
+    Returns:
+        None.
+
+    Examples:
+        ``CliRunner`` can invoke ``fetch`` rather than ``fetch-command``.
+    """
+    calls: list[tuple[Path, Path, str, str]] = []
+
+    def fake_fetch(path: Path, state_token: Path, repository: str, branch: str) -> None:
+        """Record a CLI fetch invocation.
+
+        Args:
+            path: Manifest path.
+            state_token: Token path.
+            repository: Repository name.
+            branch: Data branch.
+
+        Returns:
+            None.
+
+        Examples:
+            The command forwards every persistence option.
+        """
+        calls.append((path, state_token, repository, branch))
+
+    monkeypatch.setattr("scripts.site_archive.branch.fetch", fake_fetch)
+    result = CliRunner().invoke(
+        cli,
+        ["fetch", "--path", str(tmp_path / "manifest.json"), "--state-token", str(tmp_path / "state.json")],
+    )
+    assert result.exit_code == 0
+    assert calls == [(tmp_path / "manifest.json", tmp_path / "state.json", DEFAULT_REPOSITORY, DEFAULT_BRANCH)]

--- a/tests/test_site_archive_cli.py
+++ b/tests/test_site_archive_cli.py
@@ -1,0 +1,475 @@
+"""Offline tests for the site archive commands."""
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from scripts.site_archive import cli as archive_cli
+from scripts.site_archive.cli import ArchiveRun, cli, report_text
+from scripts.site_archive.manifest import ArchiveError, Manifest, ManifestStore
+from scripts.site_archive.wayback import WaybackClient
+
+URL = "https://palewi.re/posts/"
+
+
+def seed_manifest(path: Path, status: str = "unknown") -> Manifest:
+    """Create one live page in a local manifest.
+
+    Args:
+        path: Destination manifest.
+        status: Initial archive status.
+
+    Returns:
+        The saved manifest.
+
+    Examples:
+        ``seed_manifest(path)`` creates one unchecked live page.
+    """
+    state = Manifest()
+    page = state.page(URL)
+    page.live_status = "live"
+    page.archive_status = status
+    if status == "pending":
+        page.last_submit_at = "2026-01-01T00:00:00Z"
+        page.pending_archive_url = f"https://web.archive.org/web/20260101000000/{URL}"
+    ManifestStore(path).save(state)
+    return state
+
+
+def test_report_is_offline_and_honest(tmp_path: Path) -> None:
+    """Report pending and unknown pages without claiming complete coverage.
+
+    Args:
+        tmp_path: State directory.
+
+    Returns:
+        None.
+
+    Examples:
+        Pending snapshots count separately from confirmed archives.
+    """
+    path = tmp_path / "manifest.json"
+    state = seed_manifest(path, "pending")
+    state.discovery_queue = [URL]
+    ManifestStore(path).save(state)
+    result = CliRunner().invoke(cli, ["report", "--manifest", str(path)])
+    assert result.exit_code == 0
+    assert "| Confirmed archives | 0 |" in result.output
+    assert "| Pending capture confirmations | 1 |" in result.output
+    assert "unfinished or has gaps" in result.output
+    assert "does not guarantee" in result.output
+
+
+@pytest.mark.parametrize("command", ["report", "verify", "capture", "discover", "sync"])
+def test_corrupt_manifest_is_not_overwritten(tmp_path: Path, command: str) -> None:
+    """Fail all commands on corrupt persisted data.
+
+    Args:
+        tmp_path: State directory.
+        command: Command to run.
+
+    Returns:
+        None.
+
+    Examples:
+        No command replaces a broken manifest with a new empty document.
+    """
+    path = tmp_path / "manifest.json"
+    path.write_text("broken")
+    result = CliRunner().invoke(cli, [command, "--manifest", str(path)])
+    assert result.exit_code != 0
+    assert path.read_text() == "broken"
+
+
+def test_verify_orders_unchecked_pages_and_preserves_failures(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Checkpoint a failing check and leave other candidates for later.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces Wayback requests.
+
+    Returns:
+        None.
+
+    Examples:
+        Rate limiting stops the batch without losing the failed record.
+    """
+    path = tmp_path / "state.json"
+    state = seed_manifest(path)
+    state.page("https://palewi.re/old/").live_status = "live"
+    state.pages["https://palewi.re/old/"].last_check_at = "2020-01-01T00:00:00+00:00"
+    ManifestStore(path).save(state)
+
+    def fail(_client: WaybackClient, page: archive_cli.PageRecord) -> None:
+        """Record an API error.
+
+        Args:
+            _client: Unused client.
+            page: Candidate record.
+
+        Returns:
+            Never returns.
+
+        Examples:
+            Simulates a rate-limited lookup.
+        """
+        assert page.url == URL
+        page.last_check_status = "error"
+        page.last_error = "Rate limited"
+        raise ArchiveError("Rate limited")
+
+    monkeypatch.setattr(WaybackClient, "verify", fail)
+    report = tmp_path / "report.md"
+    result = CliRunner().invoke(cli, ["verify", "--manifest", str(path), "--summary", str(report)])
+    assert result.exit_code != 0
+    assert ManifestStore(path).load().pages[URL].last_error == "Rate limited"
+    assert report.is_file()
+    assert "| Archive checks with errors | 1 |" in report.read_text()
+
+
+def test_capture_limits_and_retry_dates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Select due missing pages and exclude pending, blocked, and non-live pages.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces capture calls.
+
+    Returns:
+        None.
+
+    Examples:
+        A future retry date keeps a missing page out of this batch.
+    """
+    path = tmp_path / "state.json"
+    monkeypatch.setattr(ArchiveRun, "check_live", lambda *args: True)
+    state = seed_manifest(path, "missing")
+    for slug, status in [("pending", "pending"), ("blocked", "blocked"), ("later", "missing")]:
+        page = state.page(f"https://palewi.re/{slug}/")
+        page.archive_status = status
+        page.live_status = "live"
+        if status == "pending":
+            page.last_submit_at = "2026-01-01T00:00:00Z"
+            page.pending_archive_url = f"https://web.archive.org/web/20260101000000/{page.url}"
+    state.pages["https://palewi.re/later/"].next_retry_at = "2099-01-01T00:00:00+00:00"
+    state.page("https://palewi.re/not-live/").archive_status = "missing"
+    ManifestStore(path).save(state)
+    calls: list[str] = []
+
+    def capture(_client: WaybackClient, page: archive_cli.PageRecord) -> None:
+        """Record a candidate capture.
+
+        Args:
+            _client: Unused client.
+            page: Candidate page.
+
+        Returns:
+            None.
+
+        Examples:
+            The candidate becomes pending, not confirmed.
+        """
+        calls.append(page.url)
+        page.archive_status = "pending"
+        page.last_submit_at = "2026-01-01T00:00:00Z"
+        page.pending_archive_url = f"https://web.archive.org/web/20260101000000/{page.url}"
+
+    monkeypatch.setattr(WaybackClient, "capture", capture)
+    result = CliRunner().invoke(cli, ["capture", "--manifest", str(path), "--max-captures", "1"])
+    assert result.exit_code == 0
+    assert calls == [URL]
+    assert ManifestStore(path).load().pages[URL].archive_status == "pending"
+
+
+def test_capture_failure_saves_summary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Surface configuration failures while keeping the candidate.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces capture requests.
+
+    Returns:
+        None.
+
+    Examples:
+        Missing credentials are not reported as successful captures.
+    """
+    path = tmp_path / "state.json"
+    monkeypatch.setattr(ArchiveRun, "check_live", lambda *args: True)
+    seed_manifest(path, "missing")
+
+    def fail(_client: WaybackClient, page: archive_cli.PageRecord) -> None:
+        """Reject a capture without credentials.
+
+        Args:
+            _client: Unused client.
+            page: Capture candidate.
+
+        Returns:
+            Never returns.
+
+        Examples:
+            Used to simulate an unconfigured local run.
+        """
+        page.last_error = "Credentials missing"
+        page.last_check_status = "error"
+        raise ArchiveError(page.last_error)
+
+    monkeypatch.setattr(WaybackClient, "capture", fail)
+    result = CliRunner().invoke(cli, ["capture", "--manifest", str(path)])
+    assert result.exit_code != 0
+    assert "Credentials missing" in result.output
+    assert ManifestStore(path).load().pages[URL].archive_status == "missing"
+
+
+def test_sync_lookup_only_and_discover_command(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run discovery and lookups without captures.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces network-facing phases.
+
+    Returns:
+        None.
+
+    Examples:
+        Lookup-only sync must not invoke the capture phase.
+    """
+    path = tmp_path / "state.json"
+    phases: list[str] = []
+    monkeypatch.setattr(archive_cli, "build_seeds", lambda build: [URL])
+
+    def discover(runner: archive_cli.PageDiscovery, seeds: list[str], *, limit: int, deadline: float) -> int:
+        """Add a discovered fixture page.
+
+        Args:
+            runner: Discovery instance.
+            seeds: Requested seeds.
+            limit: Request limit.
+            deadline: End time.
+
+        Returns:
+            One attempted request.
+
+        Examples:
+            Replaces the live crawl during a CLI test.
+        """
+        assert seeds == [URL]
+        assert limit > 0 and deadline > 0
+        phases.append("discover")
+        runner.manifest.page(URL).live_status = "live"
+        return 1
+
+    monkeypatch.setattr(archive_cli.PageDiscovery, "run", discover)
+    monkeypatch.setattr(ArchiveRun, "verify", lambda *args: phases.append("verify"))
+    monkeypatch.setattr(ArchiveRun, "capture", lambda *args: phases.append("capture"))
+    result = CliRunner().invoke(cli, ["sync", "--manifest", str(path), "--lookup-only"])
+    assert result.exit_code == 0
+    assert phases == ["discover", "verify"]
+    phases.clear()
+    result = CliRunner().invoke(cli, ["sync", "--manifest", str(path)])
+    assert result.exit_code == 0
+    assert phases == ["discover", "verify", "capture"]
+    phases.clear()
+    result = CliRunner().invoke(cli, ["discover", "--manifest", str(path)])
+    assert result.exit_code == 0
+    assert phases == ["discover"]
+
+
+def test_missing_build_saves_error_report(tmp_path: Path) -> None:
+    """Save a report even when discovery cannot start.
+
+    Args:
+        tmp_path: State directory.
+
+    Returns:
+        None.
+
+    Examples:
+        A missing build is an actionable failure, not an empty inventory success.
+    """
+    path = tmp_path / "state.json"
+    summary = tmp_path / "report.md"
+    result = CliRunner().invoke(
+        cli,
+        ["discover", "--manifest", str(path), "--build-dir", str(tmp_path / "absent"), "--summary", str(summary)],
+    )
+    assert result.exit_code != 0
+    assert "make bake" in result.output
+    assert summary.is_file()
+
+
+def test_deadlines_prevent_new_archive_requests(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stop work before making a request when the time budget is spent.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces the client with a request counter.
+
+    Returns:
+        None.
+
+    Examples:
+        Neither verify nor capture runs after its deadline.
+    """
+    path = tmp_path / "state.json"
+    seed_manifest(path, "missing")
+    calls: list[str] = []
+    monkeypatch.setattr(WaybackClient, "verify", lambda *args: calls.append("verify"))
+    monkeypatch.setattr(WaybackClient, "capture", lambda *args: calls.append("capture"))
+    run = ArchiveRun(path)
+    run.verify(1, 0)
+    run.capture(1, 0)
+    assert not calls
+
+
+def test_report_escapes_errors_and_limits_problem_list() -> None:
+    """Keep external error text readable and prevent HTML in summaries.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        Long error lists refer readers to the manifest.
+    """
+    state = Manifest()
+    for index in range(51):
+        state.discovery_errors[f"https://palewi.re/{index}/"] = "<b>failed</b>"
+    text = report_text(state)
+    assert "<b>" not in text
+    assert "&lt;b&gt;" in text
+    assert "1 more problems" in text
+
+
+def test_lookup_failure_stops_capture_phase(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Do not submit captures after availability checks fail.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces network-facing client methods.
+
+    Returns:
+        None.
+
+    Examples:
+        A service outage results in one failed lookup and no capture.
+    """
+    path = tmp_path / "state.json"
+    seed_manifest(path, "missing")
+    calls: list[str] = []
+
+    def fail(_client: WaybackClient, page: archive_cli.PageRecord) -> None:
+        """Record a service failure.
+
+        Args:
+            _client: Unused client.
+            page: Lookup candidate.
+
+        Returns:
+            Never returns.
+
+        Examples:
+            Simulates an unavailable Wayback API.
+        """
+        page.last_check_status = "error"
+        raise ArchiveError("Service unavailable")
+
+    monkeypatch.setattr(WaybackClient, "verify", fail)
+    monkeypatch.setattr(WaybackClient, "capture", lambda *args: calls.append("capture"))
+    run = ArchiveRun(path)
+    run.verify(1, float("inf"))
+    run.capture(1, float("inf"))
+    assert run.wayback_failed
+    assert not calls
+
+
+def test_capture_checkpoints_before_submission(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Persist pending state before a capture can be interrupted.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces lookup and credentials.
+
+    Returns:
+        None.
+
+    Examples:
+        An interrupted network request leaves a pending record on disk.
+    """
+    path = tmp_path / "state.json"
+    state = seed_manifest(path, "missing")
+    store = ManifestStore(path)
+    monkeypatch.setenv("SAVEPAGENOW_ACCESS_KEY", "test")
+    monkeypatch.setenv("SAVEPAGENOW_SECRET_KEY", "test")
+    monkeypatch.setattr(WaybackClient, "verify", lambda *args: None)
+
+    def interrupted(url: str, **kwargs: object) -> str:
+        """Interrupt a request after checking durable state.
+
+        Args:
+            url: Capture target.
+            **kwargs: Capture options.
+
+        Returns:
+            Never returns.
+
+        Examples:
+            Represents a process interrupted during submission.
+        """
+        saved = store.load().pages[url]
+        assert saved.archive_status == "pending"
+        assert saved.last_submit_at
+        raise KeyboardInterrupt
+
+    client = WaybackClient(capture_page=interrupted, checkpoint=lambda: store.save(state))
+    with pytest.raises(KeyboardInterrupt):
+        client.capture(state.pages[URL])
+    assert store.load().pages[URL].archive_status == "pending"
+
+
+@pytest.mark.parametrize("live_status", ["live", "missing", "error"])
+def test_capture_rechecks_public_page(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, live_status: str) -> None:
+    """Do not archive a removed or inaccessible page based on an old live check.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces live requests and capture submission.
+        live_status: Result of the new live-page request.
+
+    Returns:
+        None.
+
+    Examples:
+        A newly missing page stops before the capture API is called.
+    """
+    path = tmp_path / "state.json"
+    seed_manifest(path, "missing")
+    calls: list[str] = []
+
+    def visit(discovery: archive_cli.PageDiscovery, url: str) -> None:
+        """Simulate the current public page response.
+
+        Args:
+            discovery: Discovery instance.
+            url: Requested page.
+
+        Returns:
+            None.
+
+        Examples:
+            A failed request raises an explicit error.
+        """
+        if live_status == "error":
+            raise ArchiveError("Page request failed")
+        discovery.manifest.pages[url].live_status = live_status
+
+    monkeypatch.setattr(archive_cli.PageDiscovery, "visit", visit)
+    monkeypatch.setattr(WaybackClient, "capture", lambda *args: calls.append("capture"))
+    run = ArchiveRun(path)
+    run.capture(1, float("inf"))
+    assert calls == (["capture"] if live_status == "live" else [])
+    assert ManifestStore(path).load().pages[URL].live_status == live_status
+    assert bool(run.failures) is (live_status != "live")

--- a/tests/test_site_archive_discovery.py
+++ b/tests/test_site_archive_discovery.py
@@ -1,0 +1,505 @@
+"""Offline tests for public-page discovery."""
+
+from pathlib import Path
+
+import pytest
+import requests
+
+from coltrane.content_loaders import Doc
+from scripts.site_archive import discovery
+from scripts.site_archive.discovery import ORIGIN, PageDiscovery, build_seeds, is_page_url, normalize_url
+from scripts.site_archive.manifest import ArchiveError, Manifest, ManifestStore
+
+
+def response(body: str = "", status: int = 200, content_type: str = "text/html") -> requests.Response:
+    """Construct an in-memory HTTP response.
+
+    Args:
+        body: Response text.
+        status: HTTP status.
+        content_type: Response MIME type.
+
+    Returns:
+        A fully buffered requests response.
+
+    Examples:
+        ``response("<p>Hello</p>")`` creates an HTML response.
+    """
+    result = requests.Response()
+    result.status_code = status
+    result._content = body.encode()
+    result._content_consumed = True
+    result.headers["Content-Type"] = content_type
+    result.encoding = "utf-8"
+    return result
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("/posts/#latest", f"{ORIGIN}/posts/"),
+        ("http://www.palewi.re/docs/x/index.html", f"{ORIGIN}/docs/x/index.html"),
+        ("next.html", f"{ORIGIN}/docs/next.html"),
+        ("https://example.com/", None),
+        ("https://mastodon.palewi.re/", None),
+        ("/search.html?q=foo", None),
+        ("mailto:ben@example.com", None),
+        ("https://user:pass@palewi.re/posts/", None),
+        ("https://palewi.re:8080/posts/", None),
+        ("https://[broken/", None),
+        ("/%2e%2e/private", None),
+        ("/docs/%5cother", None),
+        ("/docs/%2fother", None),
+        ("/docs/space here", None),
+    ],
+)
+def test_normalize_url(value: str, expected: str | None) -> None:
+    """Check URL scope and normalization.
+
+    Args:
+        value: Candidate link.
+        expected: Expected normalized URL or rejection.
+
+    Returns:
+        None.
+
+    Examples:
+        Parametrized cases cover aliases, fragments, and excluded hosts.
+    """
+    assert normalize_url(value, f"{ORIGIN}/docs/") == expected
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/posts/", True),
+        ("/posts/page/2/", True),
+        ("/docs/guide/chapter.html", True),
+        ("/static/talks/deck/", True),
+        ("/static/talks/deck/file.pdf", False),
+        ("/docs/guide/_static/example.html", False),
+        ("/static/index.html", False),
+        ("/health/", False),
+        ("/media/video", False),
+        ("/feeds/posts/", False),
+        ("/", False),
+        ("/404.html", False),
+        ("/search.html", False),
+    ],
+)
+def test_page_filter(path: str, expected: bool) -> None:
+    """Check page eligibility.
+
+    Args:
+        path: Public path.
+        expected: Whether it is a page candidate.
+
+    Returns:
+        None.
+
+    Examples:
+        HTML decks are included while media files are excluded.
+    """
+    assert is_page_url(f"{ORIGIN}{path}") is expected
+
+
+def test_build_seeds_include_talks_decks_and_docs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Include pages missing from the site's sitemap.
+
+    Args:
+        tmp_path: Temporary build directory.
+        monkeypatch: Patches the docs catalog.
+
+    Returns:
+        None.
+
+    Examples:
+        Stable deck entrypoints are included; hashed copies are not.
+    """
+    for name in [
+        "posts/2026/01/01/example/index.html",
+        "talks/example/index.html",
+        "static/talks/example/index.html",
+        "static/talks/example/index.aabbcc.html",
+        "static/ignored.html",
+        "404.html",
+        "500.html",
+    ]:
+        path = tmp_path / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("<p>Page</p>")
+    monkeypatch.setattr(
+        discovery,
+        "load_docs",
+        lambda: [
+            Doc("Guide", "lesson-plan", f"{ORIGIN}/docs/guide/"),
+            Doc("External", "software", "https://example.com/"),
+        ],
+    )
+    assert build_seeds(tmp_path) == [
+        f"{ORIGIN}/docs/guide/",
+        f"{ORIGIN}/docs/guide/sitemap.xml",
+        f"{ORIGIN}/posts/2026/01/01/example/",
+        f"{ORIGIN}/sitemap.xml",
+        f"{ORIGIN}/static/talks/example/",
+        f"{ORIGIN}/talks/example/",
+    ]
+
+
+def test_empty_or_missing_build_is_an_error(tmp_path: Path) -> None:
+    """Reject an inventory with no build input.
+
+    Args:
+        tmp_path: Empty directory.
+
+    Returns:
+        None.
+
+    Examples:
+        A missing dist directory instructs the user to run make bake.
+    """
+    for path in [tmp_path, tmp_path / "absent"]:
+        with pytest.raises(ArchiveError, match="make bake"):
+            build_seeds(path)
+
+
+def test_discovery_resumes_links_and_sitemaps(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Checkpoint discovery and avoid link cycles or off-site requests.
+
+    Args:
+        tmp_path: Manifest directory.
+        monkeypatch: Replaces network access.
+
+    Returns:
+        None.
+
+    Examples:
+        The second batch processes the first batch's remaining queue.
+    """
+    first = f"{ORIGIN}/docs/guide/"
+    second = f"{ORIGIN}/docs/guide/next.html"
+    sitemap = f"{ORIGIN}/sitemap.xml"
+    responses = {
+        first: response('<a href="next.html">Next</a><a href="https://example.com/">Away</a>'),
+        second: response('<a href="./">Back</a><a href="/posts/page/2/">Older</a>'),
+        sitemap: response(
+            "<sitemapindex><sitemap><loc>https://palewi.re/sitemap-posts.xml</loc></sitemap></sitemapindex>",
+            content_type="application/xml",
+        ),
+        f"{ORIGIN}/sitemap-posts.xml": response(
+            "<urlset><url><loc>https://palewi.re/posts/page/2/</loc></url>"
+            "<url><loc>https://example.com/</loc></url></urlset>",
+            content_type="text/xml",
+        ),
+        f"{ORIGIN}/posts/page/2/": response("Done"),
+    }
+    visited: list[str] = []
+
+    def get(_session: requests.Session, url: str, **kwargs: object) -> requests.Response:
+        """Return a fixture response.
+
+        Args:
+            _session: Unused session.
+            url: Requested URL.
+            **kwargs: Request options.
+
+        Returns:
+            Fixture response.
+
+        Examples:
+            Used in place of Session.get.
+        """
+        assert kwargs["allow_redirects"] is False
+        visited.append(url)
+        return responses[url]
+
+    monkeypatch.setattr(requests.Session, "get", get)
+    store = ManifestStore(tmp_path / "manifest.json")
+    state = Manifest()
+    assert PageDiscovery(state, store, delay=0).run([first, sitemap], limit=1) == 1
+    state = store.load()
+    assert state.discovery_queue == [sitemap, second]
+    assert state.pages[first].live_status == "live"
+    assert not state.discovery_complete
+    PageDiscovery(state, store, delay=0).run([first, sitemap], limit=10)
+    assert state.discovery_complete
+    assert len(visited) == len(set(visited)) == 5
+    assert len(state.pages) == 3
+
+
+@pytest.mark.parametrize("status", [404, 410, 403])
+def test_missing_sitemap_does_not_stop_public_navigation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, status: int
+) -> None:
+    """Record unavailable sitemaps while continuing to read public links.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces network calls.
+        status: Unavailable sitemap HTTP status.
+
+    Returns:
+        None.
+
+    Examples:
+        A 403 sitemap is recorded without retrying through access controls.
+    """
+    sitemap = f"{ORIGIN}/docs/guide/sitemap.xml"
+    root = f"{ORIGIN}/docs/guide/"
+    monkeypatch.setattr(
+        requests.Session,
+        "get",
+        lambda _self, url, **kwargs: response(status=status) if url == sitemap else response("Public page"),
+    )
+    state = Manifest()
+    PageDiscovery(state, ManifestStore(tmp_path / "state.json"), delay=0).run([sitemap, root])
+    assert sitemap in state.discovery_errors
+    assert state.pages[root].live_status == "live"
+    assert not state.discovery_complete
+
+
+@pytest.mark.parametrize("destination", ["https://example.com/", "/posts/", "/alias/"])
+def test_redirects_are_not_captured(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, destination: str) -> None:
+    """Follow only same-host destinations and detect self redirects.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces network calls.
+        destination: Redirect target.
+
+    Returns:
+        None.
+
+    Examples:
+        An off-site redirect is recorded but never fetched.
+    """
+    result = response(status=302)
+    result.headers["Location"] = destination
+    monkeypatch.setattr(requests.Session, "get", lambda *args, **kwargs: result)
+    state = Manifest()
+    alias = f"{ORIGIN}/alias/"
+    PageDiscovery(state, ManifestStore(tmp_path / "state.json"), delay=0).run([alias], limit=1)
+    if destination == "/alias/":
+        assert state.pages[alias].live_status == "error"
+        assert "redirect cycle" in state.discovery_errors[alias]
+    else:
+        assert state.pages[alias].live_status == "redirect"
+        assert state.discovery_queue == ([f"{ORIGIN}/posts/"] if destination == "/posts/" else [])
+
+
+def test_errors_preserve_existing_pages(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep earlier page records when a later discovery request fails.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces network calls.
+
+    Returns:
+        None.
+
+    Examples:
+        A timeout must not delete previously discovered URLs.
+    """
+    state = Manifest()
+    url = f"{ORIGIN}/posts/"
+    state.page(url).live_status = "live"
+
+    def fail(*args: object, **kwargs: object) -> requests.Response:
+        """Raise a fake timeout.
+
+        Args:
+            *args: Unused positional arguments.
+            **kwargs: Unused options.
+
+        Returns:
+            Never returns.
+
+        Examples:
+            Replaces a network request in this test.
+        """
+        raise requests.Timeout("Timed out")
+
+    monkeypatch.setattr(requests.Session, "get", fail)
+    store = ManifestStore(tmp_path / "state.json")
+    PageDiscovery(state, store, delay=0).run([])
+    assert store.load().pages[url].live_status == "error"
+    assert state.discovery_errors[url] == "Timed out"
+    assert not state.discovery_complete
+
+
+@pytest.mark.parametrize(
+    ("result", "message"),
+    [
+        (response(status=302), "no Location"),
+        (response("binary", content_type="image/png"), "expected HTML"),
+        (response("<broken", content_type="text/xml"), "malformed sitemap"),
+        (response("<not-sitemap/>", content_type="text/xml"), "expected a sitemap"),
+    ],
+)
+def test_invalid_responses_are_recorded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, result: requests.Response, message: str
+) -> None:
+    """Record invalid responses as errors instead of valid pages.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces network calls.
+        result: Invalid response.
+        message: Expected error text.
+
+    Returns:
+        None.
+
+    Examples:
+        An image response cannot count as a live HTML page.
+    """
+    monkeypatch.setattr(requests.Session, "get", lambda *args, **kwargs: result)
+    url = f"{ORIGIN}/sitemap.xml" if result.headers["Content-Type"] == "text/xml" else f"{ORIGIN}/page/"
+    state = Manifest()
+    PageDiscovery(state, ManifestStore(tmp_path / "state.json"), delay=0).run([url])
+    assert message in state.discovery_errors[url]
+
+
+def test_response_size_limit_and_deadline(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stop large responses and retain unprocessed URLs when time runs out.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces network access and size limit.
+
+    Returns:
+        None.
+
+    Examples:
+        A deadline before now performs no network requests.
+    """
+    monkeypatch.setattr(discovery, "MAX_RESPONSE_BYTES", 2)
+    monkeypatch.setattr(requests.Session, "get", lambda *args, **kwargs: response("large"))
+    store = ManifestStore(tmp_path / "state.json")
+    state = Manifest()
+    url = f"{ORIGIN}/page/"
+    assert PageDiscovery(state, store, delay=0).run([url], deadline=0) == 0
+    assert store.load().discovery_queue == [url]
+    PageDiscovery(state, store, delay=0).run([url], limit=1)
+    assert "exceeds" in state.discovery_errors[url]
+
+
+def test_non_html_page_and_fake_sitemap(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reject responses whose format does not match their inventory role.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces network access.
+
+    Returns:
+        None.
+
+    Examples:
+        An HTML error page at sitemap.xml is not a successful sitemap.
+    """
+    root = f"{ORIGIN}/page/"
+    sitemap = f"{ORIGIN}/sitemap.xml"
+    monkeypatch.setattr(
+        requests.Session,
+        "get",
+        lambda _self, url, **kwargs: (
+            response("<urlset/>", content_type="application/xml") if url == root else response("Not a sitemap")
+        ),
+    )
+    state = Manifest()
+    PageDiscovery(state, ManifestStore(tmp_path / "state.json"), delay=0).run([root, sitemap])
+    assert "received XML" in state.discovery_errors[root]
+    assert "received HTML" in state.discovery_errors[sitemap]
+
+
+def test_redirect_cycle_across_pages(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep a multi-page redirect loop out of confirmed live pages.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces network access.
+
+    Returns:
+        None.
+
+    Examples:
+        A to B to A terminates with a recorded discovery error.
+    """
+    first = f"{ORIGIN}/first/"
+    second = f"{ORIGIN}/second/"
+
+    def get(_session: requests.Session, url: str, **kwargs: object) -> requests.Response:
+        """Return the next redirect in the loop.
+
+        Args:
+            _session: Unused session.
+            url: Requested page.
+            **kwargs: Unused request options.
+
+        Returns:
+            A redirect to the other page.
+
+        Examples:
+            The first page redirects to the second.
+        """
+        result = response(status=301)
+        result.headers["Location"] = second if url == first else first
+        return result
+
+    monkeypatch.setattr(requests.Session, "get", get)
+    state = Manifest()
+    PageDiscovery(state, ManifestStore(tmp_path / "state.json"), delay=0).run([first])
+    assert "redirect cycle" in state.discovery_errors[second]
+    assert not state.discovery_queue
+
+
+def test_live_missing_and_completed_sweep_restart(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retain missing pages and revisit them in the next sweep.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces network access.
+
+    Returns:
+        None.
+
+    Examples:
+        A page returning 404 is not silently erased from the inventory.
+    """
+    url = f"{ORIGIN}/page/"
+    state = Manifest()
+    store = ManifestStore(tmp_path / "state.json")
+    monkeypatch.setattr(requests.Session, "get", lambda *args, **kwargs: response(status=404))
+    PageDiscovery(state, store, delay=0).run([url])
+    assert state.pages[url].live_status == "missing"
+    monkeypatch.setattr(requests.Session, "get", lambda *args, **kwargs: response("Recovered"))
+    PageDiscovery(state, store, delay=0).run([])
+    assert state.pages[url].live_status == "live"
+    assert state.discovery_complete
+
+
+@pytest.mark.parametrize("status", [429, 503])
+def test_service_failures_defer_remaining_discovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, status: int
+) -> None:
+    """Stop requesting pages from a throttled or unavailable server.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces network access.
+        status: Temporary server failure.
+
+    Returns:
+        None.
+
+    Examples:
+        A 429 response leaves both pages queued for a future run.
+    """
+    first = f"{ORIGIN}/first/"
+    second = f"{ORIGIN}/second/"
+    monkeypatch.setattr(requests.Session, "get", lambda *args, **kwargs: response(status=status))
+    state = Manifest()
+    attempted = PageDiscovery(state, ManifestStore(tmp_path / "state.json"), delay=0).run([first, second])
+    assert attempted == 1
+    assert state.discovery_queue == [second, first]
+    assert not state.discovery_seen

--- a/tests/test_site_archive_manifest.py
+++ b/tests/test_site_archive_manifest.py
@@ -1,0 +1,289 @@
+"""Tests for strict site archive manifest persistence."""
+
+import json
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from scripts.site_archive.manifest import ArchiveError, Manifest, ManifestStore, PageRecord, utc_now
+
+URL = "https://palewi.re/posts/"
+SNAPSHOT = "https://web.archive.org/web/20260905120000/https://palewi.re/posts/"
+
+
+def test_manifest_rejects_contradictory_coverage(tmp_path: Path) -> None:
+    """Reject completion claims that disagree with the saved evidence.
+
+    Args:
+        tmp_path: Temporary test directory.
+
+    Returns:
+        None.
+
+    Examples:
+        A nonempty discovery queue cannot be reported as complete.
+    """
+    store = ManifestStore(tmp_path / "manifest.json")
+    state = Manifest(discovery_complete=True, discovery_queue=[URL])
+    with pytest.raises(ArchiveError, match="cannot be complete"):
+        store.save(state)
+    state = Manifest()
+    page = state.page(URL)
+    page.archive_url = SNAPSHOT
+    page.snapshot_at = "20260904120000"
+    with pytest.raises(ArchiveError, match="does not match"):
+        store.save(state)
+
+
+def test_manifest_rejects_invalid_encoding_and_broken_links(tmp_path: Path) -> None:
+    """Do not treat unreadable state as an absent manifest.
+
+    Args:
+        tmp_path: Temporary test directory.
+
+    Returns:
+        None.
+
+    Examples:
+        A broken manifest symlink raises an error instead of starting over.
+    """
+    path = tmp_path / "manifest.json"
+    path.write_bytes(b"\xff")
+    with pytest.raises(ArchiveError, match="invalid manifest"):
+        ManifestStore(path).load()
+    link = tmp_path / "broken.json"
+    link.symlink_to(tmp_path / "absent.json")
+    with pytest.raises(ArchiveError, match="invalid manifest"):
+        ManifestStore(link).load()
+
+
+def test_manifest_round_trip_creates_pages_and_writes_atomically(tmp_path: Path) -> None:
+    """Persist all supported fields and reload their typed defaults.
+
+    Args:
+        tmp_path: Temporary test directory.
+
+    Returns:
+        None.
+
+    Examples:
+        New state records a page through ``Manifest.page``.
+    """
+    path = tmp_path / "state" / "manifest.json"
+    manifest = Manifest()
+    page = manifest.page(URL)
+    page.live_status = "live"
+    page.archive_status = "archived"
+    page.archive_url = SNAPSHOT
+    page.snapshot_at = "20260905120000"
+    page.last_verified_at = utc_now()
+    manifest.discovery_complete = True
+    ManifestStore(path).save(manifest)
+
+    saved = json.loads(path.read_text())
+    assert set(saved) == {
+        "pages",
+        "discovery_queue",
+        "discovery_seen",
+        "discovery_errors",
+        "discovery_complete",
+        "discovery_started_at",
+    }
+    assert not path.with_suffix(".json.tmp").exists()
+    loaded = ManifestStore(path).load()
+    assert loaded.pages[URL] == page
+    assert loaded.discovery_complete is True
+
+
+@pytest.mark.parametrize(
+    ("contents", "message"),
+    [
+        ("not json", "invalid manifest JSON"),
+        ('{"pages": {}}', "invalid fields"),
+        (
+            '{"pages":{"http://palewi.re/posts/":{"url":"http://palewi.re/posts/"}},"discovery_queue":[],'
+            '"discovery_seen":[],"discovery_errors":{},"discovery_complete":false,"discovery_started_at":""}',
+            "normalized",
+        ),
+    ],
+)
+def test_manifest_rejects_corrupt_or_incomplete_inputs(tmp_path: Path, contents: str, message: str) -> None:
+    """Reject corrupt data instead of silently resetting saved state.
+
+    Args:
+        tmp_path: Temporary test directory.
+        contents: Invalid JSON document.
+        message: Expected error fragment.
+
+    Returns:
+        None.
+
+    Examples:
+        A file with invalid JSON raises ``ArchiveError``.
+    """
+    path = tmp_path / "manifest.json"
+    path.write_text(contents)
+    with pytest.raises(ArchiveError, match=message):
+        ManifestStore(path).load()
+    assert path.read_text() == contents
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://www.palewi.re/posts/",
+        "https://palewi.re/posts/?page=2",
+        "https://palewi.re/posts/#top",
+        "https://palewi.re/a//b/",
+        "https://palewi.re/a/../b/",
+    ],
+)
+def test_manifest_rejects_non_normalized_page_urls(url: str) -> None:
+    """Reject URLs that could expand archive scope or duplicate coverage.
+
+    Args:
+        url: Invalid page URL.
+
+    Returns:
+        None.
+
+    Examples:
+        Query-bearing URLs cannot become manifest keys.
+    """
+    with pytest.raises(ArchiveError, match="normalized"):
+        Manifest().page(url)
+
+
+def test_manifest_rejects_invalid_record_types_and_snapshot_urls(tmp_path: Path) -> None:
+    """Validate types, UTC timestamps, statuses, and matching snapshots.
+
+    Args:
+        tmp_path: Temporary test directory.
+
+    Returns:
+        None.
+
+    Examples:
+        A page snapshot for another URL is rejected.
+    """
+    path = tmp_path / "manifest.json"
+    state = Manifest()
+    page = state.page(URL)
+    page.live_status = "not-live"
+    with pytest.raises(ArchiveError, match="live_status"):
+        ManifestStore(path).save(state)
+
+    page.live_status = "live"
+    page.last_check_at = "2026-09-05T12:00:00+02:00"
+    with pytest.raises(ArchiveError, match="UTC timestamp"):
+        ManifestStore(path).save(state)
+
+    page.last_check_at = ""
+    page.archive_url = "https://web.archive.org/web/20260905120000/https://palewi.re/elsewhere/"
+    with pytest.raises(ArchiveError, match="match its page"):
+        ManifestStore(path).save(state)
+
+    page.archive_url = SNAPSHOT
+    page.attempts = True
+    with pytest.raises(ArchiveError, match="non-negative integer"):
+        ManifestStore(path).save(state)
+
+
+def test_manifest_requires_confirmed_and_pending_archive_evidence(tmp_path: Path) -> None:
+    """Reject archive statuses that would incorrectly claim durable coverage.
+
+    Args:
+        tmp_path: Temporary test directory.
+
+    Returns:
+        None.
+
+    Examples:
+        An archived record cannot omit when its snapshot was verified.
+    """
+    path = tmp_path / "manifest.json"
+    archived = Manifest()
+    page = archived.page(URL)
+    page.archive_status = "archived"
+    page.archive_url = SNAPSHOT
+    page.snapshot_at = "20260905120000"
+    with pytest.raises(ArchiveError, match="last_verified_at"):
+        ManifestStore(path).save(archived)
+
+    page.last_verified_at = utc_now()
+    ManifestStore(path).save(archived)
+    corrupted = json.loads(path.read_text())
+    corrupted["pages"][URL]["snapshot_at"] = 0
+    path.write_text(json.dumps(corrupted))
+    with pytest.raises(ArchiveError, match="snapshot_at must be a string"):
+        ManifestStore(path).load()
+
+    pending = Manifest()
+    pending.page(URL).archive_status = "pending"
+    with pytest.raises(ArchiveError, match="last_submit_at"):
+        ManifestStore(path).save(pending)
+
+
+def test_manifest_rejects_impossible_snapshot_dates(tmp_path: Path) -> None:
+    """Reject digit-only timestamps that are not real dates.
+
+    Args:
+        tmp_path: Temporary test directory.
+
+    Returns:
+        None.
+
+    Examples:
+        February 30 cannot identify an archived page.
+    """
+    path = tmp_path / "manifest.json"
+    state = Manifest()
+    page = state.page(URL)
+    page.archive_status = "archived"
+    page.archive_url = "https://web.archive.org/web/20260230000000/https://palewi.re/posts/"
+    page.snapshot_at = "20260230000000"
+    page.last_verified_at = utc_now()
+    with pytest.raises(ArchiveError, match="real UTC timestamp"):
+        ManifestStore(path).save(state)
+
+
+def test_absent_manifest_returns_empty_but_invalid_object_does_not(tmp_path: Path) -> None:
+    """Distinguish a first run from malformed persisted state.
+
+    Args:
+        tmp_path: Temporary test directory.
+
+    Returns:
+        None.
+
+    Examples:
+        A missing file returns an empty ``Manifest``.
+    """
+    path = tmp_path / "manifest.json"
+    assert ManifestStore(path).load() == Manifest()
+    with pytest.raises(ArchiveError, match="expected a Manifest"):
+        ManifestStore(path).save(cast(Manifest, PageRecord(url=URL)))
+
+
+def test_manifest_allows_normalized_sitemaps_in_discovery_state(tmp_path: Path) -> None:
+    """Persist sitemap work without treating it as an archiveable HTML page.
+
+    Args:
+        tmp_path: Temporary test directory.
+
+    Returns:
+        None.
+
+    Examples:
+        Sitemap URLs can occur in queues, seen lists, and discovery errors.
+    """
+    path = tmp_path / "manifest.json"
+    sitemap = "https://palewi.re/sitemap.xml"
+    manifest = Manifest(
+        discovery_queue=[sitemap],
+        discovery_seen=[URL],
+        discovery_errors={sitemap: "HTTP 503"},
+    )
+    ManifestStore(path).save(manifest)
+    assert ManifestStore(path).load() == manifest

--- a/tests/test_site_archive_wayback.py
+++ b/tests/test_site_archive_wayback.py
@@ -1,0 +1,398 @@
+"""Offline tests for Wayback verification and capture state changes."""
+
+import json
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import requests
+from savepagenow.exceptions import TooManyRequests, WaybackRuntimeError
+
+from scripts.site_archive.manifest import ArchiveError, PageRecord
+from scripts.site_archive.wayback import AVAILABILITY_URL, USER_AGENT, WaybackClient
+
+URL = "https://palewi.re/posts/"
+STAMP = "20260905120000"
+SNAPSHOT = f"https://web.archive.org/web/{STAMP}/https://palewi.re/posts/"
+NOW = datetime(2026, 9, 5, 12, 0, tzinfo=UTC)
+
+
+class Session:
+    """Minimal request session returning a configured response or exception."""
+
+    def __init__(self, result: requests.Response | BaseException):
+        """Set a response returned from the availability endpoint.
+
+        Args:
+            result: Response or exception to return.
+
+        Returns:
+            None.
+
+        Examples:
+            ``Session(response({"archived_snapshots": {}}))`` reports absent data.
+        """
+        self.result = result
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    def get(self, url: str, **kwargs: object) -> requests.Response:
+        """Record and return one availability response.
+
+        Args:
+            url: Requested endpoint.
+            **kwargs: Request options.
+
+        Returns:
+            Configured response.
+
+        Examples:
+            The client requests the documented availability endpoint.
+        """
+        self.calls.append((url, kwargs))
+        if isinstance(self.result, BaseException):
+            raise self.result
+        return self.result
+
+
+def response(payload: object, status: int = 200, retry_after: str | None = None) -> requests.Response:
+    """Build an in-memory JSON response.
+
+    Args:
+        payload: JSON value to return.
+        status: HTTP status code.
+        retry_after: Optional Retry-After header.
+
+    Returns:
+        Configured requests response.
+
+    Examples:
+        ``response({"archived_snapshots": {}})`` represents no snapshot.
+    """
+    result = requests.Response()
+    result.status_code = status
+    result.url = AVAILABILITY_URL
+    result._content = json.dumps(payload).encode()
+    if retry_after:
+        result.headers["Retry-After"] = retry_after
+    return result
+
+
+def client(
+    result: requests.Response | BaseException,
+    *,
+    capture_page: Callable[..., str] | None = None,
+    sleep: Callable[[float], None] | None = None,
+) -> WaybackClient:
+    """Create a deterministic client around one fake availability response.
+
+    Args:
+        result: Availability result.
+        capture_page: Optional capture replacement.
+        sleep: Optional delay replacement.
+
+    Returns:
+        Configured client.
+
+    Examples:
+        ``client(response({"archived_snapshots": {}}))``.
+    """
+    return WaybackClient(
+        session=Session(result),
+        capture_page=capture_page if capture_page is not None else lambda **kwargs: SNAPSHOT,
+        clock=lambda: NOW,
+        sleep=sleep if sleep is not None else lambda seconds: None,
+    )
+
+
+def test_verify_confirms_only_matching_valid_snapshots() -> None:
+    """Record a valid same-page snapshot as confirmed archive evidence.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        HTTP and www source equivalents are accepted for the same page.
+    """
+    page = PageRecord(url=URL, live_status="live")
+    snapshot = f"http://web.archive.org/web/{STAMP}/http://www.palewi.re/posts/"
+    archive = client(
+        response(
+            {"archived_snapshots": {"closest": {"available": True, "status": 200, "timestamp": STAMP, "url": snapshot}}}
+        )
+    )
+    archive.verify(page)
+    assert page.archive_status == "archived"
+    assert page.archive_url == snapshot.replace("http://", "https://", 1)
+    assert page.snapshot_at == STAMP
+    assert page.last_verified_at == "2026-09-05T12:00:00Z"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"archived_snapshots": {"closest": {"available": [], "status": "200"}}},
+        {"archived_snapshots": {"closest": {"available": False, "status": {}}}},
+        {"archived_snapshots": {"closest": {"available": True, "status": "200", "timestamp": "bad", "url": SNAPSHOT}}},
+        {
+            "archived_snapshots": {
+                "closest": {
+                    "available": True,
+                    "status": "200",
+                    "timestamp": STAMP,
+                    "url": f"https://web.archive.org/web/{STAMP}/https://palewi.re/other/",
+                }
+            }
+        },
+    ],
+)
+def test_verify_rejects_malformed_and_wrong_url_snapshots(payload: object) -> None:
+    """Treat malformed availability evidence as an error, never as missing.
+
+    Args:
+        payload: Invalid API payload.
+
+    Returns:
+        None.
+
+    Examples:
+        An absent ``archived_snapshots`` mapping is malformed.
+    """
+    page = PageRecord(url=URL, live_status="live")
+    with pytest.raises(ArchiveError, match="Wayback"):
+        client(response(payload)).verify(page)
+    assert page.archive_status == "unknown"
+    assert page.last_check_status == "error"
+    assert page.next_retry_at
+
+
+def test_verify_empty_mapping_is_missing_but_retains_fresh_pending_capture() -> None:
+    """Allow Save Page Now time to process before a capture is resubmitted.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        Empty snapshot data changes an ordinary record to missing.
+    """
+    ordinary = PageRecord(url=URL, live_status="live")
+    client(response({"archived_snapshots": {}})).verify(ordinary)
+    assert ordinary.archive_status == "missing"
+    assert ordinary.last_check_status == "success"
+
+    pending = PageRecord(
+        url=URL,
+        live_status="live",
+        archive_status="pending",
+        pending_archive_url=SNAPSHOT,
+        last_submit_at=(NOW - timedelta(hours=1)).isoformat(),
+    )
+    client(response({"archived_snapshots": {}})).verify(pending)
+    assert pending.archive_status == "pending"
+    assert pending.pending_archive_url == SNAPSHOT
+
+
+def test_verify_throttle_honors_retry_after_and_preserves_archived_evidence() -> None:
+    """Keep earlier valid archives when a later service request is throttled.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        A 429 response records its Retry-After cooldown.
+    """
+    page = PageRecord(
+        url=URL,
+        live_status="live",
+        archive_status="archived",
+        archive_url=SNAPSHOT,
+        snapshot_at=STAMP,
+    )
+    with pytest.raises(ArchiveError, match="availability check failed"):
+        client(response({}, status=429, retry_after="120")).verify(page)
+    assert page.archive_status == "archived"
+    assert page.archive_url == SNAPSHOT
+    assert page.last_check_status == "error"
+    assert page.next_retry_at == "2026-09-05T12:02:00Z"
+
+
+def test_capture_requires_credentials_before_network_work(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Record missing Save Page Now credentials as resumable state.
+
+    Args:
+        monkeypatch: Removes environment credentials.
+
+    Returns:
+        None.
+
+    Examples:
+        Capture does not perform its confirming lookup without credentials.
+    """
+    monkeypatch.delenv("SAVEPAGENOW_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("SAVEPAGENOW_SECRET_KEY", raising=False)
+    session = Session(response({"archived_snapshots": {}}))
+    page = PageRecord(url=URL, live_status="live", archive_status="missing")
+    with pytest.raises(ArchiveError, match="SAVEPAGENOW_ACCESS_KEY"):
+        WaybackClient(session=session, clock=lambda: NOW).capture(page)
+    assert not session.calls
+    assert page.last_check_status == "error"
+    assert page.next_retry_at
+
+
+def test_capture_rechecks_then_records_pending_and_respects_rate_delay(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Submit only after a fresh absence check and require later verification.
+
+    Args:
+        monkeypatch: Supplies capture credentials.
+
+    Returns:
+        None.
+
+    Examples:
+        A returned Save Page Now URL remains pending, not archived.
+    """
+    monkeypatch.setenv("SAVEPAGENOW_ACCESS_KEY", "key")
+    monkeypatch.setenv("SAVEPAGENOW_SECRET_KEY", "secret")
+    captured: list[dict[str, object]] = []
+
+    def submit(url: str, **kwargs: object) -> str:
+        """Return a pending snapshot URL.
+
+        Args:
+            url: Submitted page URL.
+            **kwargs: Save Page Now options.
+
+        Returns:
+            Pending snapshot URL.
+
+        Examples:
+            The submission is authenticated and permits cache results.
+        """
+        assert url == URL
+        captured.append(kwargs)
+        return SNAPSHOT
+
+    page = PageRecord(url=URL, live_status="live", archive_status="missing")
+    archive = client(response({"archived_snapshots": {}}), capture_page=submit)
+    archive.capture(page)
+    assert page.archive_status == "pending"
+    assert page.pending_archive_url == SNAPSHOT
+    assert page.archive_url == ""
+    assert page.last_submit_at == "2026-09-05T12:00:00Z"
+    assert captured == [
+        {
+            "user_agent": USER_AGENT,
+            "accept_cache": True,
+            "timeout": 30,
+            "authenticate": True,
+        }
+    ]
+
+
+def test_capture_keeps_response_headers_and_bodies_out_of_error_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Store safe capture failures while retaining retry information.
+
+    Args:
+        monkeypatch: Supplies capture credentials.
+
+    Returns:
+        None.
+
+    Examples:
+        A rate-limit response contributes only its bounded Retry-After value.
+    """
+    monkeypatch.setenv("SAVEPAGENOW_ACCESS_KEY", "key")
+    monkeypatch.setenv("SAVEPAGENOW_SECRET_KEY", "secret")
+    page = PageRecord(url=URL, live_status="live", archive_status="missing")
+
+    def throttled(url: str, **kwargs: object) -> str:
+        """Raise an exception with sensitive response headers.
+
+        Args:
+            url: Submitted page URL.
+            **kwargs: Unused Save Page Now options.
+
+        Returns:
+            Never returns.
+
+        Examples:
+            Save Page Now places headers in ``TooManyRequests.args``.
+        """
+        raise TooManyRequests({"Retry-After": "120", "Set-Cookie": "secret-cookie"})
+
+    with pytest.raises(ArchiveError, match="rate limited"):
+        client(response({"archived_snapshots": {}}), capture_page=throttled).capture(page)
+    assert page.last_error == "Wayback capture was rate limited (HTTP 429)"
+    assert "secret-cookie" not in page.last_error
+    assert page.next_retry_at == "2026-09-05T12:02:00Z"
+
+    opaque = PageRecord(url=URL, live_status="live", archive_status="missing")
+
+    def malformed_response(url: str, **kwargs: object) -> str:
+        """Raise an opaque Wayback error with a response-like body.
+
+        Args:
+            url: Submitted page URL.
+            **kwargs: Unused Save Page Now options.
+
+        Returns:
+            Never returns.
+
+        Examples:
+            Missing capture location errors must not write raw API payloads.
+        """
+        raise WaybackRuntimeError({"headers": {"Set-Cookie": "secret-cookie"}, "content": b"private body"})
+
+    with pytest.raises(ArchiveError, match="capture request failed"):
+        client(response({"archived_snapshots": {}}), capture_page=malformed_response).capture(opaque)
+    assert opaque.last_error == "Wayback capture request failed"
+    assert "private body" not in opaque.last_error
+
+
+def test_capture_timeout_stays_pending_before_later_verification(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Treat a lost capture response as potentially accepted by Wayback.
+
+    Args:
+        monkeypatch: Supplies capture credentials.
+
+    Returns:
+        None.
+
+    Examples:
+        A later availability lookup, rather than another submit, resolves a timeout.
+    """
+    monkeypatch.setenv("SAVEPAGENOW_ACCESS_KEY", "key")
+    monkeypatch.setenv("SAVEPAGENOW_SECRET_KEY", "secret")
+    page = PageRecord(url=URL, live_status="live", archive_status="missing")
+
+    def lost_response(url: str, **kwargs: object) -> str:
+        """Simulate a capture request whose response is lost.
+
+        Args:
+            url: Submitted page URL.
+            **kwargs: Unused Save Page Now options.
+
+        Returns:
+            Never returns.
+
+        Examples:
+            A timeout does not prove that Wayback rejected the capture.
+        """
+        raise requests.Timeout("private upstream response")
+
+    with pytest.raises(ArchiveError, match="capture timed out"):
+        client(response({"archived_snapshots": {}}), capture_page=lost_response).capture(page)
+    assert page.archive_status == "pending"
+    assert page.pending_archive_url == ""
+    assert page.last_submit_at == "2026-09-05T12:00:00Z"
+    assert page.last_check_status == "error"
+    assert page.last_error == "Wayback capture timed out"

--- a/tests/test_site_archive_workflow.py
+++ b/tests/test_site_archive_workflow.py
@@ -1,0 +1,74 @@
+"""Checks for the archive workflow's cross-job checkpoint wiring."""
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "site-archive.yaml"
+
+
+def test_checkpoint_includes_hidden_files_and_restores_expected_directory() -> None:
+    """Keep the persistent job's paths aligned with the uploaded artifact.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        The hidden .site-archive directory must not be excluded by upload-artifact.
+    """
+    jobs = yaml.safe_load(WORKFLOW.read_text())["jobs"]
+    upload = next(step for step in jobs["archive"]["steps"] if step.get("uses", "").startswith("actions/upload-"))
+    download = next(step for step in jobs["persist"]["steps"] if step.get("uses", "").startswith("actions/download-"))
+    assert upload["with"]["include-hidden-files"] is True
+    assert upload["with"]["if-no-files-found"] == "error"
+    assert upload["with"]["name"] == download["with"]["name"]
+    assert download["with"]["path"] == ".site-archive"
+    assert ".site-archive/manifest.json" in upload["with"]["path"]
+    assert ".site-archive/state-token.json" in upload["with"]["path"]
+    assert "always()" in upload["if"]
+    assert "always()" in jobs["persist"]["if"]
+
+
+def test_only_persistence_can_write_and_both_jobs_use_the_same_source() -> None:
+    """Limit write access and prevent different code between archive and persist.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        A push to main during a long run cannot change its persistence code.
+    """
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    jobs = workflow["jobs"]
+    assert jobs["archive"]["permissions"]["contents"] == "read"
+    assert jobs["persist"]["permissions"]["contents"] == "write"
+    assert workflow["concurrency"]["cancel-in-progress"] is False
+    for job in jobs.values():
+        checkout = next(step for step in job["steps"] if step.get("uses", "").startswith("actions/checkout@"))
+        assert checkout["with"]["ref"] == "${{ github.sha }}"
+        assert checkout["with"]["persist-credentials"] is False
+    assert "SAVEPAGENOW_SECRET_KEY" not in jobs["persist"]["env"]
+
+
+def test_lookup_failures_are_not_hidden_by_checkpoint_recovery() -> None:
+    """Report synchronization failures after recovery files have been uploaded.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        Saving partial progress must not turn a failed archive run green.
+    """
+    steps = yaml.safe_load(WORKFLOW.read_text())["jobs"]["archive"]["steps"]
+    failure = next(step for step in steps if step["name"] == "Surface synchronization failure")
+    assert failure["if"] == "steps.sync.outcome == 'failure'"
+    assert "exit 1" in failure["run"]


### PR DESCRIPTION
## Summary

<!-- What does this PR change? -->

- Discover public palewi.re pages, same-site documentation, and hosted HTML slide decks, rather than relying on the incomplete main sitemap.
- Check existing Wayback snapshots and request missing captures in limited, resumable batches. Keep pending requests, confirmed snapshots, blocked pages, and service errors separate.
- Save the manifest on the dedicated `site-archive-data` branch through guarded GitHub API updates. Run weekly or manually without blocking site deployment.
- Add local commands, operating documentation, and offline coverage for discovery, capture state, persistence, and workflow artifact handling.

## Testing

<!-- How was this tested? Did `make check` pass? -->

- [x] `make check` passes locally

552 tests passed, 2 skipped, with 91.10% coverage after bringing in the latest main. Live lookup-only batches confirmed existing snapshots and a missing page. Real data-branch creation, update, unchanged-state handling, and fetch comparisons succeeded. A live documentation crawl continued through public navigation when its optional sitemap returned 403. Authenticated captures will be exercised in Actions after merge; the required secret names are already configured there.

## Changelog

<!-- Required: apply exactly one changelog category before merging. The Lint
     check will fail until exactly one is applied. See RELEASING.md. -->

- [ ] `feature`
- [ ] `improvement`
- [ ] `fix`
- [x] `maintenance`
- [ ] `skip-changelog`

## Deployment notes

<!-- Any configuration changes or manual steps needed after deploy? -->

The `site-archive-data` branch already contains an initial, partial manifest: 176 known URLs, 5 confirmed archives, 1 missing archive, and 170 unchecked pages. Further discovery remains queued. No credentials or generated state are added to main.

After merge, run **Site archive** with `lookup_only=true`, inspect its persisted report, then run its limited authenticated capture batch. Weekly runs are Mondays at 06:17 UTC. Only the persistence job needs `contents: write`; Save Page Now credentials are restricted to the archive job.

A page snapshot does not guarantee preservation of embedded media or interactive features. Unlinked documentation pages published by other repositories cannot be proven discoverable from this repository alone.