### PR TITLE
Fix archive crawl canonical aliases

### DIFF
--- a/docs/site-archive.md
+++ b/docs/site-archive.md
@@ -37,9 +37,9 @@ HTML and checks Wayback again. It saves the pending request before contacting
 the capture service, so an interrupted response does not lead to an immediate
 duplicate submission. Availability lookups time out after 30 seconds; capture
 requests have a separate 120-second timeout. Due pending captures are checked
-before pages that have never been checked. A returned snapshot URL that differs
-only by one trailing slash is accepted only after both live pages report the
-requested canonical URL.
+before pages that have never been checked. A returned snapshot URL that differs only by one trailing slash is accepted
+only after both live pages report the same canonical URL, which must be one
+of those two slash variants.
 
 ## Durable branch persistence
 
@@ -101,14 +101,19 @@ responses are recorded as errors, not converted to `missing`; routine backlog
 is different from an outage or configuration failure.
 
 Discovery starts with the production build, the live sitemap, internal links,
-and same-site documentation catalogs. Public documentation navigation is
-followed when a sitemap is absent or unavailable. A docs sitemap returning
-403, 404, or 410 is reported as an optional discovery gap so navigation can
-continue; other discovery and service errors fail the run and remain visible
-in the report. A docs site published by another repository may still have
-unlinked pages that cannot be proven discoverable without that publisher's
-complete inventory. Interrupted scans keep their queue and known URLs for a
-later run.
+and same-site documentation catalogs. A page that declares a sole same-site
+canonical URL differing only by a trailing slash is treated as an alias; its
+links are ignored and the canonical page is fetched instead so relative links
+use the right base URL. Public documentation navigation is followed when a
+sitemap is absent or unavailable. Links returning 403, 404, or 410 remain
+visible as coverage gaps and are never submitted for capture. They are
+backlog items, not a failed archive service run. Timeouts, rate limits, server
+errors, malformed responses, and persistence failures remain operational
+errors that fail the current run. Earlier gaps stay in the report without
+making later clean runs fail. A docs site published by another repository may
+still have unlinked pages that cannot be proven discoverable without that
+publisher's complete inventory. Interrupted scans keep their queue and known
+URLs for a later run.
 
 A blocked page is not submitted again automatically. Resolve the stated
 restriction first. To retry, fetch into a fresh directory, change that page's

--- a/scripts/site_archive/cli.py
+++ b/scripts/site_archive/cli.py
@@ -49,7 +49,7 @@ def report_text(manifest: Manifest) -> str:
         f"| Live HTML pages | {live_counts['live']} |",
         f"| Live pages missing or unavailable | {live_counts['missing'] + live_counts['error']} |",
         f"| Live pages not yet checked | {live_counts['unknown']} |",
-        f"| Redirect aliases (not separate pages) | {live_counts['redirect']} |",
+        f"| Redirect or canonical aliases (not separate pages) | {live_counts['redirect']} |",
         f"| Discovery requests remaining | {len(manifest.discovery_queue)} |",
         f"| Discovery problems | {len(manifest.discovery_errors)} |",
         "",
@@ -183,7 +183,9 @@ class ArchiveRun:
             if time.monotonic() >= deadline:
                 break
             if not self.check_live(page):
-                break
+                if self.failures:
+                    break
+                continue
             failures_before = len(self.failures)
             try:
                 client.capture(page)
@@ -215,11 +217,12 @@ class ArchiveRun:
             page.live_error = str(error)
             self.manifest.discovery_errors[page.url] = str(error)
             self.manifest.discovery_complete = False
+            self.failures.append(f"{page.url}: {error}")
         finally:
             discovery.session.close()
             self.store.save(self.manifest)
         if page.live_status != "live":
-            self.failures.append(f"{page.url}: capture deferred; live page is {page.live_status}")
+            click.echo(f"{page.url}: capture deferred; live page is {page.live_status}")
             return False
         return True
 
@@ -440,14 +443,9 @@ def execute(
         try:
             if action in {"discover", "sync"}:
                 discovery_deadline = start + max_seconds / 3 if action == "sync" else deadline
-                PageDiscovery(run.manifest, run.store).run(
-                    build_seeds(build_dir), limit=max_pages, deadline=discovery_deadline
-                )
-                run.failures.extend(
-                    f"{url}: {error}"
-                    for url, error in run.manifest.discovery_errors.items()
-                    if not (url.endswith("/sitemap.xml") and error in {"HTTP 403", "HTTP 404", "HTTP 410"})
-                )
+                discovery = PageDiscovery(run.manifest, run.store)
+                discovery.run(build_seeds(build_dir), limit=max_pages, deadline=discovery_deadline)
+                run.failures.extend(discovery.failures)
             if action in {"verify", "sync"}:
                 verify_deadline = start + max_seconds * 2 / 3 if action == "sync" and not lookup_only else deadline
                 run.verify(max_checks, verify_deadline)

--- a/scripts/site_archive/discovery.py
+++ b/scripts/site_archive/discovery.py
@@ -11,7 +11,13 @@ import requests
 
 from coltrane.content_loaders import load_docs
 from scripts.check_built_site import ERROR_PAGES, PageParser, public_url_for_page
-from scripts.site_archive.manifest import ArchiveError, Manifest, ManifestStore, utc_now
+from scripts.site_archive.manifest import (
+    ArchiveError,
+    Manifest,
+    ManifestStore,
+    paths_differ_only_by_trailing_slash,
+    utc_now,
+)
 
 ORIGIN = "https://palewi.re"
 USER_AGENT = "palewi.re archive inventory (https://github.com/palewire/palewi.re)"
@@ -141,6 +147,7 @@ class PageDiscovery:
         self.delay = delay
         self.session = requests.Session()
         self.session.headers["User-Agent"] = USER_AGENT
+        self.failures: list[str] = []
 
     def enqueue(self, url: str) -> None:
         """Queue a URL once during this discovery sweep.
@@ -176,7 +183,6 @@ class PageDiscovery:
         """
         if not self.manifest.discovery_queue:
             self.manifest.discovery_seen = []
-            self.manifest.discovery_errors = {}
             self.manifest.discovery_started_at = utc_now()
             # Revisit old pages too: a temporarily absent link must not erase them.
             seeds = list(dict.fromkeys([*seeds, *self.manifest.pages]))
@@ -192,6 +198,7 @@ class PageDiscovery:
                     self.visit(url)
                 except (requests.RequestException, ArchiveError) as error:
                     self.manifest.discovery_errors[url] = str(error)
+                    self.failures.append(f"{url}: {error}")
                     defer = isinstance(error, (requests.ConnectionError, requests.Timeout)) or (
                         isinstance(error, requests.HTTPError)
                         and error.response is not None
@@ -257,9 +264,9 @@ class PageDiscovery:
                 if destination and (is_page_url(destination) or destination.endswith(".xml")):
                     self.enqueue(destination)
                 return
-            if response.status_code in {404, 410} or (response.status_code == 403 and url.endswith("/sitemap.xml")):
+            if response.status_code in {404, 410, 403}:
                 if page:
-                    page.live_status = "missing"
+                    page.live_status = "missing" if response.status_code in {404, 410} else "error"
                     page.live_error = f"Live page returned HTTP {response.status_code}"
                 self.manifest.discovery_errors[url] = f"HTTP {response.status_code}"
                 self.manifest.discovery_complete = False
@@ -283,6 +290,13 @@ class PageDiscovery:
                 page.live_status = "live"
                 parser = PageParser()
                 parser.feed(bytes(body).decode(response.encoding or "utf-8", errors="replace"))
+                if len(parser.canonicals) == 1:
+                    canonical = normalize_url(parser.canonicals[0], url)
+                    if canonical and paths_differ_only_by_trailing_slash(urlsplit(url).path, urlsplit(canonical).path):
+                        page.live_status = "redirect"
+                        self.enqueue(canonical)
+                        self.manifest.discovery_errors.pop(url, None)
+                        return
                 for link in parser.links:
                     destination = normalize_url(link.value, url)
                     if link.tag == "a" and destination and is_page_url(destination):

--- a/scripts/site_archive/wayback.py
+++ b/scripts/site_archive/wayback.py
@@ -244,7 +244,8 @@ class WaybackClient:
         alias_url = normalize_url(original)
         if alias_url is None:
             raise ArchiveError("Wayback snapshot does not match the requested page URL")
-        if self._live_canonical(page_url) != page_url or self._live_canonical(alias_url) != page_url:
+        canonical = self._live_canonical(page_url)
+        if canonical != self._live_canonical(alias_url) or canonical not in {page_url, alias_url}:
             raise ArchiveError("Wayback snapshot trailing-slash alias cannot be proven by live canonical links")
         return normalized, timestamp
 

--- a/tests/test_site_archive_cli.py
+++ b/tests/test_site_archive_cli.py
@@ -519,4 +519,73 @@ def test_capture_rechecks_public_page(tmp_path: Path, monkeypatch: pytest.Monkey
     run.capture(1, float("inf"))
     assert calls == (["capture"] if live_status == "live" else [])
     assert ManifestStore(path).load().pages[URL].live_status == live_status
-    assert bool(run.failures) is (live_status != "live")
+    assert bool(run.failures) is (live_status == "error")
+
+
+def test_stale_discovery_gaps_do_not_fail_a_clean_discovery_batch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Report an old gap without failing a later clean command.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces build and discovery work.
+
+    Returns:
+        None.
+
+    Examples:
+        A historical 404 remains in the manifest but exits successfully.
+    """
+    path = tmp_path / "state.json"
+    state = Manifest(discovery_errors={f"{URL}missing/": "HTTP 404"})
+    ManifestStore(path).save(state)
+    monkeypatch.setattr(archive_cli, "build_seeds", lambda _build_dir: [])
+    monkeypatch.setattr(archive_cli.PageDiscovery, "run", lambda *args, **kwargs: 0)
+    result = CliRunner().invoke(cli, ["discover", "--manifest", str(path)])
+    assert result.exit_code == 0
+    assert f"{URL}missing/" in ManifestStore(path).load().discovery_errors
+
+
+def test_capture_skips_nonlive_candidates_and_continues(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Defer an alias candidate while continuing to the next live page.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces discovery and capture requests.
+
+    Returns:
+        None.
+
+    Examples:
+        A canonical alias is never submitted to Save Page Now.
+    """
+    path = tmp_path / "state.json"
+    state = seed_manifest(path, "missing")
+    alias = state.page("https://palewi.re/alias/")
+    alias.live_status = "live"
+    alias.archive_status = "missing"
+    ManifestStore(path).save(state)
+    calls: list[str] = []
+
+    def visit(discovery: archive_cli.PageDiscovery, url: str) -> None:
+        """Mark one candidate as an alias and leave the other live.
+
+        Args:
+            discovery: Discovery instance.
+            url: Requested candidate URL.
+
+        Returns:
+            None.
+
+        Examples:
+            An alias is deferred before archive submission.
+        """
+        discovery.manifest.pages[url].live_status = "redirect" if url == alias.url else "live"
+
+    monkeypatch.setattr(archive_cli.PageDiscovery, "visit", visit)
+    monkeypatch.setattr(WaybackClient, "capture", lambda _client, page: calls.append(page.url))
+    run = ArchiveRun(path)
+    run.capture(2, float("inf"))
+    assert calls == [URL]
+    assert not run.failures

--- a/tests/test_site_archive_discovery.py
+++ b/tests/test_site_archive_discovery.py
@@ -478,6 +478,113 @@ def test_live_missing_and_completed_sweep_restart(tmp_path: Path, monkeypatch: p
     assert state.discovery_complete
 
 
+def test_canonical_slash_alias_uses_canonical_link_base(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fetch a trailing-slash canonical page before following relative links.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces network access.
+
+    Returns:
+        None.
+
+    Examples:
+        ``/docs/course`` discovers links from ``/docs/course/``.
+    """
+    alias = f"{ORIGIN}/docs/course"
+    canonical = f"{alias}/"
+    chapter = f"{canonical}scripts/week-1"
+    calls: list[str] = []
+    responses = {
+        alias: response(f'<link rel="canonical" href="{canonical}"><a href="scripts/week-1">Week 1</a>'),
+        canonical: response('<a href="scripts/week-1">Week 1</a>'),
+        chapter: response("Week 1"),
+    }
+
+    def get(_session: requests.Session, url: str, **kwargs: object) -> requests.Response:
+        """Return a fixture response and record its URL.
+
+        Args:
+            _session: Unused session.
+            url: Requested URL.
+            **kwargs: Request options.
+
+        Returns:
+            Configured fixture response.
+
+        Examples:
+            The alias page is fetched before its canonical page.
+        """
+        calls.append(url)
+        return responses[url]
+
+    monkeypatch.setattr(requests.Session, "get", get)
+    state = Manifest()
+    PageDiscovery(state, ManifestStore(tmp_path / "state.json"), delay=0).run([alias], limit=3)
+    assert calls == [alias, canonical, chapter]
+    assert state.pages[alias].live_status == "redirect"
+    assert f"{ORIGIN}/docs/scripts/week-1" not in state.pages
+
+
+@pytest.mark.parametrize(
+    "canonical",
+    ["https://palewi.re/docs/other/", "https://example.com/docs/course/"],
+)
+def test_unrelated_or_offsite_canonical_is_not_an_alias(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, canonical: str
+) -> None:
+    """Ignore canonicals that are not the one permitted slash alias.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces network access.
+        canonical: Unrelated or off-site canonical URL.
+
+    Returns:
+        None.
+
+    Examples:
+        An external canonical does not redirect discovery outside the site.
+    """
+    url = f"{ORIGIN}/docs/course"
+    monkeypatch.setattr(
+        requests.Session,
+        "get",
+        lambda *args, **kwargs: response(f'<link rel="canonical" href="{canonical}">'),
+    )
+    state = Manifest()
+    PageDiscovery(state, ManifestStore(tmp_path / "state.json"), delay=0).run([url])
+    assert state.pages[url].live_status == "live"
+    assert not state.discovery_queue
+
+
+@pytest.mark.parametrize("status", [403, 404, 410])
+def test_broken_page_links_are_gaps_not_run_failures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, status: int
+) -> None:
+    """Retain inaccessible links without treating them as service failures.
+
+    Args:
+        tmp_path: State directory.
+        monkeypatch: Replaces network access.
+        status: Broken-link HTTP status.
+
+    Returns:
+        None.
+
+    Examples:
+        A 403 stays visible but is not retried as an outage.
+    """
+    url = f"{ORIGIN}/broken/"
+    monkeypatch.setattr(requests.Session, "get", lambda *args, **kwargs: response(status=status))
+    state = Manifest()
+    crawler = PageDiscovery(state, ManifestStore(tmp_path / "state.json"), delay=0)
+    crawler.run([url])
+    assert state.discovery_errors[url] == f"HTTP {status}"
+    assert state.pages[url].live_status == ("error" if status == 403 else "missing")
+    assert not crawler.failures
+
+
 @pytest.mark.parametrize("status", [429, 503])
 def test_service_failures_defer_remaining_discovery(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, status: int
@@ -499,7 +606,9 @@ def test_service_failures_defer_remaining_discovery(
     second = f"{ORIGIN}/second/"
     monkeypatch.setattr(requests.Session, "get", lambda *args, **kwargs: response(status=status))
     state = Manifest()
-    attempted = PageDiscovery(state, ManifestStore(tmp_path / "state.json"), delay=0).run([first, second])
+    crawler = PageDiscovery(state, ManifestStore(tmp_path / "state.json"), delay=0)
+    attempted = crawler.run([first, second])
     assert attempted == 1
     assert state.discovery_queue == [second, first]
     assert not state.discovery_seen
+    assert crawler.failures

--- a/tests/test_site_archive_wayback.py
+++ b/tests/test_site_archive_wayback.py
@@ -246,11 +246,46 @@ def test_verify_accepts_proven_trailing_slash_snapshot_alias() -> None:
     assert [url for url, _ in session.calls] == [AVAILABILITY_URL, requested, alias]
 
 
+def test_verify_accepts_reverse_proven_trailing_slash_snapshot_alias() -> None:
+    """Confirm aliases when the slash form is the shared canonical URL.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        A ``/week-1/`` snapshot can confirm a ``/week-1`` record.
+    """
+    requested = "https://palewi.re/docs/coding-the-news/scripts/week-1"
+    alias = f"{requested}/"
+    snapshot = f"https://web.archive.org/web/{STAMP}/{alias}"
+    canonical_link = f'<link rel="canonical" href="{alias}">'
+    session = Session(
+        [
+            response(
+                {
+                    "archived_snapshots": {
+                        "closest": {"available": True, "status": 200, "timestamp": STAMP, "url": snapshot}
+                    }
+                }
+            ),
+            response(canonical_link, content_type="text/html"),
+            response(canonical_link, content_type="text/html"),
+        ]
+    )
+    page = PageRecord(url=requested, live_status="live")
+    WaybackClient(session=session, clock=lambda: NOW, sleep=lambda seconds: None).verify(page)
+    assert page.archive_status == "archived"
+
+
 @pytest.mark.parametrize(
     "alias_html",
     [
         "<p>No canonical link</p>",
         '<link rel="canonical" href="https://palewi.re/docs/coding-the-news/scripts/week-2/">',
+        '<link rel="canonical" href="https://example.com/docs/coding-the-news/scripts/week-1/">',
     ],
 )
 def test_verify_rejects_unproven_trailing_slash_snapshot_alias(alias_html: str) -> None:


### PR DESCRIPTION
## Summary
- crawl trailing-slash canonical aliases from the canonical URL before resolving links
- distinguish recorded broken-link coverage gaps from current discovery service failures
- accept either proven trailing-slash canonical direction for Wayback snapshots

## Testing
- `make check`

## Changelog
- fix