### PR TITLE
Fix site archive capture reliability

### DIFF
--- a/.github/workflows/site-archive.yaml
+++ b/.github/workflows/site-archive.yaml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Upload recovery checkpoint
         if: always() && steps.fetch.outputs.ready == 'true'
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: site-archive-checkpoint
           path: |
@@ -153,7 +153,7 @@ jobs:
         run: make ci-bootstrap
 
       - name: Download recovery checkpoint
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: site-archive-checkpoint
           path: .site-archive

--- a/docs/site-archive.md
+++ b/docs/site-archive.md
@@ -37,7 +37,9 @@ HTML and checks Wayback again. It saves the pending request before contacting
 the capture service, so an interrupted response does not lead to an immediate
 duplicate submission. Availability lookups time out after 30 seconds; capture
 requests have a separate 120-second timeout. Due pending captures are checked
-before pages that have never been checked.
+before pages that have never been checked. A returned snapshot URL that differs
+only by one trailing slash is accepted only after both live pages report the
+requested canonical URL.
 
 ## Durable branch persistence
 

--- a/docs/site-archive.md
+++ b/docs/site-archive.md
@@ -35,7 +35,9 @@ credentials.
 Before submitting a capture, the tool checks that the page still serves public
 HTML and checks Wayback again. It saves the pending request before contacting
 the capture service, so an interrupted response does not lead to an immediate
-duplicate submission.
+duplicate submission. Availability lookups time out after 30 seconds; capture
+requests have a separate 120-second timeout. Due pending captures are checked
+before pages that have never been checked.
 
 ## Durable branch persistence
 

--- a/scripts/site_archive/cli.py
+++ b/scripts/site_archive/cli.py
@@ -114,7 +114,7 @@ class ArchiveRun:
         self.wayback_failed = False
 
     def verify(self, limit: int, deadline: float) -> None:
-        """Check live pages, prioritizing unknown state and older checks.
+        """Check live pages, prioritizing pending confirmations, then fair ordering.
 
         Args:
             limit: Maximum page lookups.
@@ -133,7 +133,12 @@ class ArchiveRun:
                 for page in self.manifest.pages.values()
                 if page.live_status == "live" and page.archive_status != "blocked" and is_due(page)
             ),
-            key=lambda page: (bool(page.last_check_at), page.last_check_at, page.url),
+            key=lambda page: (
+                page.archive_status != "pending",
+                bool(page.last_check_at),
+                page.last_check_at,
+                page.url,
+            ),
         )
         for page in pages[:limit]:
             if time.monotonic() >= deadline:

--- a/scripts/site_archive/manifest.py
+++ b/scripts/site_archive/manifest.py
@@ -441,9 +441,27 @@ def _validate_snapshot_url(url: str, location: str, page_url: str) -> None:
         or original_port not in {None, 80 if original.scheme == "http" else 443}
         or original.query
         or original.fragment
-        or original.path != page.path
+        or (original.path != page.path and not paths_differ_only_by_trailing_slash(original.path, page.path))
     ):
         raise ArchiveError(f"{location}: snapshot must match its page URL")
+
+
+def paths_differ_only_by_trailing_slash(first: str, second: str) -> bool:
+    """Check whether two paths differ only by one final slash.
+
+    Args:
+        first: First URL path.
+        second: Second URL path.
+
+    Returns:
+        Whether either path is the other path with exactly one trailing slash.
+
+    Examples:
+        ``paths_differ_only_by_trailing_slash("/docs/week-1", "/docs/week-1/")`` is True.
+    """
+    return (first.endswith("/") and not second.endswith("/") and first[:-1] == second) or (
+        second.endswith("/") and not first.endswith("/") and second[:-1] == first
+    )
 
 
 def _validate_wayback_timestamp(value: str, location: str) -> None:

--- a/scripts/site_archive/wayback.py
+++ b/scripts/site_archive/wayback.py
@@ -16,7 +16,9 @@ from savepagenow import BlockedByRobots
 from savepagenow import capture as save_capture
 from savepagenow.exceptions import BadGateway, TooManyRequests, UnknownError, WaybackRuntimeError
 
-from scripts.site_archive.manifest import ArchiveError, PageRecord
+from scripts.check_built_site import PageParser
+from scripts.site_archive.discovery import MAX_RESPONSE_BYTES, normalize_url
+from scripts.site_archive.manifest import ArchiveError, PageRecord, paths_differ_only_by_trailing_slash
 
 AVAILABILITY_URL = "https://archive.org/wayback/available"
 USER_AGENT = "palewi.re site archiver (https://github.com/palewire/palewi.re)"
@@ -119,7 +121,7 @@ class WaybackClient:
             )
             response.raise_for_status()
             payload = response.json()
-            snapshot = _availability_snapshot(payload, page.url)
+            snapshot = _availability_snapshot(payload, page.url, self._validate_snapshot)
         except (requests.RequestException, ValueError, ArchiveError) as error:
             message = _safe_error(error, operation="availability check")
             self._record_error(page, message, _retry_after(error, self._datetime()))
@@ -192,7 +194,7 @@ class WaybackClient:
             )
             if not isinstance(snapshot_url, str):
                 raise ArchiveError("Wayback capture returned no snapshot URL")
-            normalized, _ = _validate_snapshot(snapshot_url, page.url)
+            normalized, _ = self._validate_snapshot(snapshot_url, page.url)
         except BlockedByRobots:
             page.archive_status = "blocked"
             page.last_error = "Wayback capture blocked by the publisher's robots policy"
@@ -217,6 +219,77 @@ class WaybackClient:
         page.last_error = ""
         page.next_retry_at = ""
         page.attempts = 0
+
+    def _validate_snapshot(self, snapshot_url: str, page_url: str) -> tuple[str, str]:
+        """Validate a snapshot and prove a permitted trailing-slash alias.
+
+        Args:
+            snapshot_url: Candidate Wayback snapshot URL.
+            page_url: Requested canonical public page URL.
+
+        Returns:
+            Normalized HTTPS snapshot URL and its timestamp.
+
+        Raises:
+            ArchiveError: The snapshot is invalid or its alias cannot be proven.
+
+        Examples:
+            ``client._validate_snapshot(snapshot, "https://palewi.re/posts/")`` validates a snapshot.
+        """
+        normalized, timestamp, original = _parse_snapshot(snapshot_url)
+        if _same_original_url(original, page_url):
+            return normalized, timestamp
+        if not _is_trailing_slash_alias(original, page_url):
+            raise ArchiveError("Wayback snapshot does not match the requested page URL")
+        alias_url = normalize_url(original)
+        if alias_url is None:
+            raise ArchiveError("Wayback snapshot does not match the requested page URL")
+        if self._live_canonical(page_url) != page_url or self._live_canonical(alias_url) != page_url:
+            raise ArchiveError("Wayback snapshot trailing-slash alias cannot be proven by live canonical links")
+        return normalized, timestamp
+
+    def _live_canonical(self, url: str) -> str:
+        """Fetch one public HTML page and return its sole normalized canonical link.
+
+        Args:
+            url: Normalized public page URL to read.
+
+        Returns:
+            The page's normalized canonical URL.
+
+        Raises:
+            ArchiveError: The page is not successful HTML with one valid canonical link.
+            requests.RequestException: The public page request fails.
+
+        Examples:
+            ``client._live_canonical("https://palewi.re/posts/")`` returns its canonical URL.
+        """
+        self._wait_for("lookup")
+        with self.session.get(
+            url,
+            headers={"User-Agent": USER_AGENT},
+            timeout=self.timeout,
+            allow_redirects=False,
+            stream=True,
+        ) as response:
+            if response.status_code != 200:
+                raise ArchiveError(f"{url}: expected live HTML, got HTTP {response.status_code}")
+            content_type = response.headers.get("Content-Type", "").split(";", 1)[0].strip().lower()
+            if content_type not in {"text/html", "application/xhtml+xml"}:
+                raise ArchiveError(f"{url}: expected live HTML, got {content_type!r}")
+            body = bytearray()
+            for chunk in response.iter_content(chunk_size=64_000):
+                body.extend(chunk)
+                if len(body) > MAX_RESPONSE_BYTES:
+                    raise ArchiveError(f"{url}: response exceeds {MAX_RESPONSE_BYTES} bytes")
+        parser = PageParser()
+        parser.feed(bytes(body).decode(response.encoding or "utf-8", errors="replace"))
+        if len(parser.canonicals) != 1:
+            raise ArchiveError(f"{url}: expected exactly one canonical link")
+        canonical = normalize_url(parser.canonicals[0], url)
+        if canonical is None:
+            raise ArchiveError(f"{url}: canonical link is not a normalized public URL")
+        return canonical
 
     def _wait_for(self, kind: str) -> None:
         """Apply the configured finite delay before another API request.
@@ -295,18 +368,23 @@ class WaybackClient:
         page.next_retry_at = (self._datetime() + delay).isoformat().replace("+00:00", "Z")
 
 
-def _availability_snapshot(payload: Any, page_url: str) -> tuple[str, str] | None:
+def _availability_snapshot(
+    payload: Any,
+    page_url: str,
+    validate_snapshot: Callable[[str, str], tuple[str, str]],
+) -> tuple[str, str] | None:
     """Extract a confirmed matching snapshot from an API response.
 
     Args:
         payload: Decoded Wayback availability response.
         page_url: Requested canonical public page URL.
+        validate_snapshot: Client method that validates a candidate snapshot.
 
     Returns:
         Normalized snapshot URL and timestamp, or None when truly absent.
 
     Examples:
-        ``_availability_snapshot({"archived_snapshots": {}}, url)`` is None.
+        ``_availability_snapshot({"archived_snapshots": {}}, url, validate_snapshot)`` is None.
     """
     if not isinstance(payload, dict):
         raise ArchiveError("Wayback returned an invalid availability response")
@@ -332,24 +410,23 @@ def _availability_snapshot(payload: Any, page_url: str) -> tuple[str, str] | Non
         raise ArchiveError("Wayback availability response has an invalid timestamp")
     if not isinstance(snapshot_url, str):
         raise ArchiveError("Wayback availability response has an invalid snapshot URL")
-    normalized, path_timestamp = _validate_snapshot(snapshot_url, page_url)
+    normalized, path_timestamp = validate_snapshot(snapshot_url, page_url)
     if path_timestamp != timestamp:
         raise ArchiveError("Wayback availability response has mismatched snapshot timestamps")
     return normalized, timestamp
 
 
-def _validate_snapshot(snapshot_url: str, page_url: str) -> tuple[str, str]:
-    """Validate, normalize, and identify one same-page Wayback snapshot.
+def _parse_snapshot(snapshot_url: str) -> tuple[str, str, str]:
+    """Validate and normalize the structure of one Wayback snapshot URL.
 
     Args:
         snapshot_url: Candidate Wayback snapshot URL.
-        page_url: Requested canonical public page URL.
 
     Returns:
-        Normalized HTTPS snapshot URL and its timestamp.
+        Normalized HTTPS snapshot URL, timestamp, and embedded original URL.
 
     Examples:
-        ``_validate_snapshot(snapshot, "https://palewi.re/")`` validates a snapshot.
+        ``_parse_snapshot(snapshot)`` extracts its original URL.
     """
     try:
         parsed = urlsplit(snapshot_url)
@@ -372,9 +449,7 @@ def _validate_snapshot(snapshot_url: str, page_url: str) -> tuple[str, str]:
     timestamp, original = match.groups()
     if not _is_wayback_timestamp(timestamp):
         raise ArchiveError("Wayback returned an invalid snapshot timestamp")
-    if not _same_original_url(original, page_url):
-        raise ArchiveError("Wayback snapshot does not match the requested page URL")
-    return f"https://web.archive.org{parsed.path}", timestamp
+    return f"https://web.archive.org{parsed.path}", timestamp, original
 
 
 def _same_original_url(candidate: str, page_url: str) -> bool:
@@ -408,6 +483,39 @@ def _same_original_url(candidate: str, page_url: str) -> bool:
         and original.path.rstrip("/") == page.path.rstrip("/")
         and original.path.endswith("/") == page.path.endswith("/")
         and page_port is None
+    )
+
+
+def _is_trailing_slash_alias(candidate: str, page_url: str) -> bool:
+    """Check whether a snapshot source is a supported one-slash path alias.
+
+    Args:
+        candidate: Original URL embedded in a Wayback snapshot.
+        page_url: Canonical requested public page URL.
+
+    Returns:
+        Whether the source satisfies strict URL checks except for one final slash.
+
+    Examples:
+        ``_is_trailing_slash_alias("https://palewi.re/posts", "https://palewi.re/posts/")`` is True.
+    """
+    try:
+        original = urlsplit(candidate)
+        page = urlsplit(page_url)
+        original_port = original.port
+        page_port = page.port
+    except ValueError:
+        return False
+    return (
+        original.scheme in {"http", "https"}
+        and original.hostname in {"palewi.re", "www.palewi.re"}
+        and original.username is None
+        and original.password is None
+        and original_port in {None, 80 if original.scheme == "http" else 443}
+        and not original.query
+        and not original.fragment
+        and page_port is None
+        and paths_differ_only_by_trailing_slash(original.path, page.path)
     )
 
 

--- a/scripts/site_archive/wayback.py
+++ b/scripts/site_archive/wayback.py
@@ -50,6 +50,7 @@ class WaybackClient:
         self,
         *,
         timeout: float = 30.0,
+        capture_timeout: float = 120.0,
         capture_delay: float = 12.0,
         lookup_delay: float = 1.0,
         session: HttpSession | None = None,
@@ -62,7 +63,8 @@ class WaybackClient:
         """Configure a rate-limited Wayback client.
 
         Args:
-            timeout: Per-request timeout in seconds.
+            timeout: Availability lookup timeout in seconds.
+            capture_timeout: Save Page Now capture timeout in seconds.
             capture_delay: Minimum delay between capture submissions.
             lookup_delay: Minimum delay between availability lookups.
             session: Optional requests session for testing or customization.
@@ -76,9 +78,10 @@ class WaybackClient:
             None.
 
         Examples:
-            ``WaybackClient(timeout=10.0).verify(page)`` checks one page.
+            ``WaybackClient(timeout=10.0, capture_timeout=120.0).verify(page)`` checks one page.
         """
         self.timeout = timeout
+        self.capture_timeout = capture_timeout
         self.capture_delay = capture_delay
         self.lookup_delay = lookup_delay
         self.session = session or requests.Session()
@@ -184,7 +187,7 @@ class WaybackClient:
                 page.url,
                 user_agent=USER_AGENT,
                 accept_cache=True,
-                timeout=max(1, int(self.timeout)),
+                timeout=max(1, int(self.capture_timeout)),
                 authenticate=True,
             )
             if not isinstance(snapshot_url, str):

--- a/tests/test_site_archive_cli.py
+++ b/tests/test_site_archive_cli.py
@@ -128,6 +128,53 @@ def test_verify_orders_unchecked_pages_and_preserves_failures(tmp_path: Path, mo
     assert "| Archive checks with errors | 1 |" in report.read_text()
 
 
+def test_verify_prioritizes_due_pending_confirmations(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Check pending confirmations before the unverified discovery backlog.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces Wayback requests.
+
+    Returns:
+        None.
+
+    Examples:
+        A due pending capture is checked even when unknown pages exist.
+    """
+    path = tmp_path / "state.json"
+    state = seed_manifest(path)
+    pending = state.page("https://palewi.re/pending/")
+    pending.live_status = "live"
+    pending.archive_status = "pending"
+    pending.last_submit_at = "2026-01-01T00:00:00Z"
+    deferred = state.page("https://palewi.re/deferred/")
+    deferred.live_status = "live"
+    deferred.archive_status = "pending"
+    deferred.last_submit_at = "2026-01-01T00:00:00Z"
+    deferred.next_retry_at = "2099-01-01T00:00:00+00:00"
+    ManifestStore(path).save(state)
+    calls: list[str] = []
+
+    def verify(_client: WaybackClient, page: archive_cli.PageRecord) -> None:
+        """Record each selected confirmation candidate.
+
+        Args:
+            _client: Unused client.
+            page: Selected page record.
+
+        Returns:
+            None.
+
+        Examples:
+            The first candidate is the due pending page.
+        """
+        calls.append(page.url)
+
+    monkeypatch.setattr(WaybackClient, "verify", verify)
+    ArchiveRun(path).verify(1, float("inf"))
+    assert calls == [pending.url]
+
+
 def test_capture_limits_and_retry_dates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Select due missing pages and exclude pending, blocked, and non-live pages.
 

--- a/tests/test_site_archive_manifest.py
+++ b/tests/test_site_archive_manifest.py
@@ -225,6 +225,30 @@ def test_manifest_requires_confirmed_and_pending_archive_evidence(tmp_path: Path
         ManifestStore(path).save(pending)
 
 
+def test_manifest_round_trips_a_one_trailing_slash_snapshot_alias(tmp_path: Path) -> None:
+    """Allow runtime-proven snapshot aliases to remain in saved state.
+
+    Args:
+        tmp_path: Temporary test directory.
+
+    Returns:
+        None.
+
+    Examples:
+        An archived ``/posts`` snapshot may belong to canonical ``/posts/``.
+    """
+    path = tmp_path / "manifest.json"
+    state = Manifest()
+    page = state.page(URL)
+    page.live_status = "live"
+    page.archive_status = "archived"
+    page.archive_url = SNAPSHOT.rstrip("/")
+    page.snapshot_at = "20260905120000"
+    page.last_verified_at = utc_now()
+    ManifestStore(path).save(state)
+    assert ManifestStore(path).load().pages[URL].archive_url == SNAPSHOT.rstrip("/")
+
+
 def test_manifest_rejects_impossible_snapshot_dates(tmp_path: Path) -> None:
     """Reject digit-only timestamps that are not real dates.
 

--- a/tests/test_site_archive_wayback.py
+++ b/tests/test_site_archive_wayback.py
@@ -292,10 +292,58 @@ def test_capture_rechecks_then_records_pending_and_respects_rate_delay(monkeypat
         {
             "user_agent": USER_AGENT,
             "accept_cache": True,
-            "timeout": 30,
+            "timeout": 120,
             "authenticate": True,
         }
     ]
+
+
+def test_lookup_and_capture_timeouts_are_separate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Use dedicated timeouts for availability checks and capture submissions.
+
+    Args:
+        monkeypatch: Supplies capture credentials.
+
+    Returns:
+        None.
+
+    Examples:
+        A short availability timeout does not shorten a slow capture request.
+    """
+    monkeypatch.setenv("SAVEPAGENOW_ACCESS_KEY", "key")
+    monkeypatch.setenv("SAVEPAGENOW_SECRET_KEY", "secret")
+    submitted: list[dict[str, object]] = []
+    session = Session(response({"archived_snapshots": {}}))
+    page = PageRecord(url=URL, live_status="live", archive_status="missing")
+
+    def submit(url: str, **kwargs: object) -> str:
+        """Record the Save Page Now options used for one capture.
+
+        Args:
+            url: Submitted page URL.
+            **kwargs: Save Page Now options.
+
+        Returns:
+            Pending snapshot URL.
+
+        Examples:
+            A capture uses the configured capture timeout.
+        """
+        assert url == URL
+        submitted.append(kwargs)
+        return SNAPSHOT
+
+    archive = WaybackClient(
+        timeout=7.5,
+        capture_timeout=80.9,
+        session=session,
+        capture_page=submit,
+        clock=lambda: NOW,
+        sleep=lambda seconds: None,
+    )
+    archive.capture(page)
+    assert session.calls[0][1]["timeout"] == 7.5
+    assert submitted[0]["timeout"] == 80
 
 
 def test_capture_keeps_response_headers_and_bodies_out_of_error_state(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_site_archive_wayback.py
+++ b/tests/test_site_archive_wayback.py
@@ -18,13 +18,13 @@ NOW = datetime(2026, 9, 5, 12, 0, tzinfo=UTC)
 
 
 class Session:
-    """Minimal request session returning a configured response or exception."""
+    """Minimal request session returning configured responses or exceptions."""
 
-    def __init__(self, result: requests.Response | BaseException):
-        """Set a response returned from the availability endpoint.
+    def __init__(self, result: requests.Response | BaseException | list[requests.Response | BaseException]):
+        """Set one or more responses returned from requests.
 
         Args:
-            result: Response or exception to return.
+            result: Response, exception, or ordered responses and exceptions to return.
 
         Returns:
             None.
@@ -32,7 +32,7 @@ class Session:
         Examples:
             ``Session(response({"archived_snapshots": {}}))`` reports absent data.
         """
-        self.result = result
+        self.results = list(result) if isinstance(result, list) else [result]
         self.calls: list[tuple[str, dict[str, object]]] = []
 
     def get(self, url: str, **kwargs: object) -> requests.Response:
@@ -49,18 +49,27 @@ class Session:
             The client requests the documented availability endpoint.
         """
         self.calls.append((url, kwargs))
-        if isinstance(self.result, BaseException):
-            raise self.result
-        return self.result
+        result = self.results.pop(0)
+        if isinstance(result, BaseException):
+            raise result
+        if not isinstance(result, requests.Response):
+            raise AssertionError("Session result must be a requests response")
+        return result
 
 
-def response(payload: object, status: int = 200, retry_after: str | None = None) -> requests.Response:
+def response(
+    payload: object,
+    status: int = 200,
+    retry_after: str | None = None,
+    content_type: str | None = None,
+) -> requests.Response:
     """Build an in-memory JSON response.
 
     Args:
         payload: JSON value to return.
         status: HTTP status code.
         retry_after: Optional Retry-After header.
+        content_type: Optional response MIME type.
 
     Returns:
         Configured requests response.
@@ -71,9 +80,12 @@ def response(payload: object, status: int = 200, retry_after: str | None = None)
     result = requests.Response()
     result.status_code = status
     result.url = AVAILABILITY_URL
-    result._content = json.dumps(payload).encode()
+    result._content = payload.encode() if isinstance(payload, str) else json.dumps(payload).encode()
+    result._content_consumed = True
     if retry_after:
         result.headers["Retry-After"] = retry_after
+    if content_type:
+        result.headers["Content-Type"] = content_type
     return result
 
 
@@ -196,6 +208,84 @@ def test_verify_empty_mapping_is_missing_but_retains_fresh_pending_capture() -> 
     client(response({"archived_snapshots": {}})).verify(pending)
     assert pending.archive_status == "pending"
     assert pending.pending_archive_url == SNAPSHOT
+
+
+def test_verify_accepts_proven_trailing_slash_snapshot_alias() -> None:
+    """Confirm an alias snapshot only when both live pages name one canonical URL.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        A snapshot of ``/week-1`` can confirm the canonical ``/week-1/`` page.
+    """
+    requested = "https://palewi.re/docs/coding-the-news/scripts/week-1/"
+    alias = requested.rstrip("/")
+    snapshot = f"http://web.archive.org/web/{STAMP}/{alias}"
+    canonical_link = f'<link rel="canonical" href="{requested}">'
+    session = Session(
+        [
+            response(
+                {
+                    "archived_snapshots": {
+                        "closest": {"available": True, "status": 200, "timestamp": STAMP, "url": snapshot}
+                    }
+                }
+            ),
+            response(canonical_link, content_type="text/html"),
+            response(canonical_link, content_type="text/html"),
+        ]
+    )
+    page = PageRecord(url=requested, live_status="live")
+    WaybackClient(session=session, clock=lambda: NOW, sleep=lambda seconds: None).verify(page)
+    assert page.archive_status == "archived"
+    assert page.archive_url == snapshot.replace("http://", "https://", 1)
+    assert [url for url, _ in session.calls] == [AVAILABILITY_URL, requested, alias]
+
+
+@pytest.mark.parametrize(
+    "alias_html",
+    [
+        "<p>No canonical link</p>",
+        '<link rel="canonical" href="https://palewi.re/docs/coding-the-news/scripts/week-2/">',
+    ],
+)
+def test_verify_rejects_unproven_trailing_slash_snapshot_alias(alias_html: str) -> None:
+    """Reject a slash alias unless both live pages prove the requested canonical.
+
+    Args:
+        alias_html: Alias page HTML without the requested sole canonical link.
+
+    Returns:
+        None.
+
+    Examples:
+        A missing or unrelated canonical link keeps a snapshot unconfirmed.
+    """
+    requested = "https://palewi.re/docs/coding-the-news/scripts/week-1/"
+    alias = requested.rstrip("/")
+    snapshot = f"https://web.archive.org/web/{STAMP}/{alias}"
+    session = Session(
+        [
+            response(
+                {
+                    "archived_snapshots": {
+                        "closest": {"available": True, "status": 200, "timestamp": STAMP, "url": snapshot}
+                    }
+                }
+            ),
+            response(f'<link rel="canonical" href="{requested}">', content_type="text/html"),
+            response(alias_html, content_type="text/html"),
+        ]
+    )
+    page = PageRecord(url=requested, live_status="live")
+    with pytest.raises(ArchiveError, match="canonical"):
+        WaybackClient(session=session, clock=lambda: NOW, sleep=lambda seconds: None).verify(page)
+    assert page.archive_status == "unknown"
+    assert page.last_check_status == "error"
 
 
 def test_verify_throttle_honors_retry_after_and_preserves_archived_evidence() -> None:
@@ -344,6 +434,42 @@ def test_lookup_and_capture_timeouts_are_separate(monkeypatch: pytest.MonkeyPatc
     archive.capture(page)
     assert session.calls[0][1]["timeout"] == 7.5
     assert submitted[0]["timeout"] == 80
+
+
+def test_capture_accepts_proven_trailing_slash_snapshot_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Save a proven trailing-slash alias as a pending capture result.
+
+    Args:
+        monkeypatch: Supplies capture credentials.
+
+    Returns:
+        None.
+
+    Examples:
+        A ``/week-1`` response remains pending for canonical ``/week-1/``.
+    """
+    monkeypatch.setenv("SAVEPAGENOW_ACCESS_KEY", "key")
+    monkeypatch.setenv("SAVEPAGENOW_SECRET_KEY", "secret")
+    requested = "https://palewi.re/docs/coding-the-news/scripts/week-1/"
+    alias = requested.rstrip("/")
+    snapshot = f"https://web.archive.org/web/{STAMP}/{alias}"
+    canonical_link = f'<link rel="canonical" href="{requested}">'
+    session = Session(
+        [
+            response({"archived_snapshots": {}}),
+            response(canonical_link, content_type="text/html"),
+            response(canonical_link, content_type="text/html"),
+        ]
+    )
+    page = PageRecord(url=requested, live_status="live", archive_status="missing")
+    WaybackClient(
+        session=session,
+        capture_page=lambda url, **kwargs: snapshot,
+        clock=lambda: NOW,
+        sleep=lambda seconds: None,
+    ).capture(page)
+    assert page.archive_status == "pending"
+    assert page.pending_archive_url == snapshot
 
 
 def test_capture_keeps_response_headers_and_bodies_out_of_error_state(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_site_archive_workflow.py
+++ b/tests/test_site_archive_workflow.py
@@ -32,6 +32,25 @@ def test_checkpoint_includes_hidden_files_and_restores_expected_directory() -> N
     assert "always()" in jobs["persist"]["if"]
 
 
+def test_artifact_actions_are_pinned_to_node24_releases() -> None:
+    """Use current artifact actions that run on the supported Node version.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        The upload and download steps use the verified v7 and v8 release commits.
+    """
+    jobs = yaml.safe_load(WORKFLOW.read_text())["jobs"]
+    upload = next(step for step in jobs["archive"]["steps"] if step.get("uses", "").startswith("actions/upload-"))
+    download = next(step for step in jobs["persist"]["steps"] if step.get("uses", "").startswith("actions/download-"))
+    assert upload["uses"] == "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+    assert download["uses"] == "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
+
+
 def test_only_persistence_can_write_and_both_jobs_use_the_same_source() -> None:
     """Limit write access and prevent different code between archive and persist.
 


### PR DESCRIPTION
## Summary

- Give Save Page Now captures their own 120-second timeout while keeping availability checks at 30 seconds.
- Check due pending capture confirmations before the unverified backlog without bypassing retry dates.
- Accept a one-trailing-slash Wayback alias only when both live HTML pages report the requested canonical URL.
- Update checkpoint artifact actions to Node 24-supported, SHA-pinned releases.

## Testing

- [x] `make check` passes locally

## Changelog

- [ ] `feature`
- [ ] `improvement`
- [x] `fix`
- [ ] `maintenance`
- [ ] `skip-changelog`

## Deployment notes

No manual steps required.