### PR TITLE
Add manual site archive capture controls

### DIFF
--- a/.github/workflows/site-archive.yaml
+++ b/.github/workflows/site-archive.yaml
@@ -10,6 +10,16 @@ on:
         required: false
         default: false
         type: boolean
+      capture_only:
+        description: "Request captures only; skip discovery and archive lookups"
+        required: false
+        default: false
+        type: boolean
+      max_captures:
+        description: "Maximum capture requests for a manual run (1-100)"
+        required: false
+        default: 10
+        type: number
 
 permissions:
   contents: read
@@ -35,6 +45,9 @@ jobs:
       MANIFEST: .site-archive/manifest.json
       STATE_TOKEN: .site-archive/state-token.json
       SUMMARY: .site-archive/report.md
+      LOOKUP_ONLY: ${{ inputs.lookup_only || false }}
+      CAPTURE_ONLY: ${{ inputs.capture_only || false }}
+      MAX_CAPTURES: ${{ inputs.max_captures || '10' }}
     steps:
       - name: Check out production source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -76,17 +89,33 @@ jobs:
         id: sync
         continue-on-error: true
         run: |
+          if test "$LOOKUP_ONLY" = "true" && test "$CAPTURE_ONLY" = "true"; then
+            echo "lookup_only and capture_only cannot both be enabled." >&2
+            exit 1
+          fi
+          if ! [[ "$MAX_CAPTURES" =~ ^[1-9][0-9]*$ ]] || test "$MAX_CAPTURES" -gt 100; then
+            echo "max_captures must be a whole number from 1 through 100." >&2
+            exit 1
+          fi
+          if test "$CAPTURE_ONLY" = "true"; then
+            uv run python -m scripts.site_archive capture \
+              --manifest "$MANIFEST" \
+              --max-captures "$MAX_CAPTURES" \
+              --max-seconds 900 \
+              --summary "$SUMMARY"
+            exit 0
+          fi
           args=(
             sync
             --build-dir dist
             --manifest "$MANIFEST"
             --max-pages 100
             --max-checks 100
-            --max-captures 10
+            --max-captures "$MAX_CAPTURES"
             --max-seconds 900
             --summary "$SUMMARY"
           )
-          if test "${{ inputs.lookup_only || false }}" = "true"; then
+          if test "$LOOKUP_ONLY" = "true"; then
             args+=(--lookup-only)
           fi
           uv run python -m scripts.site_archive "${args[@]}"

--- a/docs/site-archive.md
+++ b/docs/site-archive.md
@@ -83,6 +83,23 @@ branch head. Fetch into a fresh local directory so the recovery copy is not
 overwritten. Reconcile its page records with the latest manifest, then push
 using the newly fetched token.
 
+## Manual capture-only backlog runs
+
+To work through confirmed missing archives without spending the run on
+discovery or Wayback lookups, start the workflow from `main` with
+`capture_only=true`. For example, this requests up to 62 captures:
+
+```sh
+gh workflow run site-archive.yaml --ref main \
+  -f capture_only=true -f max_captures=62
+```
+
+The workflow accepts whole-number capture limits from 1 through 100. It keeps
+the 900-second deadline, so a large batch can be split across runs. Re-running
+the same capture-only request safely resumes eligible work and does not submit
+recent pending captures again. Capture confirmation remains separate lookup
+work: run a later `lookup_only=true` workflow to confirm pending snapshots.
+
 After these code changes reach `main`, the weekly job runs on Mondays at
 06:17 UTC. For the first run, use **Run workflow** with **lookup_only** enabled
 to inspect the inventory without requesting captures. Then allow a small

--- a/tests/test_site_archive_workflow.py
+++ b/tests/test_site_archive_workflow.py
@@ -1,10 +1,43 @@
 """Checks for the archive workflow's cross-job checkpoint wiring."""
 
 from pathlib import Path
+from typing import Any
 
 import yaml
 
 WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "site-archive.yaml"
+
+
+def load_workflow() -> dict[Any, Any]:
+    """Load the archive workflow while preserving PyYAML's legacy `on` key.
+
+    Args:
+        None.
+
+    Returns:
+        Parsed GitHub Actions workflow.
+
+    Examples:
+        ``load_workflow()["jobs"]`` returns the configured jobs.
+    """
+    return yaml.safe_load(WORKFLOW.read_text())
+
+
+def archive_step() -> dict[str, Any]:
+    """Return the workflow step that performs archive maintenance.
+
+    Args:
+        None.
+
+    Returns:
+        Parsed synchronization step.
+
+    Examples:
+        ``archive_step()["id"]`` is ``"sync"``.
+    """
+    workflow = load_workflow()
+    jobs = workflow["jobs"]
+    return next(step for step in jobs["archive"]["steps"] if step.get("id") == "sync")
 
 
 def test_checkpoint_includes_hidden_files_and_restores_expected_directory() -> None:
@@ -19,7 +52,7 @@ def test_checkpoint_includes_hidden_files_and_restores_expected_directory() -> N
     Examples:
         The hidden .site-archive directory must not be excluded by upload-artifact.
     """
-    jobs = yaml.safe_load(WORKFLOW.read_text())["jobs"]
+    jobs = load_workflow()["jobs"]
     upload = next(step for step in jobs["archive"]["steps"] if step.get("uses", "").startswith("actions/upload-"))
     download = next(step for step in jobs["persist"]["steps"] if step.get("uses", "").startswith("actions/download-"))
     assert upload["with"]["include-hidden-files"] is True
@@ -44,7 +77,7 @@ def test_artifact_actions_are_pinned_to_node24_releases() -> None:
     Examples:
         The upload and download steps use the verified v7 and v8 release commits.
     """
-    jobs = yaml.safe_load(WORKFLOW.read_text())["jobs"]
+    jobs = load_workflow()["jobs"]
     upload = next(step for step in jobs["archive"]["steps"] if step.get("uses", "").startswith("actions/upload-"))
     download = next(step for step in jobs["persist"]["steps"] if step.get("uses", "").startswith("actions/download-"))
     assert upload["uses"] == "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
@@ -63,7 +96,7 @@ def test_only_persistence_can_write_and_both_jobs_use_the_same_source() -> None:
     Examples:
         A push to main during a long run cannot change its persistence code.
     """
-    workflow = yaml.safe_load(WORKFLOW.read_text())
+    workflow = load_workflow()
     jobs = workflow["jobs"]
     assert jobs["archive"]["permissions"]["contents"] == "read"
     assert jobs["persist"]["permissions"]["contents"] == "write"
@@ -87,7 +120,82 @@ def test_lookup_failures_are_not_hidden_by_checkpoint_recovery() -> None:
     Examples:
         Saving partial progress must not turn a failed archive run green.
     """
-    steps = yaml.safe_load(WORKFLOW.read_text())["jobs"]["archive"]["steps"]
+    steps = load_workflow()["jobs"]["archive"]["steps"]
     failure = next(step for step in steps if step["name"] == "Surface synchronization failure")
     assert failure["if"] == "steps.sync.outcome == 'failure'"
     assert "exit 1" in failure["run"]
+
+
+def test_scheduled_runs_keep_the_existing_sync_limits() -> None:
+    """Keep the default weekly run scoped to its established batch sizes.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        A schedule run selects sync with 100 discoveries, checks, and a 10-page capture limit.
+    """
+    workflow = load_workflow()
+    dispatch = workflow[True]["workflow_dispatch"]
+    inputs = dispatch["inputs"]
+    run = archive_step()["run"]
+
+    assert workflow[True]["schedule"] == [{"cron": "17 6 * * 1"}]
+    assert inputs["lookup_only"]["default"] is False
+    assert inputs["capture_only"]["default"] is False
+    assert inputs["max_captures"]["default"] == 10
+    assert "MAX_CAPTURES: ${{ inputs.max_captures || '10' }}" in WORKFLOW.read_text()
+    assert "--max-pages 100" in run
+    assert "--max-checks 100" in run
+    assert '--max-captures "$MAX_CAPTURES"' in run
+    assert "sync" in run
+
+
+def test_capture_only_selects_capture_command_without_discovery_or_lookup() -> None:
+    """Keep manual capture-only runs separate from the full synchronization path.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        A 62-page manual batch calls ``capture`` with the configured limit.
+    """
+    run = archive_step()["run"]
+    capture_branch, sync_branch = run.split("fi\nargs=(", maxsplit=1)
+
+    assert 'if test "$CAPTURE_ONLY" = "true"; then' in capture_branch
+    assert "scripts.site_archive capture" in capture_branch
+    assert '--manifest "$MANIFEST"' in capture_branch
+    assert '--max-captures "$MAX_CAPTURES"' in capture_branch
+    assert "--max-seconds 900" in capture_branch
+    assert '--summary "$SUMMARY"' in capture_branch
+    assert "scripts.site_archive sync" not in capture_branch
+    assert "sync\n" in sync_branch
+
+
+def test_manual_inputs_reject_conflicting_flags_and_unsafe_capture_limits() -> None:
+    """Require one unambiguous mode and a bounded whole-number capture limit.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        ``lookup_only`` and ``capture_only`` cannot both be true.
+    """
+    run = archive_step()["run"]
+
+    assert 'if test "$LOOKUP_ONLY" = "true" && test "$CAPTURE_ONLY" = "true"; then' in run
+    assert "lookup_only and capture_only cannot both be enabled." in run
+    assert '[[ "$MAX_CAPTURES" =~ ^[1-9][0-9]*$ ]]' in run
+    assert 'test "$MAX_CAPTURES" -gt 100' in run
+    assert "max_captures must be a whole number from 1 through 100." in run
+    assert archive_step()["continue-on-error"] is True


### PR DESCRIPTION
## Summary

- add validated `capture_only` and `max_captures` inputs to the site archive workflow
- preserve the weekly sync batch while allowing a manual capture-only backlog run
- document a 62-page run and test workflow mode, validation, and checkpoint behavior

## Validation

- `make check`