### PR TITLE
Remove dead OpenNews recording link

### DIFF
--- a/coltrane/content/talks.yaml
+++ b/coltrane/content/talks.yaml
@@ -354,7 +354,6 @@ talks:
   venue: OpenNews Community Call
   location: SoundCloud
   date: '2021-11-04'
-  video_url: https://soundcloud.app.goo.gl/K4Qmy
 - title: 'Beyond JMS: The power of Python'
   venue: San Diego State University
   location: Zoom

--- a/preservation-review-baseline.json
+++ b/preservation-review-baseline.json
@@ -15,7 +15,6 @@
     {"source_url": "https://palewire.s3.amazonaws.com/latimes-tour/handle.mp4", "code": "local-media-untracked", "reason": "Historical media source awaiting recovery in issue #396."},
     {"source_url": "https://palewire.s3.amazonaws.com/latimes-tour/kardex.mp4", "code": "local-media-untracked", "reason": "Historical media source awaiting recovery in issue #396."},
     {"source_url": "https://soundcloud.app.goo.gl/7hPSU", "code": "local-media-untracked", "reason": "Historical media source awaiting recovery in issue #396."},
-    {"source_url": "https://soundcloud.app.goo.gl/K4Qmy", "code": "local-media-untracked", "reason": "Historical media source awaiting recovery in issue #396."},
     {"source_url": "https://soundcloud.com/ire-nicar/a-conversation-with-ben-welsh", "code": "local-media-untracked", "reason": "Public M4A stream was backed up and checksum-verified in the external archive, then mirrored to the private palewire-talk-media R2 bucket on 2026-09-05."},
     {"source_url": "https://vimeo.com/1187819115/4fcb0378ca?share=copy&fl=sv&fe=ci", "code": "local-media-untracked", "reason": "Historical media source awaiting recovery in issue #396."},
     {"source_url": "https://vimeo.com/214875675", "code": "local-media-untracked", "reason": "Historical media source awaiting recovery in issue #396."},

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -120,7 +120,7 @@ def test_list_pages_use_page_specific_metadata_descriptions(client, page, expect
         ("/code/", "e68e63b83db587a66dc18b1f7d07584dbb38f6bc9ab45d92a25089d7c02b52e7"),
         ("/guides/", "d0ce6e3ca42af59d07b3fa71e04ef5051de41202012b6fdc9b9ac535216b06b3"),
         ("/docs/", "bced3578a4a815d297afebd115ce705f82f366e5807eab902af66ad5f332a5b3"),
-        ("/talks/", "970dd096ab9dd688148c8caa62f5444ed42239aa67e699bd4fdf4eb8861262b6"),
+        ("/talks/", "7f2e2528159cdb851952e2e610d8b3d1e1a5eebab1bb148a99e5245039e7b8a0"),
         ("/bots/", "9e2991194a5be838f4ff33d1b5403065a752c57e235a28e7253399772dd63b41"),
     ],
 )


### PR DESCRIPTION
## Summary
- remove the unavailable OpenNews SoundCloud URL from the talks index
- retain the historical talk record as an unlinked entry
- remove the matching stale preservation item

## Validation
- `make preservation-review`
- `make check`