### PR TITLE
Continue archive catch-up in Actions

### DIFF
--- a/.github/workflows/site-archive-catch-up.yaml
+++ b/.github/workflows/site-archive-catch-up.yaml
@@ -4,11 +4,6 @@ run-name: Site archive catch-up controller
 on:
   schedule:
     - cron: "*/10 * * * *"
-  workflow_run:
-    workflows:
-      - Site archive
-    types:
-      - completed
   workflow_dispatch:
     inputs:
       action:
@@ -21,6 +16,7 @@ on:
           - resume
           - stop
           - status
+          - continue
 
 permissions:
   actions: write
@@ -32,10 +28,6 @@ concurrency:
 
 jobs:
   controller:
-    if: >-
-      github.event_name != 'workflow_run' ||
-      (github.event.workflow_run.head_branch == 'main' &&
-      github.event.workflow_run.head_repository.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -91,6 +83,8 @@ jobs:
             status)
               uv run python -m scripts.site_archive.catch_up status --state "$STATE"
               echo "skip=true" >> "$GITHUB_ENV"
+              ;;
+            continue)
               ;;
             *)
               echo "Unsupported control action: $ACTION" >&2

--- a/.github/workflows/site-archive.yaml
+++ b/.github/workflows/site-archive.yaml
@@ -163,8 +163,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      actions: write
       contents: write
     env:
+      CATCH_UP_ID: ${{ inputs.catch_up_id || '' }}
       GH_TOKEN: ${{ github.token }}
       UV_NO_ENV_FILE: "1"
     steps:
@@ -198,3 +200,9 @@ jobs:
           uv run python -m scripts.site_archive.branch push \
             --path .site-archive/manifest.json \
             --state-token .site-archive/state-token.json
+
+      - name: Continue controller-dispatched catch-up
+        if: env.CATCH_UP_ID != ''
+        run: |
+          gh workflow run site-archive-catch-up.yaml --repo "$GITHUB_REPOSITORY" --ref main \
+            -f action=continue

--- a/docs/site-archive.md
+++ b/docs/site-archive.md
@@ -37,9 +37,10 @@ credentials.
 The regular Monday workflow remains a one-time maintenance batch. The separate
 **Site archive catch-up** workflow polls every ten minutes but does nothing
 until an operator starts the durable controller state on `site-archive-data`.
-It also wakes after a trusted `main` **Site archive** completion. It dispatches
-at most one existing archive batch at a time, and dispatch is its final step,
-so the batch starts only after the controller releases the shared writer slot.
+Each controller-dispatched archive run queues an internal continuation only
+after its checkpoint persistence succeeds. It dispatches at most one existing
+archive batch at a time, and dispatch is its final step, so the batch starts
+only after the controller releases the shared writer slot.
 
 Start or resume only after checking that no manual archive run is in progress:
 

--- a/tests/test_site_archive_workflow.py
+++ b/tests/test_site_archive_workflow.py
@@ -63,6 +63,7 @@ def test_checkpoint_includes_hidden_files_and_restores_expected_directory() -> N
     assert ".site-archive/state-token.json" in upload["with"]["path"]
     assert "always()" in upload["if"]
     assert "always()" in jobs["persist"]["if"]
+    assert jobs["persist"]["permissions"] == {"actions": "write", "contents": "write"}
 
 
 def test_artifact_actions_are_pinned_to_node24_releases() -> None:
@@ -219,7 +220,6 @@ def test_catch_up_controller_wiring_is_serialized_and_leaves_weekly_run_unchange
     run = "\n".join(step.get("run", "") for step in jobs["controller"]["steps"])
 
     assert controller[True]["schedule"] == [{"cron": "*/10 * * * *"}]
-    assert controller[True]["workflow_run"] == {"workflows": ["Site archive"], "types": ["completed"]}
     assert controller["permissions"] == {"actions": "write", "contents": "write"}
     assert controller["concurrency"] == load_workflow()["concurrency"]
     assert controller[True]["workflow_dispatch"]["inputs"]["action"]["options"] == [
@@ -227,6 +227,7 @@ def test_catch_up_controller_wiring_is_serialized_and_leaves_weekly_run_unchange
         "resume",
         "stop",
         "status",
+        "continue",
     ]
     assert "scripts.site_archive.catch_up fetch" in run
     assert "scripts.site_archive.catch_up push" in run
@@ -234,9 +235,10 @@ def test_catch_up_controller_wiring_is_serialized_and_leaves_weekly_run_unchange
     assert 'catch_up_id="$GITHUB_RUN_ID"' in run
     assert "capture_only=true" in run
     assert "lookup_only=true" in run
-    assert "github.event.workflow_run.head_branch == 'main'" in jobs["controller"]["if"]
-    assert "github.event.workflow_run.head_repository.full_name == github.repository" in jobs["controller"]["if"]
     step_names = [step["name"] for step in jobs["controller"]["steps"]]
     assert step_names.index("Persist controller state") < step_names.index("Dispatch selected archive batch")
+    archive_steps = [step["name"] for step in load_workflow()["jobs"]["persist"]["steps"]]
+    assert archive_steps.index("Persist checkpoint") < archive_steps.index("Continue controller-dispatched catch-up")
+    assert "action=continue" in "\n".join(step.get("run", "") for step in load_workflow()["jobs"]["persist"]["steps"])
     assert load_workflow()[True]["schedule"] == [{"cron": "17 6 * * 1"}]
     assert load_workflow()[True]["workflow_dispatch"]["inputs"]["catch_up_id"]["type"] == "string"


### PR DESCRIPTION
## Summary
- queue an internal controller continuation only after a controller-dispatched archive batch persists its checkpoint
- remove the unreliable completion-event dependency while retaining the inactive recovery schedule
- prove the continuation is ordered after persistence and remains isolated from ordinary weekly maintenance

## Validation
- `make check`

This follows up on #534 after production activation showed that GitHub did not emit the expected scheduled or completion-event controller tick.