### PR TITLE
Add site archive catch-up controller

### DIFF
--- a/.github/workflows/site-archive-catch-up.yaml
+++ b/.github/workflows/site-archive-catch-up.yaml
@@ -1,0 +1,134 @@
+name: Site archive catch-up
+run-name: Site archive catch-up controller
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_run:
+    workflows:
+      - Site archive
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Control action"
+        required: true
+        default: status
+        type: choice
+        options:
+          - start
+          - resume
+          - stop
+          - status
+
+permissions:
+  actions: write
+  contents: write
+
+concurrency:
+  group: site-archive-data-writer
+  cancel-in-progress: false
+
+jobs:
+  controller:
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.head_repository.full_name == github.repository)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      UV_NO_ENV_FILE: "1"
+      MANIFEST: .site-archive/manifest.json
+      STATE: .site-archive/catch-up.json
+      STATE_TOKEN: .site-archive/state-token.json
+      ACTION: ${{ inputs.action || 'tick' }}
+    steps:
+      - name: Check out production source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Guard production-only checkout
+        run: |
+          if test "$GITHUB_EVENT_NAME" = workflow_dispatch && test "$GITHUB_REF" != refs/heads/main; then
+            echo "Site archive catch-up must run from main, not $GITHUB_REF." >&2
+            exit 1
+          fi
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          python-version: "3.12"
+
+      - name: Install Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+
+      - name: Bootstrap controller
+        run: make ci-bootstrap
+
+      - name: Fetch durable archive state
+        run: |
+          mkdir -p .site-archive
+          uv run python -m scripts.site_archive.catch_up fetch \
+            --manifest "$MANIFEST" --state "$STATE" --state-token "$STATE_TOKEN"
+
+      - name: Apply requested control action
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          case "$ACTION" in
+            start|resume)
+              uv run python -m scripts.site_archive.catch_up start --state "$STATE"
+              ;;
+            stop)
+              uv run python -m scripts.site_archive.catch_up stop --state "$STATE"
+              ;;
+            status)
+              uv run python -m scripts.site_archive.catch_up status --state "$STATE"
+              echo "skip=true" >> "$GITHUB_ENV"
+              ;;
+            *)
+              echo "Unsupported control action: $ACTION" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Select next archive batch
+        if: env.skip != 'true'
+        id: tick
+        run: |
+          action="$(
+            uv run python -m scripts.site_archive.catch_up tick \
+              --manifest "$MANIFEST" --state "$STATE" --controller-run-id "$GITHUB_RUN_ID"
+          )"
+          case "$action" in
+            capture|lookup|wait|idle|blocked|complete)
+              echo "action=$action" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unexpected controller action: $action" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Persist controller state
+        if: env.skip != 'true'
+        run: |
+          uv run python -m scripts.site_archive.catch_up push \
+            --state "$STATE" --state-token "$STATE_TOKEN"
+
+      - name: Dispatch selected archive batch
+        if: steps.tick.outputs.action == 'capture' || steps.tick.outputs.action == 'lookup'
+        run: |
+          if test "${{ steps.tick.outputs.action }}" = capture; then
+            gh workflow run site-archive.yaml --repo "$GITHUB_REPOSITORY" --ref main \
+              -f capture_only=true -f max_captures=100 -f catch_up_id="$GITHUB_RUN_ID"
+          else
+            gh workflow run site-archive.yaml --repo "$GITHUB_REPOSITORY" --ref main \
+              -f lookup_only=true -f max_captures=1 -f catch_up_id="$GITHUB_RUN_ID"
+          fi

--- a/.github/workflows/site-archive.yaml
+++ b/.github/workflows/site-archive.yaml
@@ -1,4 +1,5 @@
 name: Site archive
+run-name: ${{ inputs.catch_up_id && format('Site archive catch-up {0}', inputs.catch_up_id) || 'Site archive' }}
 
 on:
   schedule:
@@ -20,6 +21,11 @@ on:
         required: false
         default: 10
         type: number
+      catch_up_id:
+        description: "Internal controller run ID; leave blank for ordinary manual runs"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read

--- a/docs/site-archive.md
+++ b/docs/site-archive.md
@@ -32,6 +32,43 @@ The corresponding convenience targets are
 requests are allowed; lookup-only verification does not need Save Page Now
 credentials.
 
+## GitHub Actions catch-up controller
+
+The regular Monday workflow remains a one-time maintenance batch. The separate
+**Site archive catch-up** workflow polls every ten minutes but does nothing
+until an operator starts the durable controller state on `site-archive-data`.
+It also wakes after a trusted `main` **Site archive** completion. It dispatches
+at most one existing archive batch at a time, and dispatch is its final step,
+so the batch starts only after the controller releases the shared writer slot.
+
+Start or resume only after checking that no manual archive run is in progress:
+
+```sh
+gh workflow run site-archive-catch-up.yaml --ref main -f action=start
+gh workflow run site-archive-catch-up.yaml --ref main -f action=resume
+```
+
+Stop later dispatches or inspect the saved controller state without changing
+it:
+
+```sh
+gh workflow run site-archive-catch-up.yaml --ref main -f action=stop
+gh workflow run site-archive-catch-up.yaml --ref main -f action=status
+```
+
+It starts with known, due missing pages, then alternates 100-page capture
+batches with lookup/discovery batches. It does not repeat a queued or running
+batch, honors per-page Retry-After deadlines and the 24-hour pending-capture
+window. A persisted partial batch with a current transient Wayback error stays
+active and waits for the later of its recorded retry time or a conservative
+ten-minute pause; its next batch begins with lookup confirmation. It blocks
+only when persistence, configuration, or validation fails; its dispatched run
+cannot be found; or two successful batches make no durable progress. Use
+`resume` only after resolving a blocked cause. It waits through documented
+retry and pending-confirmation deadlines, and marks itself complete only when
+the discovery queue is empty and every known live page is archived or blocked;
+unavailable references remain reported as gaps rather than claimed as archives.
+
 Before submitting a capture, the tool checks that the page still serves public
 HTML and checks Wayback again. It saves the pending request before contacting
 the capture service, so an interrupted response does not lead to an immediate

--- a/scripts/site_archive/branch.py
+++ b/scripts/site_archive/branch.py
@@ -20,6 +20,7 @@ from scripts.site_archive.manifest import ArchiveError, Manifest, ManifestStore
 DEFAULT_REPOSITORY = "palewire/palewi.re"
 DEFAULT_BRANCH = "site-archive-data"
 REMOTE_MANIFEST = "manifest.json"
+REMOTE_CATCH_UP_STATE = "catch-up.json"
 COAUTHOR = "Copilot App <223556219+Copilot@users.noreply.github.com>"
 GH_TIMEOUT_SECONDS = 60
 _SHA = re.compile(r"^[0-9a-fA-F]{40}$")
@@ -178,8 +179,46 @@ class GitHubClient:
             raise BranchPersistenceError("GitHub returned an invalid branch head")
         return sha
 
+    def content(self, head: str, path: str, *, required: bool = True) -> bytes | None:
+        """Read a known data-branch file through an immutable commit ref.
+
+        Args:
+            head: Commit SHA to read.
+            path: One permitted data-branch filename.
+            required: Whether a missing file is an error.
+
+        Returns:
+            UTF-8 file bytes, or None when an optional file is absent.
+
+        Raises:
+            BranchPersistenceError: If the file is absent, malformed, or unreadable.
+
+        Examples:
+            ``client.content(head, REMOTE_MANIFEST)`` reads the manifest.
+        """
+        if path not in {REMOTE_MANIFEST, REMOTE_CATCH_UP_STATE}:
+            raise BranchPersistenceError("unsupported archive data path")
+        try:
+            response = self.request(f"contents/{path}?ref={quote(head, safe='')}")
+        except GitHubRequestError as error:
+            if not required and error.status == 404:
+                return None
+            raise BranchPersistenceError(f"cannot read {path} at {head}: {error}") from error
+        value = response.value
+        if not isinstance(value, dict):
+            raise BranchPersistenceError(f"GitHub returned no usable {path}")
+        if value.get("encoding") == "none" and isinstance(value.get("sha"), str):
+            return self.blob(value["sha"])
+        if value.get("encoding") != "base64" or not isinstance(value.get("content"), str):
+            raise BranchPersistenceError(f"GitHub returned no usable {path}")
+        try:
+            encoded = "".join(value["content"].split())
+            return base64.b64decode(encoded, validate=True)
+        except (binascii.Error, ValueError) as error:
+            raise BranchPersistenceError(f"GitHub returned invalid {path} content") from error
+
     def manifest(self, head: str) -> bytes:
-        """Read the manifest through an immutable commit ref.
+        """Read the required manifest through an immutable commit ref.
 
         Args:
             head: Commit SHA to read.
@@ -188,27 +227,14 @@ class GitHubClient:
             UTF-8 manifest bytes.
 
         Raises:
-            BranchPersistenceError: If the file is absent, malformed, or unreadable.
+            BranchPersistenceError: The required manifest cannot be read.
 
         Examples:
             ``client.manifest(head)`` reads exactly the file at that commit.
         """
-        try:
-            response = self.request(f"contents/{REMOTE_MANIFEST}?ref={quote(head, safe='')}")
-        except GitHubRequestError as error:
-            raise BranchPersistenceError(f"cannot read {REMOTE_MANIFEST} at {head}: {error}") from error
-        value = response.value
-        if not isinstance(value, dict):
-            raise BranchPersistenceError(f"GitHub returned no usable {REMOTE_MANIFEST}")
-        if value.get("encoding") == "none" and isinstance(value.get("sha"), str):
-            return self.blob(value["sha"])
-        if value.get("encoding") != "base64" or not isinstance(value.get("content"), str):
-            raise BranchPersistenceError(f"GitHub returned no usable {REMOTE_MANIFEST}")
-        try:
-            encoded = "".join(value["content"].split())
-            return base64.b64decode(encoded, validate=True)
-        except (binascii.Error, ValueError) as error:
-            raise BranchPersistenceError(f"GitHub returned invalid {REMOTE_MANIFEST} content") from error
+        content = self.content(head, REMOTE_MANIFEST)
+        assert content is not None
+        return content
 
     def blob(self, sha: str) -> bytes:
         """Read an immutable Git blob by SHA.
@@ -293,12 +319,13 @@ class GitHubClient:
             raise BranchPersistenceError("cannot create manifest blob") from error
         return _require_sha(sha, "blob")
 
-    def create_tree(self, blob: str, base_tree: str | None) -> str:
+    def create_tree(self, blob: str, base_tree: str | None, path: str = REMOTE_MANIFEST) -> str:
         """Create a tree containing only the manifest file.
 
         Args:
             blob: Manifest blob SHA.
             base_tree: Existing tree SHA, or ``None`` for an orphan commit.
+            path: Permitted data-branch filename replaced by this blob.
 
         Returns:
             New tree SHA.
@@ -309,7 +336,9 @@ class GitHubClient:
         Examples:
             ``client.create_tree(blob, None)`` creates an orphan single-file tree.
         """
-        payload: dict[str, Any] = {"tree": [{"path": REMOTE_MANIFEST, "mode": "100644", "type": "blob", "sha": blob}]}
+        if path not in {REMOTE_MANIFEST, REMOTE_CATCH_UP_STATE}:
+            raise BranchPersistenceError("unsupported archive data path")
+        payload: dict[str, Any] = {"tree": [{"path": path, "mode": "100644", "type": "blob", "sha": blob}]}
         if base_tree is not None:
             payload["base_tree"] = base_tree
         try:

--- a/scripts/site_archive/catch_up.py
+++ b/scripts/site_archive/catch_up.py
@@ -1,0 +1,975 @@
+"""Durably control GitHub Actions site-archive catch-up batches."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import click
+
+from scripts.site_archive.branch import (
+    DEFAULT_REPOSITORY,
+    REMOTE_CATCH_UP_STATE,
+    BranchPersistenceError,
+    BranchToken,
+    GitHubClient,
+    _read_token,
+    _write_token,
+)
+from scripts.site_archive.cli import is_due
+from scripts.site_archive.manifest import ArchiveError, Manifest, ManifestStore, PageRecord
+from scripts.site_archive.wayback import PENDING_COOLDOWN
+
+STATE_FIELDS = {
+    "active",
+    "phase",
+    "dispatch_token",
+    "dispatched_at",
+    "archive_run_id",
+    "last_run_id",
+    "next_retry_at",
+    "last_error",
+    "finished_at",
+    "before_manifest_sha256",
+    "before_archive_progress",
+    "no_progress_runs",
+}
+PHASES = {"capture", "lookup", "blocked", "complete"}
+WORKFLOW_NAME = "site-archive.yaml"
+RUN_TITLE_PREFIX = "Site archive catch-up "
+DISPATCH_GRACE = timedelta(minutes=15)
+MAX_NO_PROGRESS_RUNS = 2
+
+
+class CatchUpError(RuntimeError):
+    """Raised when durable catch-up control state is invalid or unsafe."""
+
+
+@dataclass
+class CatchUpState:
+    """Persisted controller state for the full-site archive catch-up."""
+
+    active: bool = False
+    phase: str = "capture"
+    dispatch_token: str = ""
+    dispatched_at: str = ""
+    archive_run_id: int = 0
+    last_run_id: int = 0
+    next_retry_at: str = ""
+    last_error: str = ""
+    finished_at: str = ""
+    before_manifest_sha256: str = ""
+    before_archive_progress: int = 0
+    no_progress_runs: int = 0
+
+
+class CatchUpStore:
+    """Validate and atomically save one local controller state file."""
+
+    def __init__(self, path: Path):
+        """Configure a store.
+
+        Args:
+            path: Local JSON state destination.
+
+        Returns:
+            None.
+
+        Examples:
+            ``CatchUpStore(Path(".site-archive/catch-up.json"))``.
+        """
+        self.path = path
+
+    def load(self) -> CatchUpState:
+        """Load controller state or return a safe inactive default when absent.
+
+        Returns:
+            Validated persisted state.
+
+        Raises:
+            CatchUpError: The existing JSON state is malformed.
+
+        Examples:
+            ``store.load().active`` reports whether catch-up is enabled.
+        """
+        if not self.path.exists() and not self.path.is_symlink():
+            return CatchUpState()
+        try:
+            value = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as error:
+            raise CatchUpError(f"{self.path}: invalid catch-up state: {error}") from error
+        return _state_from_value(value, str(self.path))
+
+    def save(self, state: CatchUpState) -> None:
+        """Validate and atomically save controller state.
+
+        Args:
+            state: Catch-up state to persist.
+
+        Returns:
+            None.
+
+        Raises:
+            CatchUpError: The state cannot be validated or saved.
+
+        Examples:
+            ``store.save(CatchUpState(active=True))`` enables a fresh catch-up.
+        """
+        value = _state_to_value(state)
+        _state_from_value(value, str(self.path))
+        temporary = self.path.with_suffix(f"{self.path.suffix}.tmp")
+        try:
+            temporary.parent.mkdir(parents=True, exist_ok=True)
+            temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            temporary.replace(self.path)
+        except OSError as error:
+            raise CatchUpError(f"{self.path}: unable to save catch-up state: {error}") from error
+
+
+@dataclass(frozen=True)
+class WorkflowRun:
+    """The small subset of an archive Actions run used by the controller."""
+
+    id: int
+    status: str
+    conclusion: str | None
+
+
+@dataclass(frozen=True)
+class ControllerDecision:
+    """One action selected by an offline controller tick."""
+
+    action: str
+    detail: str
+
+
+def _state_to_value(state: CatchUpState) -> dict[str, Any]:
+    """Convert catch-up state to its one supported JSON form.
+
+    Args:
+        state: State instance to serialize.
+
+    Returns:
+        JSON-compatible state mapping.
+
+    Raises:
+        CatchUpError: The input is not a state instance.
+
+    Examples:
+        ``_state_to_value(CatchUpState())["active"]`` is False.
+    """
+    if not isinstance(state, CatchUpState):
+        raise CatchUpError("catch-up state must be a CatchUpState")
+    return asdict(state)
+
+
+def _state_from_value(value: Any, location: str) -> CatchUpState:
+    """Validate and reconstruct catch-up state from decoded JSON.
+
+    Args:
+        value: Decoded JSON value.
+        location: Human-readable source identifier.
+
+    Returns:
+        Validated catch-up state.
+
+    Raises:
+        CatchUpError: The JSON has unsupported or contradictory values.
+
+    Examples:
+        ``_state_from_value(_state_to_value(CatchUpState()), "state")`` succeeds.
+    """
+    if not isinstance(value, dict) or set(value) != STATE_FIELDS:
+        raise CatchUpError(f"{location}: invalid catch-up state fields")
+    if type(value["active"]) is not bool:
+        raise CatchUpError(f"{location}: active must be a boolean")
+    if not isinstance(value["phase"], str) or value["phase"] not in PHASES:
+        raise CatchUpError(f"{location}: invalid phase")
+    for name in (
+        "dispatch_token",
+        "dispatched_at",
+        "next_retry_at",
+        "last_error",
+        "finished_at",
+        "before_manifest_sha256",
+    ):
+        if not isinstance(value[name], str):
+            raise CatchUpError(f"{location}: {name} must be a string")
+    for name in ("dispatched_at", "next_retry_at", "finished_at"):
+        _timestamp(value[name], f"{location}: {name}")
+    if value["dispatch_token"] and not value["dispatch_token"].isdigit():
+        raise CatchUpError(f"{location}: dispatch_token must be a GitHub run ID")
+    if type(value["archive_run_id"]) is not int or value["archive_run_id"] < 0:
+        raise CatchUpError(f"{location}: archive_run_id must be a non-negative integer")
+    if type(value["last_run_id"]) is not int or value["last_run_id"] < 0:
+        raise CatchUpError(f"{location}: last_run_id must be a non-negative integer")
+    if type(value["no_progress_runs"]) is not int or value["no_progress_runs"] < 0:
+        raise CatchUpError(f"{location}: no_progress_runs must be a non-negative integer")
+    if type(value["before_archive_progress"]) is not int or value["before_archive_progress"] < 0:
+        raise CatchUpError(f"{location}: before_archive_progress must be a non-negative integer")
+    digest = value["before_manifest_sha256"]
+    if digest and (len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest)):
+        raise CatchUpError(f"{location}: before_manifest_sha256 must be a lowercase SHA-256")
+    dispatched = bool(value["dispatch_token"])
+    if dispatched != bool(value["dispatched_at"]) or dispatched != bool(value["before_manifest_sha256"]):
+        raise CatchUpError(f"{location}: dispatch fields must be present together")
+    if not dispatched and value["archive_run_id"]:
+        raise CatchUpError(f"{location}: archive_run_id requires a dispatched run")
+    if value["phase"] in {"blocked", "complete"} and value["active"]:
+        raise CatchUpError(f"{location}: terminal phases cannot remain active")
+    return CatchUpState(**value)
+
+
+def _timestamp(value: str, location: str) -> None:
+    """Validate one optional UTC ISO timestamp.
+
+    Args:
+        value: Empty or UTC timestamp string.
+        location: Human-readable state-field location.
+
+    Returns:
+        None.
+
+    Raises:
+        CatchUpError: The timestamp is not valid UTC ISO text.
+
+    Examples:
+        ``_timestamp("2026-09-06T12:00:00Z", "state")`` succeeds.
+    """
+    if not value:
+        return
+    if not value.endswith(("Z", "+00:00")):
+        raise CatchUpError(f"{location}: must be a UTC timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise CatchUpError(f"{location}: invalid timestamp") from error
+    if parsed.tzinfo is None or parsed.utcoffset() != UTC.utcoffset(parsed):
+        raise CatchUpError(f"{location}: must be a UTC timestamp")
+
+
+def start(state: CatchUpState) -> CatchUpState:
+    """Enable catch-up starting with known missing archive pages.
+
+    Args:
+        state: Existing controller state.
+
+    Returns:
+        Reset active state ready for a capture batch.
+
+    Examples:
+        ``start(CatchUpState()).phase`` is ``"capture"``.
+    """
+    state.active = True
+    state.phase = "capture"
+    state.dispatch_token = ""
+    state.dispatched_at = ""
+    state.archive_run_id = 0
+    state.next_retry_at = ""
+    state.last_error = ""
+    state.finished_at = ""
+    state.before_manifest_sha256 = ""
+    state.before_archive_progress = 0
+    state.no_progress_runs = 0
+    return state
+
+
+def stop(state: CatchUpState, now: datetime) -> CatchUpState:
+    """Disable catch-up without changing archive inventory evidence.
+
+    Args:
+        state: Existing controller state.
+        now: Current timezone-aware UTC time.
+
+    Returns:
+        Inactive state marked complete by an explicit operator stop.
+
+    Examples:
+        ``stop(CatchUpState(active=True), now).active`` is False.
+    """
+    state.active = False
+    state.phase = "complete"
+    state.dispatch_token = ""
+    state.dispatched_at = ""
+    state.archive_run_id = 0
+    state.next_retry_at = ""
+    state.finished_at = _utc_text(now)
+    state.before_manifest_sha256 = ""
+    state.before_archive_progress = 0
+    return state
+
+
+def decide(
+    state: CatchUpState,
+    manifest: Manifest,
+    *,
+    now: datetime,
+    workflow_run: WorkflowRun | None,
+    manifest_sha256: str,
+    controller_run_id: str,
+) -> ControllerDecision:
+    """Advance state and select at most one safe action for a controller run.
+
+    Args:
+        state: Mutable durable controller state.
+        manifest: Fresh archive manifest from the data branch.
+        now: Current timezone-aware UTC time.
+        workflow_run: Matching dispatched archive run, when known.
+        manifest_sha256: Exact digest of the freshly fetched manifest.
+        controller_run_id: Current controller Actions run ID used to label a dispatch.
+
+    Returns:
+        Selected action: ``capture``, ``lookup``, ``wait``, ``idle``, ``blocked``, or ``complete``.
+
+    Raises:
+        CatchUpError: Required controller inputs are invalid.
+
+    Examples:
+        ``decide(state, manifest, now=now, workflow_run=None, manifest_sha256=digest, controller_run_id="1")``.
+    """
+    _require_utc(now)
+    if not controller_run_id.isdigit():
+        raise CatchUpError("controller_run_id must be a GitHub run ID")
+    if len(manifest_sha256) != 64:
+        raise CatchUpError("manifest_sha256 must be a SHA-256")
+    if not state.active:
+        return ControllerDecision("idle", "Catch-up is not active.")
+    if state.dispatch_token:
+        settled = _settle_dispatched_run(state, manifest, now, workflow_run, manifest_sha256)
+        if settled is not None:
+            return settled
+    retry_at = _parse_timestamp(state.next_retry_at)
+    if retry_at and now < retry_at:
+        return ControllerDecision("wait", f"Waiting until {state.next_retry_at}.")
+    action, detail, retry = _next_action(state.phase, manifest, now)
+    if action in {"capture", "lookup"}:
+        state.dispatch_token = controller_run_id
+        state.dispatched_at = _utc_text(now)
+        state.before_manifest_sha256 = manifest_sha256
+        state.before_archive_progress = archive_progress(manifest)
+        state.next_retry_at = _utc_text(now + DISPATCH_GRACE)
+        state.last_error = ""
+        state.finished_at = ""
+        state.phase = "lookup" if action == "capture" else "capture"
+        return ControllerDecision(action, detail)
+    if action == "wait":
+        assert retry is not None
+        state.next_retry_at = _utc_text(retry)
+        return ControllerDecision("wait", detail)
+    state.active = False
+    state.phase = action
+    state.finished_at = _utc_text(now)
+    state.next_retry_at = ""
+    return ControllerDecision(action, detail)
+
+
+def _settle_dispatched_run(
+    state: CatchUpState,
+    manifest: Manifest,
+    now: datetime,
+    workflow_run: WorkflowRun | None,
+    manifest_sha256: str,
+) -> ControllerDecision | None:
+    """Wait for or record the result of the only archive run in flight.
+
+    Args:
+        state: Mutable state with a dispatch token.
+        manifest: Fresh archive manifest after the dispatched batch.
+        now: Current UTC time.
+        workflow_run: Matching archive Actions run, if visible.
+        manifest_sha256: Current manifest digest.
+
+    Returns:
+        Safe wait or blocked action, or None when the completed batch allows
+        immediate next-phase selection.
+
+    Examples:
+        A queued run returns ``ControllerDecision("wait", ...)``.
+    """
+    dispatched_at = _parse_timestamp(state.dispatched_at)
+    assert dispatched_at is not None
+    if workflow_run is None:
+        if now < dispatched_at + DISPATCH_GRACE:
+            return ControllerDecision("wait", "Waiting for the dispatched archive run to appear.")
+        return _block(state, now, "The dispatched archive run did not appear within 15 minutes.")
+    state.archive_run_id = workflow_run.id
+    if workflow_run.status != "completed":
+        return ControllerDecision("wait", f"Archive run {workflow_run.id} is {workflow_run.status}.")
+    state.last_run_id = workflow_run.id
+    state.archive_run_id = 0
+    state.dispatch_token = ""
+    state.dispatched_at = ""
+    state.next_retry_at = ""
+    made_archive_progress = archive_progress(manifest) > state.before_archive_progress
+    manifest_changed = state.before_manifest_sha256 != manifest_sha256
+    if workflow_run.conclusion != "success":
+        retry_at = _transient_retry(manifest, now) if manifest_changed else None
+        state.before_manifest_sha256 = ""
+        state.before_archive_progress = 0
+        if retry_at is not None:
+            state.phase = "lookup"
+            state.next_retry_at = _utc_text(max(retry_at, now + timedelta(minutes=10)))
+            if made_archive_progress:
+                state.no_progress_runs = 0
+            return ControllerDecision(
+                "wait",
+                f"Archive run {workflow_run.id} made partial progress and will retry after {state.next_retry_at}.",
+            )
+        return _block(
+            state,
+            now,
+            f"Archive run {workflow_run.id} ended with {workflow_run.conclusion or 'no conclusion'}.",
+        )
+    if state.before_manifest_sha256 == manifest_sha256:
+        state.no_progress_runs += 1
+    else:
+        state.no_progress_runs = 0
+    state.before_manifest_sha256 = ""
+    state.before_archive_progress = 0
+    if state.no_progress_runs >= MAX_NO_PROGRESS_RUNS:
+        return _block(state, now, "Two successful archive batches made no durable progress.")
+    return None
+
+
+def _next_action(phase: str, manifest: Manifest, now: datetime) -> tuple[str, str, datetime | None]:
+    """Choose the next work phase from persisted inventory evidence.
+
+    Args:
+        phase: Preferred phase after the last completed batch.
+        manifest: Fresh archive inventory.
+        now: Current UTC time.
+
+    Returns:
+        Action name, explanation, and optional retry time.
+
+    Examples:
+        A due missing page selects ``"capture"`` during the capture phase.
+    """
+    missing = _due_missing(manifest)
+    lookup_needed = _lookup_needed(manifest, now)
+    if phase == "capture" and missing:
+        return "capture", f"Requesting captures for {len(missing)} known missing live pages.", None
+    if phase == "lookup" and lookup_needed:
+        return "lookup", "Checking pending, unknown, and discovery work.", None
+    if missing:
+        return "capture", f"Requesting captures for {len(missing)} known missing live pages.", None
+    if lookup_needed:
+        return "lookup", "Checking pending, unknown, and discovery work.", None
+    retry_at = _next_retry(manifest, now)
+    if retry_at:
+        return "wait", f"Waiting for the next permitted archive check at {_utc_text(retry_at)}.", retry_at
+    return (
+        "complete",
+        "All known live pages are archived or blocked; discovery is drained and unavailable references remain recorded.",
+        None,
+    )
+
+
+def archive_progress(manifest: Manifest) -> int:
+    """Count confirmed archives and unambiguous successful capture candidates.
+
+    Args:
+        manifest: Archive inventory to inspect.
+
+    Returns:
+        Count of confirmed snapshots plus pending captures with a returned URL.
+
+    Examples:
+        ``archive_progress(Manifest())`` is zero.
+    """
+    return sum(
+        page.archive_status == "archived" or (page.archive_status == "pending" and bool(page.pending_archive_url))
+        for page in manifest.pages.values()
+    )
+
+
+def _transient_retry(manifest: Manifest, now: datetime) -> datetime | None:
+    """Find a current Wayback retry deadline from persisted transient failures.
+
+    Args:
+        manifest: Fresh archive inventory after a failed batch.
+        now: Current UTC time.
+
+    Returns:
+        Earliest eligible retry time, or None for configuration or validation failures.
+
+    Examples:
+        A rate-limited Wayback request returns its recorded retry time.
+    """
+    retries: list[datetime] = []
+    for page in manifest.pages.values():
+        retry_at = _parse_timestamp(page.next_retry_at)
+        if (
+            page.last_check_status == "error"
+            and retry_at is not None
+            and page.last_error.startswith("Wayback ")
+            and "SAVEPAGENOW_" not in page.last_error
+        ):
+            retries.append(retry_at)
+    return min(retries, default=None)
+
+
+def _due_missing(manifest: Manifest) -> list[PageRecord]:
+    """Return live, missing archive records that can be submitted now.
+
+    Args:
+        manifest: Archive inventory to inspect.
+
+    Returns:
+        Due missing live pages.
+
+    Examples:
+        ``_due_missing(Manifest())`` is an empty list.
+    """
+    return [
+        page
+        for page in manifest.pages.values()
+        if page.live_status == "live" and page.archive_status == "missing" and is_due(page)
+    ]
+
+
+def _lookup_needed(manifest: Manifest, now: datetime) -> bool:
+    """Determine whether a lookup/discovery batch can make safe progress now.
+
+    Args:
+        manifest: Archive inventory to inspect.
+        now: Current UTC time.
+
+    Returns:
+        Whether lookup-only synchronization is due.
+
+    Examples:
+        A nonempty discovery queue requires a lookup batch.
+    """
+    if manifest.discovery_queue:
+        return True
+    for page in manifest.pages.values():
+        if page.live_status != "live" or not is_due(page):
+            continue
+        if page.archive_status == "unknown":
+            return True
+        if page.archive_status == "pending" and _pending_due(page, now):
+            return True
+    return False
+
+
+def _next_retry(manifest: Manifest, now: datetime) -> datetime | None:
+    """Find the earliest retry deadline for remaining but currently deferred work.
+
+    Args:
+        manifest: Archive inventory to inspect.
+        now: Current UTC time.
+
+    Returns:
+        Earliest future permitted time, or None when no deferred work exists.
+
+    Examples:
+        ``_next_retry(Manifest(), now)`` returns None.
+    """
+    retries: list[datetime] = []
+    for page in manifest.pages.values():
+        if page.live_status != "live":
+            continue
+        retry = _parse_timestamp(page.next_retry_at)
+        if retry and retry > now and page.archive_status in {"unknown", "missing", "pending"}:
+            retries.append(retry)
+        if page.archive_status == "pending":
+            submitted = _parse_timestamp(page.last_submit_at)
+            if submitted:
+                due = submitted + PENDING_COOLDOWN
+                if due > now:
+                    retries.append(due)
+    return min(retries, default=None)
+
+
+def _pending_due(page: PageRecord, now: datetime) -> bool:
+    """Determine whether a pending submission has passed its 24-hour wait.
+
+    Args:
+        page: Pending archive record.
+        now: Current UTC time.
+
+    Returns:
+        Whether independent confirmation may be requested now.
+
+    Examples:
+        A freshly submitted page returns False.
+    """
+    submitted = _parse_timestamp(page.last_submit_at)
+    return submitted is not None and now >= submitted + PENDING_COOLDOWN
+
+
+def _parse_timestamp(value: str) -> datetime | None:
+    """Parse an optional validated UTC timestamp.
+
+    Args:
+        value: Empty or ISO UTC timestamp.
+
+    Returns:
+        Parsed UTC time or None.
+
+    Examples:
+        ``_parse_timestamp("")`` returns None.
+    """
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+def _utc_text(value: datetime) -> str:
+    """Serialize a timezone-aware time using the persistent UTC form.
+
+    Args:
+        value: Time to serialize.
+
+    Returns:
+        ISO UTC timestamp ending in ``Z``.
+
+    Examples:
+        ``_utc_text(now).endswith("Z")`` is True.
+    """
+    _require_utc(value)
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _require_utc(value: datetime) -> None:
+    """Require a timezone-aware UTC-compatible time.
+
+    Args:
+        value: Time to validate.
+
+    Returns:
+        None.
+
+    Raises:
+        CatchUpError: The value has no timezone.
+
+    Examples:
+        ``_require_utc(datetime.now(UTC))`` succeeds.
+    """
+    if value.tzinfo is None:
+        raise CatchUpError("time must be timezone-aware")
+
+
+def _block(state: CatchUpState, now: datetime, detail: str) -> ControllerDecision:
+    """Record a terminal pause that requires an explicit manual resume.
+
+    Args:
+        state: Mutable controller state.
+        now: Current UTC time.
+        detail: Clear operator-facing pause reason.
+
+    Returns:
+        Blocked decision.
+
+    Examples:
+        ``_block(state, now, "Archive run failed").action`` is ``"blocked"``.
+    """
+    state.active = False
+    state.phase = "blocked"
+    state.last_error = detail
+    state.next_retry_at = ""
+    state.finished_at = _utc_text(now)
+    state.before_manifest_sha256 = ""
+    state.before_archive_progress = 0
+    return ControllerDecision("blocked", detail)
+
+
+def manifest_digest(path: Path) -> str:
+    """Return the exact SHA-256 digest for a fetched manifest file.
+
+    Args:
+        path: Validated local manifest file.
+
+    Returns:
+        Lowercase SHA-256 text.
+
+    Raises:
+        CatchUpError: The file cannot be read.
+
+    Examples:
+        ``len(manifest_digest(Path("manifest.json")))`` is 64.
+    """
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError as error:
+        raise CatchUpError(f"{path}: unable to read manifest: {error}") from error
+
+
+def fetch_state(manifest_path: Path, state_path: Path, state_token: Path) -> None:
+    """Fetch the manifest and optional controller state at the same branch head.
+
+    Args:
+        manifest_path: Local archive manifest destination.
+        state_path: Local controller state destination.
+        state_token: Optimistic branch-head token destination.
+
+    Returns:
+        None.
+
+    Raises:
+        CatchUpError: The data branch or local state is unsafe.
+
+    Examples:
+        ``fetch_state(manifest, state, token)`` prepares one controller run.
+    """
+    from scripts.site_archive.branch import fetch
+
+    try:
+        fetch(manifest_path, state_token)
+        token = _read_token(state_token)
+        if token.head is None:
+            raise CatchUpError("site-archive-data does not yet contain an archive manifest")
+        content = GitHubClient(token.repository).content(token.head, REMOTE_CATCH_UP_STATE, required=False)
+        if content is None:
+            CatchUpStore(state_path).save(CatchUpState())
+            return
+        temporary = state_path.with_suffix(f"{state_path.suffix}.fetch.tmp")
+        temporary.parent.mkdir(parents=True, exist_ok=True)
+        temporary.write_bytes(content)
+        CatchUpStore(temporary).load()
+        temporary.replace(state_path)
+    except (ArchiveError, BranchPersistenceError, OSError) as error:
+        raise CatchUpError(str(error)) from error
+
+
+def push_state(state_path: Path, state_token: Path) -> None:
+    """Persist controller state with the fetched data-branch head as a lock.
+
+    Args:
+        state_path: Validated local controller state.
+        state_token: Token written by :func:`fetch_state`.
+
+    Returns:
+        None.
+
+    Raises:
+        CatchUpError: The branch changed or state cannot be safely written.
+
+    Examples:
+        ``push_state(state, token)`` saves a controller transition.
+    """
+    try:
+        CatchUpStore(state_path).load()
+        content = state_path.read_bytes()
+        token = _read_token(state_token)
+        if token.head is None:
+            raise CatchUpError("cannot create catch-up state before the archive manifest exists")
+        client = GitHubClient(token.repository)
+        if client.ref(token.branch) != token.head:
+            raise CatchUpError("branch changed since fetch; refusing stale catch-up write")
+        remote = client.content(token.head, REMOTE_CATCH_UP_STATE, required=False)
+        if remote == content:
+            click.echo("Catch-up state is unchanged; no commit created.")
+            return
+        tree = client.create_tree(
+            client.create_blob(content),
+            client.commit_tree(token.head),
+            REMOTE_CATCH_UP_STATE,
+        )
+        commit = client.create_commit(tree, token.head)
+        client.update_ref(token.branch, commit, create=False)
+        _write_token(state_token, BranchToken(token.repository, token.branch, commit))
+        click.echo(f"Persisted {REMOTE_CATCH_UP_STATE} at {commit}.")
+    except (ArchiveError, BranchPersistenceError, OSError) as error:
+        raise CatchUpError(str(error)) from error
+
+
+def find_dispatched_run(state: CatchUpState) -> WorkflowRun | None:
+    """Find the one archive Actions run labelled by the saved controller token.
+
+    Args:
+        state: Controller state with a nonempty dispatch token.
+
+    Returns:
+        Matching archive workflow run, or None when it is not visible yet.
+
+    Raises:
+        CatchUpError: GitHub returns malformed workflow data.
+
+    Examples:
+        ``find_dispatched_run(state)`` checks the current archive batch.
+    """
+    if not state.dispatch_token:
+        return None
+    try:
+        value = (
+            GitHubClient(DEFAULT_REPOSITORY)
+            .request(f"actions/workflows/{WORKFLOW_NAME}/runs?event=workflow_dispatch&per_page=100")
+            .value
+        )
+    except BranchPersistenceError as error:
+        raise CatchUpError(f"cannot read archive workflow runs: {error}") from error
+    if not isinstance(value, dict) or not isinstance(value.get("workflow_runs"), list):
+        raise CatchUpError("GitHub returned malformed archive workflow runs")
+    expected = f"{RUN_TITLE_PREFIX}{state.dispatch_token}"
+    for run in value["workflow_runs"]:
+        if not isinstance(run, dict) or run.get("display_title") != expected:
+            continue
+        run_id = run.get("id")
+        status = run.get("status")
+        conclusion = run.get("conclusion")
+        if (
+            type(run_id) is not int
+            or not isinstance(status, str)
+            or conclusion is not None
+            and not isinstance(conclusion, str)
+        ):
+            raise CatchUpError("GitHub returned malformed archive workflow run")
+        return WorkflowRun(run_id, status, conclusion)
+    return None
+
+
+@click.group()
+def cli() -> None:
+    """Manage durable GitHub Actions catch-up state.
+
+    Returns:
+        None.
+
+    Examples:
+        ``uv run python -m scripts.site_archive.catch_up status`` reports state.
+    """
+
+
+@cli.command("fetch")
+@click.option("--manifest", "manifest_path", type=click.Path(path_type=Path), required=True)
+@click.option("--state", "state_path", type=click.Path(path_type=Path), required=True)
+@click.option("--state-token", type=click.Path(path_type=Path), required=True)
+def fetch_command(manifest_path: Path, state_path: Path, state_token: Path) -> None:
+    """Fetch archive and controller state from the protected data branch.
+
+    Args:
+        manifest_path: Local archive manifest destination.
+        state_path: Local controller state destination.
+        state_token: Local branch-head token destination.
+
+    Returns:
+        None.
+
+    Examples:
+        ``... catch_up fetch --manifest manifest.json --state catch-up.json --state-token token.json``.
+    """
+    try:
+        fetch_state(manifest_path, state_path, state_token)
+    except CatchUpError as error:
+        raise click.ClickException(str(error)) from error
+
+
+@cli.command("push")
+@click.option("--state", "state_path", type=click.Path(path_type=Path), required=True)
+@click.option("--state-token", type=click.Path(path_type=Path), required=True)
+def push_command(state_path: Path, state_token: Path) -> None:
+    """Persist controller state to the protected data branch.
+
+    Args:
+        state_path: Local controller state file.
+        state_token: Local branch-head token produced by fetch.
+
+    Returns:
+        None.
+
+    Examples:
+        ``... catch_up push --state catch-up.json --state-token token.json``.
+    """
+    try:
+        push_state(state_path, state_token)
+    except CatchUpError as error:
+        raise click.ClickException(str(error)) from error
+
+
+@cli.command("start")
+@click.option("--state", "state_path", type=click.Path(path_type=Path), required=True)
+def start_command(state_path: Path) -> None:
+    """Enable catch-up after a controller-state fetch.
+
+    Args:
+        state_path: Local controller state path.
+
+    Returns:
+        None.
+
+    Examples:
+        ``... catch_up start --state catch-up.json`` enables capture work.
+    """
+    store = CatchUpStore(state_path)
+    store.save(start(store.load()))
+
+
+@cli.command("stop")
+@click.option("--state", "state_path", type=click.Path(path_type=Path), required=True)
+def stop_command(state_path: Path) -> None:
+    """Disable catch-up after a controller-state fetch.
+
+    Args:
+        state_path: Local controller state path.
+
+    Returns:
+        None.
+
+    Examples:
+        ``... catch_up stop --state catch-up.json`` stops later dispatches.
+    """
+    store = CatchUpStore(state_path)
+    store.save(stop(store.load(), datetime.now(UTC)))
+
+
+@cli.command("status")
+@click.option("--state", "state_path", type=click.Path(path_type=Path), required=True)
+def status_command(state_path: Path) -> None:
+    """Print validated controller state as JSON.
+
+    Args:
+        state_path: Local controller state path.
+
+    Returns:
+        None.
+
+    Examples:
+        ``... catch_up status --state catch-up.json`` prints durable status.
+    """
+    click.echo(json.dumps(_state_to_value(CatchUpStore(state_path).load()), indent=2, sort_keys=True))
+
+
+@cli.command("tick")
+@click.option("--manifest", "manifest_path", type=click.Path(path_type=Path), required=True)
+@click.option("--state", "state_path", type=click.Path(path_type=Path), required=True)
+@click.option("--controller-run-id", required=True)
+def tick_command(manifest_path: Path, state_path: Path, controller_run_id: str) -> None:
+    """Select and save one controller action using fetched durable data.
+
+    Args:
+        manifest_path: Fresh local archive manifest.
+        state_path: Fresh local controller state.
+        controller_run_id: Current controller Actions run ID.
+
+    Returns:
+        None.
+
+    Examples:
+        ``... catch_up tick --manifest manifest.json --state catch-up.json --controller-run-id 1``.
+    """
+    try:
+        store = CatchUpStore(state_path)
+        state = store.load()
+        decision = decide(
+            state,
+            ManifestStore(manifest_path).load(),
+            now=datetime.now(UTC),
+            workflow_run=find_dispatched_run(state),
+            manifest_sha256=manifest_digest(manifest_path),
+            controller_run_id=controller_run_id,
+        )
+        store.save(state)
+        click.echo(decision.action)
+        click.echo(decision.detail, err=True)
+    except (ArchiveError, CatchUpError, OSError) as error:
+        raise click.ClickException(str(error)) from error
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/test_site_archive_catch_up.py
+++ b/tests/test_site_archive_catch_up.py
@@ -213,7 +213,14 @@ def test_failed_or_missing_dispatched_runs_pause_controller() -> None:
     assert "did not appear" in state.last_error
 
 
-def test_partial_transient_failure_waits_then_automatically_resumes() -> None:
+@pytest.mark.parametrize(
+    "error",
+    [
+        "Wayback capture request failed",
+        "Wayback capture connection failed",
+    ],
+)
+def test_partial_transient_failure_waits_then_automatically_resumes(error: str) -> None:
     """Keep catch-up active after a persisted partial Wayback service failure.
 
     Args:
@@ -234,7 +241,7 @@ def test_partial_transient_failure_waits_then_automatically_resumes() -> None:
     ambiguous = manifest.pages["https://palewi.re/ambiguous/"]
     ambiguous.last_submit_at = "2026-09-06T12:00:00Z"
     ambiguous.last_check_status = "error"
-    ambiguous.last_error = "Wayback capture request failed"
+    ambiguous.last_error = error
     ambiguous.next_retry_at = "2026-09-06T12:03:00Z"
     state = state_with_dispatch()
     state.before_archive_progress = 0

--- a/tests/test_site_archive_catch_up.py
+++ b/tests/test_site_archive_catch_up.py
@@ -1,0 +1,755 @@
+"""Offline tests for durable site-archive catch-up control."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from click.testing import CliRunner
+
+from scripts.site_archive import catch_up
+from scripts.site_archive.branch import DEFAULT_BRANCH, DEFAULT_REPOSITORY
+from scripts.site_archive.manifest import Manifest, ManifestStore
+
+NOW = datetime(2026, 9, 6, 12, 0, tzinfo=UTC)
+DIGEST = "a" * 64
+
+
+def state_with_dispatch() -> catch_up.CatchUpState:
+    """Create an active state waiting for one dispatched archive run.
+
+    Returns:
+        Controller state with valid in-flight dispatch fields.
+
+    Examples:
+        ``state_with_dispatch().dispatch_token`` is a GitHub run ID.
+    """
+    return catch_up.CatchUpState(
+        active=True,
+        phase="lookup",
+        dispatch_token="123",
+        dispatched_at="2026-09-06T12:00:00Z",
+        next_retry_at="2026-09-06T12:15:00Z",
+        before_manifest_sha256=DIGEST,
+    )
+
+
+def live_page(manifest: Manifest, status: str, path: str = "posts") -> None:
+    """Add one due live archive record to a manifest.
+
+    Args:
+        manifest: Mutable archive manifest.
+        status: Archive status for the page.
+        path: URL path component used to make the page unique.
+
+    Returns:
+        None.
+
+    Examples:
+        ``live_page(manifest, "missing")`` creates a capture candidate.
+    """
+    page = manifest.page(f"https://palewi.re/{path}/")
+    page.live_status = "live"
+    page.archive_status = status
+
+
+def test_start_stop_and_resume_reset_controller_state() -> None:
+    """Require explicit start or resume after a stopped or blocked state.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        Start always chooses known missing capture work first.
+    """
+    state = catch_up.CatchUpState(active=False, phase="blocked", last_error="Archive failed", no_progress_runs=2)
+    resumed = catch_up.start(state)
+    assert resumed.active is True
+    assert resumed.phase == "capture"
+    assert resumed.last_error == ""
+    assert resumed.no_progress_runs == 0
+    stopped = catch_up.stop(resumed, NOW)
+    assert stopped.active is False
+    assert stopped.phase == "complete"
+    assert stopped.finished_at == "2026-09-06T12:00:00Z"
+
+
+def test_capture_is_selected_before_lookup_and_only_once() -> None:
+    """Dispatch known missing pages first and retain an in-flight marker.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        A second tick cannot duplicate the same capture dispatch.
+    """
+    manifest = Manifest()
+    live_page(manifest, "missing")
+    state = catch_up.start(catch_up.CatchUpState())
+    decision = catch_up.decide(
+        state,
+        manifest,
+        now=NOW,
+        workflow_run=None,
+        manifest_sha256=DIGEST,
+        controller_run_id="456",
+    )
+    assert decision.action == "capture"
+    assert state.phase == "lookup"
+    assert state.dispatch_token == "456"
+    waiting = catch_up.decide(
+        state,
+        manifest,
+        now=NOW + timedelta(minutes=1),
+        workflow_run=None,
+        manifest_sha256=DIGEST,
+        controller_run_id="789",
+    )
+    assert waiting.action == "wait"
+    assert state.dispatch_token == "456"
+
+
+def test_completed_capture_selects_lookup_before_another_capture() -> None:
+    """Alternate a completed capture batch with discovery and verification.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        A changed manifest clears the no-progress counter.
+    """
+    manifest = Manifest(discovery_queue=["https://palewi.re/sitemap.xml"])
+    state = state_with_dispatch()
+    decision = catch_up.decide(
+        state,
+        manifest,
+        now=NOW + timedelta(minutes=1),
+        workflow_run=catch_up.WorkflowRun(99, "completed", "success"),
+        manifest_sha256="b" * 64,
+        controller_run_id="456",
+    )
+    assert decision.action == "lookup"
+    assert state.dispatch_token == "456"
+    assert state.phase == "capture"
+
+
+def test_pending_capture_waits_for_the_full_confirmation_window() -> None:
+    """Avoid a premature lookup or repeat capture for a fresh pending page.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        A pending capture becomes eligible exactly after 24 hours.
+    """
+    manifest = Manifest()
+    live_page(manifest, "pending")
+    page = next(iter(manifest.pages.values()))
+    page.last_submit_at = "2026-09-06T11:00:00Z"
+    state = catch_up.start(catch_up.CatchUpState())
+    decision = catch_up.decide(
+        state,
+        manifest,
+        now=NOW,
+        workflow_run=None,
+        manifest_sha256=DIGEST,
+        controller_run_id="456",
+    )
+    assert decision.action == "wait"
+    assert state.next_retry_at == "2026-09-07T11:00:00Z"
+
+
+def test_failed_or_missing_dispatched_runs_pause_controller() -> None:
+    """Pause instead of retrying a failed or unavailable Actions batch.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        A failed archive job requires an explicit resume.
+    """
+    manifest = Manifest()
+    state = state_with_dispatch()
+    failed = catch_up.decide(
+        state,
+        manifest,
+        now=NOW,
+        workflow_run=catch_up.WorkflowRun(12, "completed", "failure"),
+        manifest_sha256=DIGEST,
+        controller_run_id="456",
+    )
+    assert failed.action == "blocked"
+    assert state.active is False
+    assert "ended with failure" in state.last_error
+
+    state = state_with_dispatch()
+    missing = catch_up.decide(
+        state,
+        manifest,
+        now=NOW + timedelta(minutes=16),
+        workflow_run=None,
+        manifest_sha256=DIGEST,
+        controller_run_id="456",
+    )
+    assert missing.action == "blocked"
+    assert "did not appear" in state.last_error
+
+
+def test_partial_transient_failure_waits_then_automatically_resumes() -> None:
+    """Keep catch-up active after a persisted partial Wayback service failure.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        A returned pending snapshot counts as progress, unlike an empty pending marker.
+    """
+    manifest = Manifest()
+    live_page(manifest, "pending", "captured")
+    captured = manifest.pages["https://palewi.re/captured/"]
+    captured.pending_archive_url = "https://web.archive.org/web/20260906120000/https://palewi.re/captured/"
+    captured.last_submit_at = "2026-09-06T12:00:00Z"
+    live_page(manifest, "pending", "ambiguous")
+    ambiguous = manifest.pages["https://palewi.re/ambiguous/"]
+    ambiguous.last_submit_at = "2026-09-06T12:00:00Z"
+    ambiguous.last_check_status = "error"
+    ambiguous.last_error = "Wayback capture request failed"
+    ambiguous.next_retry_at = "2026-09-06T12:03:00Z"
+    state = state_with_dispatch()
+    state.before_archive_progress = 0
+    waiting = catch_up.decide(
+        state,
+        manifest,
+        now=NOW,
+        workflow_run=catch_up.WorkflowRun(12, "completed", "failure"),
+        manifest_sha256="b" * 64,
+        controller_run_id="456",
+    )
+    assert waiting.action == "wait"
+    assert state.active is True
+    assert state.phase == "lookup"
+    assert state.next_retry_at == "2026-09-06T12:10:00Z"
+    assert state.no_progress_runs == 0
+
+
+def test_failed_run_without_persisted_transient_retry_is_blocked() -> None:
+    """Block failures that lack durable transient error and retry evidence.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        A failed persistence job leaves no changed manifest and cannot resume safely.
+    """
+    state = state_with_dispatch()
+    blocked = catch_up.decide(
+        state,
+        Manifest(),
+        now=NOW,
+        workflow_run=catch_up.WorkflowRun(12, "completed", "failure"),
+        manifest_sha256=DIGEST,
+        controller_run_id="456",
+    )
+    assert blocked.action == "blocked"
+    assert state.active is False
+
+
+def test_no_progress_and_drained_unavailable_references_are_terminal() -> None:
+    """Pause after repeated no-change batches and complete drained known gaps.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        A 403 reference does not block completion once its queue is drained.
+    """
+    state = state_with_dispatch()
+    state.no_progress_runs = 1
+    blocked = catch_up.decide(
+        state,
+        Manifest(),
+        now=NOW,
+        workflow_run=catch_up.WorkflowRun(12, "completed", "success"),
+        manifest_sha256=DIGEST,
+        controller_run_id="456",
+    )
+    assert blocked.action == "blocked"
+    assert "no durable progress" in state.last_error
+
+    manifest = Manifest(discovery_errors={"https://palewi.re/unavailable/": "HTTP 403"})
+    page = manifest.page("https://palewi.re/unavailable/")
+    page.live_status = "error"
+    state = catch_up.start(catch_up.CatchUpState())
+    complete = catch_up.decide(
+        state,
+        manifest,
+        now=NOW,
+        workflow_run=None,
+        manifest_sha256=DIGEST,
+        controller_run_id="456",
+    )
+    assert complete.action == "complete"
+    assert state.active is False
+
+
+def test_catch_up_store_rejects_unknown_persisted_fields(tmp_path: Path) -> None:
+    """Reject malformed durable state rather than replacing it.
+
+    Args:
+        tmp_path: Temporary test directory.
+
+    Returns:
+        None.
+
+    Examples:
+        An extra JSON field causes a clear state validation error.
+    """
+    path = tmp_path / "catch-up.json"
+    value = catch_up._state_to_value(catch_up.CatchUpState())
+    value["unexpected"] = True
+    path.write_text(json.dumps(value))
+    with pytest.raises(catch_up.CatchUpError, match="fields"):
+        catch_up.CatchUpStore(path).load()
+    assert "unexpected" in path.read_text()
+
+
+def test_catch_up_store_round_trips_and_cli_controls(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Persist valid state and expose local start, status, stop, and tick commands.
+
+    Args:
+        tmp_path: Temporary test directory.
+        monkeypatch: Replaces GitHub workflow lookup during the local tick.
+
+    Returns:
+        None.
+
+    Examples:
+        The CLI prints ``capture`` when a started state has a missing page.
+    """
+    state_path = tmp_path / "catch-up.json"
+    manifest_path = tmp_path / "manifest.json"
+    manifest = Manifest()
+    live_page(manifest, "missing")
+    ManifestStore(manifest_path).save(manifest)
+    runner = CliRunner()
+
+    assert runner.invoke(catch_up.cli, ["start", "--state", str(state_path)]).exit_code == 0
+    assert catch_up.CatchUpStore(state_path).load().active is True
+    status = runner.invoke(catch_up.cli, ["status", "--state", str(state_path)])
+    assert status.exit_code == 0
+    assert json.loads(status.output)["phase"] == "capture"
+    monkeypatch.setattr(catch_up, "find_dispatched_run", lambda state: None)
+    tick = runner.invoke(
+        catch_up.cli,
+        ["tick", "--manifest", str(manifest_path), "--state", str(state_path), "--controller-run-id", "123"],
+    )
+    assert tick.exit_code == 0
+    assert tick.output.startswith("capture\n")
+    assert runner.invoke(catch_up.cli, ["stop", "--state", str(state_path)]).exit_code == 0
+    assert catch_up.CatchUpStore(state_path).load().phase == "complete"
+
+
+def test_fetch_state_loads_optional_remote_state_at_manifest_head(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fetch controller JSON using the exact manifest branch-head token.
+
+    Args:
+        tmp_path: Temporary test directory.
+        monkeypatch: Replaces GitHub branch and contents calls.
+
+    Returns:
+        None.
+
+    Examples:
+        A present remote state replaces the local controller state.
+    """
+    manifest_path = tmp_path / "manifest.json"
+    state_path = tmp_path / "catch-up.json"
+    token_path = tmp_path / "token.json"
+    remote_state = catch_up.CatchUpState(active=True)
+
+    def fake_fetch(path: Path, token: Path) -> None:
+        """Write a valid manifest and matching branch token.
+
+        Args:
+            path: Local manifest destination.
+            token: Local branch-token destination.
+
+        Returns:
+            None.
+
+        Examples:
+            The fake fetch prepares an immutable branch head.
+        """
+        ManifestStore(path).save(Manifest())
+        token.write_text(
+            json.dumps(
+                {
+                    "repository": DEFAULT_REPOSITORY,
+                    "branch": DEFAULT_BRANCH,
+                    "missing": False,
+                    "head": "a" * 40,
+                }
+            )
+        )
+
+    class ContentClient:
+        """Return the one serialized remote controller state."""
+
+        def __init__(self, repository: str):
+            """Validate the repository selection.
+
+            Args:
+                repository: Requested repository.
+
+            Returns:
+                None.
+
+            Examples:
+                The controller always uses the current repository.
+            """
+            assert repository == DEFAULT_REPOSITORY
+
+        def content(self, head: str, path: str, *, required: bool) -> bytes:
+            """Return state bytes at the requested immutable head.
+
+            Args:
+                head: Immutable data branch head.
+                path: Requested data filename.
+                required: Whether file absence is allowed.
+
+            Returns:
+                Serialized controller state.
+
+            Examples:
+                The optional catch-up state is available on the test branch.
+            """
+            assert head == "a" * 40
+            assert path == catch_up.REMOTE_CATCH_UP_STATE
+            assert required is False
+            return (json.dumps(catch_up._state_to_value(remote_state)) + "\n").encode()
+
+    monkeypatch.setattr("scripts.site_archive.branch.fetch", fake_fetch)
+    monkeypatch.setattr(catch_up, "GitHubClient", ContentClient)
+    catch_up.fetch_state(manifest_path, state_path, token_path)
+    assert catch_up.CatchUpStore(state_path).load() == remote_state
+
+
+def test_find_dispatched_run_matches_only_its_controller_label(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Find the labelled archive run without confusing ordinary manual runs.
+
+    Args:
+        monkeypatch: Replaces GitHub Actions response.
+
+    Returns:
+        None.
+
+    Examples:
+        Only the saved controller token identifies the in-flight batch.
+    """
+    state = state_with_dispatch()
+
+    class RunClient:
+        """Return ordinary and controller-labelled workflow runs."""
+
+        def __init__(self, repository: str):
+            """Validate the requested repository.
+
+            Args:
+                repository: Requested repository.
+
+            Returns:
+                None.
+
+            Examples:
+                Workflow status is read from the current repository.
+            """
+            assert repository == DEFAULT_REPOSITORY
+
+        def request(self, endpoint: str) -> SimpleNamespace:
+            """Return a workflow-run list.
+
+            Args:
+                endpoint: GitHub Actions endpoint.
+
+            Returns:
+                Response-shaped object containing workflow runs.
+
+            Examples:
+                The controller run appears after unrelated manual runs.
+            """
+            assert endpoint.endswith("event=workflow_dispatch&per_page=100")
+            return SimpleNamespace(
+                value={
+                    "workflow_runs": [
+                        {"id": 1, "status": "in_progress", "conclusion": None, "display_title": "Site archive"},
+                        {
+                            "id": 2,
+                            "status": "queued",
+                            "conclusion": None,
+                            "display_title": "Site archive catch-up 123",
+                        },
+                    ]
+                }
+            )
+
+    monkeypatch.setattr(catch_up, "GitHubClient", RunClient)
+    assert catch_up.find_dispatched_run(state) == catch_up.WorkflowRun(2, "queued", None)
+
+
+def test_push_state_rejects_stale_branch_before_any_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Refuse a controller-state write if another archive writer advanced the branch.
+
+    Args:
+        tmp_path: Temporary test directory.
+        monkeypatch: Replaces GitHub client construction.
+
+    Returns:
+        None.
+
+    Examples:
+        A stale token raises instead of overwriting newer catch-up state.
+    """
+    state_path = tmp_path / "catch-up.json"
+    token_path = tmp_path / "token.json"
+    catch_up.CatchUpStore(state_path).save(catch_up.CatchUpState())
+    token_path.write_text(
+        json.dumps(
+            {
+                "repository": DEFAULT_REPOSITORY,
+                "branch": DEFAULT_BRANCH,
+                "missing": False,
+                "head": "a" * 40,
+            }
+        )
+    )
+
+    class StaleClient:
+        """Report a branch head that differs from the fetched token."""
+
+        def __init__(self, repository: str):
+            """Store the requested repository.
+
+            Args:
+                repository: Requested GitHub repository.
+
+            Returns:
+                None.
+
+            Examples:
+                ``StaleClient(DEFAULT_REPOSITORY)`` records the safe target.
+            """
+            assert repository == DEFAULT_REPOSITORY
+
+        def ref(self, branch: str) -> str:
+            """Return a newer protected data-branch head.
+
+            Args:
+                branch: Data branch name.
+
+            Returns:
+                Newer commit SHA.
+
+            Examples:
+                ``client.ref(DEFAULT_BRANCH)`` differs from the token head.
+            """
+            assert branch == DEFAULT_BRANCH
+            return "b" * 40
+
+    monkeypatch.setattr(catch_up, "GitHubClient", StaleClient)
+    with pytest.raises(catch_up.CatchUpError, match="stale"):
+        catch_up.push_state(state_path, token_path)
+
+
+def test_push_state_writes_only_controller_file_with_a_fresh_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Write controller state without replacing the archive manifest tree entry.
+
+    Args:
+        tmp_path: Temporary test directory.
+        monkeypatch: Replaces GitHub Git-database methods.
+
+    Returns:
+        None.
+
+    Examples:
+        A fresh data-branch token permits a non-forced state commit.
+    """
+    state_path = tmp_path / "catch-up.json"
+    token_path = tmp_path / "token.json"
+    catch_up.CatchUpStore(state_path).save(catch_up.CatchUpState(active=True))
+    token_path.write_text(
+        json.dumps(
+            {
+                "repository": DEFAULT_REPOSITORY,
+                "branch": DEFAULT_BRANCH,
+                "missing": False,
+                "head": "a" * 40,
+            }
+        )
+    )
+
+    class FreshClient:
+        """Provide a deterministic successful Git database update."""
+
+        def __init__(self, repository: str):
+            """Validate the requested repository.
+
+            Args:
+                repository: Requested repository.
+
+            Returns:
+                None.
+
+            Examples:
+                The state writer is scoped to the current repository.
+            """
+            assert repository == DEFAULT_REPOSITORY
+            self.tree_path = ""
+
+        def ref(self, branch: str) -> str:
+            """Return the same branch head observed by fetch.
+
+            Args:
+                branch: Protected data branch.
+
+            Returns:
+                Current branch head.
+
+            Examples:
+                A matching head permits the controlled update.
+            """
+            assert branch == DEFAULT_BRANCH
+            return "a" * 40
+
+        def content(self, head: str, path: str, *, required: bool) -> bytes | None:
+            """Report no prior controller-state file.
+
+            Args:
+                head: Immutable branch head.
+                path: Requested file.
+                required: Whether missing files are errors.
+
+            Returns:
+                None for the absent optional state.
+
+            Examples:
+                The first controller write creates only its state file.
+            """
+            assert head == "a" * 40
+            assert path == catch_up.REMOTE_CATCH_UP_STATE
+            assert required is False
+            return None
+
+        def create_blob(self, content: bytes) -> str:
+            """Accept serialized state bytes.
+
+            Args:
+                content: Controller state content.
+
+            Returns:
+                New blob identifier.
+
+            Examples:
+                A valid JSON blob is added to the data tree.
+            """
+            assert b'"active": true' in content
+            return "b" * 40
+
+        def commit_tree(self, head: str) -> str:
+            """Return the existing data tree.
+
+            Args:
+                head: Current branch head.
+
+            Returns:
+                Current tree identifier.
+
+            Examples:
+                Base-tree updates preserve the manifest.
+            """
+            assert head == "a" * 40
+            return "c" * 40
+
+        def create_tree(self, blob: str, tree: str, path: str) -> str:
+            """Record the sole replacement path.
+
+            Args:
+                blob: New controller-state blob.
+                tree: Existing base tree.
+                path: Replaced data filename.
+
+            Returns:
+                New tree identifier.
+
+            Examples:
+                Only catch-up.json is replaced in the existing tree.
+            """
+            assert (blob, tree) == ("b" * 40, "c" * 40)
+            assert path == catch_up.REMOTE_CATCH_UP_STATE
+            return "d" * 40
+
+        def create_commit(self, tree: str, parent: str) -> str:
+            """Create a child state commit.
+
+            Args:
+                tree: New tree identifier.
+                parent: Existing branch head.
+
+            Returns:
+                New commit identifier.
+
+            Examples:
+                A controller commit remains linear with archive commits.
+            """
+            assert (tree, parent) == ("d" * 40, "a" * 40)
+            return "e" * 40
+
+        def update_ref(self, branch: str, commit: str, *, create: bool) -> None:
+            """Require a non-forced existing-ref update.
+
+            Args:
+                branch: Protected data branch.
+                commit: New state commit.
+                create: Whether a new branch would be created.
+
+            Returns:
+                None.
+
+            Examples:
+                Existing branch updates never create a replacement ref.
+            """
+            assert (branch, commit, create) == (DEFAULT_BRANCH, "e" * 40, False)
+
+    monkeypatch.setattr(catch_up, "GitHubClient", FreshClient)
+    catch_up.push_state(state_path, token_path)
+    assert json.loads(token_path.read_text())["head"] == "e" * 40

--- a/tests/test_site_archive_workflow.py
+++ b/tests/test_site_archive_workflow.py
@@ -236,5 +236,7 @@ def test_catch_up_controller_wiring_is_serialized_and_leaves_weekly_run_unchange
     assert "lookup_only=true" in run
     assert "github.event.workflow_run.head_branch == 'main'" in jobs["controller"]["if"]
     assert "github.event.workflow_run.head_repository.full_name == github.repository" in jobs["controller"]["if"]
+    step_names = [step["name"] for step in jobs["controller"]["steps"]]
+    assert step_names.index("Persist controller state") < step_names.index("Dispatch selected archive batch")
     assert load_workflow()[True]["schedule"] == [{"cron": "17 6 * * 1"}]
     assert load_workflow()[True]["workflow_dispatch"]["inputs"]["catch_up_id"]["type"] == "string"

--- a/tests/test_site_archive_workflow.py
+++ b/tests/test_site_archive_workflow.py
@@ -199,3 +199,42 @@ def test_manual_inputs_reject_conflicting_flags_and_unsafe_capture_limits() -> N
     assert 'test "$MAX_CAPTURES" -gt 100' in run
     assert "max_captures must be a whole number from 1 through 100." in run
     assert archive_step()["continue-on-error"] is True
+
+
+def test_catch_up_controller_wiring_is_serialized_and_leaves_weekly_run_unchanged() -> None:
+    """Keep continuous catch-up opt-in, durable, and separate from Monday maintenance.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+
+    Examples:
+        The controller dispatches one labelled existing archive workflow run.
+    """
+    controller_path = WORKFLOW.with_name("site-archive-catch-up.yaml")
+    controller = yaml.safe_load(controller_path.read_text())
+    jobs = controller["jobs"]
+    run = "\n".join(step.get("run", "") for step in jobs["controller"]["steps"])
+
+    assert controller[True]["schedule"] == [{"cron": "*/10 * * * *"}]
+    assert controller[True]["workflow_run"] == {"workflows": ["Site archive"], "types": ["completed"]}
+    assert controller["permissions"] == {"actions": "write", "contents": "write"}
+    assert controller["concurrency"] == load_workflow()["concurrency"]
+    assert controller[True]["workflow_dispatch"]["inputs"]["action"]["options"] == [
+        "start",
+        "resume",
+        "stop",
+        "status",
+    ]
+    assert "scripts.site_archive.catch_up fetch" in run
+    assert "scripts.site_archive.catch_up push" in run
+    assert "group: site-archive-data-writer" in controller_path.read_text()
+    assert 'catch_up_id="$GITHUB_RUN_ID"' in run
+    assert "capture_only=true" in run
+    assert "lookup_only=true" in run
+    assert "github.event.workflow_run.head_branch == 'main'" in jobs["controller"]["if"]
+    assert "github.event.workflow_run.head_repository.full_name == github.repository" in jobs["controller"]["if"]
+    assert load_workflow()[True]["schedule"] == [{"cron": "17 6 * * 1"}]
+    assert load_workflow()[True]["workflow_dispatch"]["inputs"]["catch_up_id"]["type"] == "string"


### PR DESCRIPTION
## Summary
- add an inactive-by-default GitHub Actions controller for durable, one-batch archive catch-up
- dispatch capture and lookup batches with shared writer serialization and trusted-main completion recovery
- preserve retry metadata, pending-capture windows, partial transient progress, and explicit terminal states

## Validation
- `make check`

The controller has **not** been activated and does not modify `site-archive-data` until it is started from `main`.